### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,5 +31,5 @@ jobs:
           path: bin/
       - uses: engineerd/setup-kind@v0.2.0
       - run: chmod +x bin/preflight
-      - run: bin/preflight https://preflight.replicated.com
+      - run: bin/preflight --interactive=false https://preflight.replicated.com
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,35 @@
+name: "Run preflights on a cluster"
+on: [pull_request, push]
+
+jobs:
+  compile-preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.12.14'
+      - name: setup env
+        run: |
+          echo "::set-env name=GOPATH::$(go env GOPATH)"
+          echo "::add-path::$(go env GOPATH)/bin"
+        shell: bash
+      - uses: actions/checkout@master
+      - run: make preflight
+      - uses: actions/upload-artifact@v1
+        with:
+          name: preflight
+          path: bin/preflight
+
+  run-preflights:
+    runs-on: ubuntu-latest
+    needs: compile-preflight
+    steps:
+      - name: Download preflight binary
+        uses: actions/download-artifact@v1
+        with:
+          name: preflight
+          path: bin/
+      - uses: engineerd/setup-kind@v0.2.0
+      - run: chmod +x bin/preflight
+      - run: bin/preflight https://preflight.replicated.com
+

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -31,5 +31,5 @@ jobs:
           path: bin/
       - uses: engineerd/setup-kind@v0.2.0
       - run: chmod +x bin/preflight
-      - run: bin/preflight --interactive=false https://preflight.replicated.com
+      - run: bin/preflight --interactive=false --foramt=json https://preflight.replicated.com
 

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -1,5 +1,5 @@
 name: "Run preflights on a cluster"
-on: [pull_request, push]
+on: [push]
 
 jobs:
   compile-preflight:

--- a/.github/workflows/preflight.yaml
+++ b/.github/workflows/preflight.yaml
@@ -31,5 +31,5 @@ jobs:
           path: bin/
       - uses: engineerd/setup-kind@v0.2.0
       - run: chmod +x bin/preflight
-      - run: bin/preflight --interactive=false --foramt=json https://preflight.replicated.com
+      - run: bin/preflight --interactive=false --format=json https://preflight.replicated.com
 

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -126,7 +126,7 @@ func runPreflights(v *viper.Viper, arg string) error {
 		return showInteractiveResults(preflight.Name, analyzeResults)
 	}
 
-	return showStdoutResults(preflight.Name, analyzeResults)
+	return showStdoutResults(v.GetString("format"), preflight.Name, analyzeResults)
 }
 
 func runCollectors(v *viper.Viper, preflight troubleshootv1beta1.Preflight) (map[string][]byte, error) {


### PR DESCRIPTION
This adds e2e tests using kind and github actions.

To support this, I also added a `--format=json` flag that is used when running non-interactive preflights.

```
$ kubectl preflight https://preflight.replicated.com
  Running Preflight checks ⠋ 
{
  "pass": [
    {
      "title": "Required Kubernetes Version",
      "message": "Your cluster meets the recommended and required versions of Kubernetes."
    }
  ],
  "fail": [
    {
      "title": "Gatekeeper policy runtime",
      "message": "Gatekeeper is required for the application, but not found in the cluster.",
      "uri": "https://enterprise.support.io/installing/gatekeeper"
    },
    {
      "title": "Registry credentials for Quay.io",
      "message": "Cannot pull from quay.io. An image pull secret should be deployed to the cluster that has credentials to pull the images. To obtain this secret, please contact your support rep.\n",
      "uri": "https://enterprise.support.io/installing/registry-credentials"
    }
  ]
}
```