### PR TITLE
include ServerGroupsAndResources in troubleshoot cluster-resources

### DIFF
--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ahmetalpbalkan/go-cursor"
+	cursor "github.com/ahmetalpbalkan/go-cursor"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	analyzerunner "github.com/replicatedhq/troubleshoot/pkg/analyze"
@@ -19,7 +19,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/viper"
-	"github.com/tj/go-spin"
+	spin "github.com/tj/go-spin"
 	"gopkg.in/yaml.v2"
 )
 
@@ -199,7 +199,11 @@ func runCollectors(v *viper.Viper, preflight troubleshootv1beta1.Preflight, prog
 	// Run preflights collectors synchronously
 	for _, collector := range collectors {
 		if len(collector.RBACErrors) > 0 {
-			continue
+			// don't skip clusterResources collector due to RBAC issues
+			if collector.Collect.ClusterResources == nil {
+				progressChan <- fmt.Sprintf("skipping collector %s with insufficient RBAC permissions", collector.GetDisplayName())
+				continue
+			}
 		}
 
 		result, err := collector.RunCollectorSync()

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -191,7 +191,11 @@ func runCollectors(v *viper.Viper, collector troubleshootv1beta1.Collector, prog
 	// Run preflights collectors synchronously
 	for _, collector := range collectors {
 		if len(collector.RBACErrors) > 0 {
-			continue
+			// don't skip clusterResources collector due to RBAC issues
+			if collector.Collect.ClusterResources == nil {
+				progressChan <- fmt.Sprintf("skipping collector %s with insufficient RBAC permissions", collector.GetDisplayName())
+				continue
+			}
 		}
 
 		progressChan <- collector.GetDisplayName()

--- a/sample-troubleshoot.yaml
+++ b/sample-troubleshoot.yaml
@@ -1,0 +1,14 @@
+apiVersion: troubleshoot.replicated.com/v1beta1
+kind: Collector
+metadata:
+  name: my-application-name
+spec:
+  collectors:
+  - clusterInfo:
+      collectorName: my-cluster-info
+  - clusterResources:
+      collectorName: my-cluster-resources
+  - http:
+      name: healthz
+      get:
+        url: http://api:3000/healthz


### PR DESCRIPTION
include ServerGroupsAndResources in troubleshoot cluster-resources
also run cluster-resources collector even when some rbac permissions are missing
print progress message when skipping a collector due to rbac issues
include a sample troubleshoot yaml spec in the repo