### PR TITLE
Node aggregate analyzers

### DIFF
--- a/pkg/analyze/node_resources.go
+++ b/pkg/analyze/node_resources.go
@@ -97,7 +97,7 @@ func compareNodeResourceConditionalToActual(conditional string, matchingNodes []
 		return true, nil
 	}
 
-	parts := strings.Split(strings.TrimSpace(conditional), " ")
+	parts := strings.Fields(strings.TrimSpace(conditional))
 
 	if len(parts) == 2 {
 		parts = append([]string{"count"}, parts...)

--- a/pkg/analyze/node_resources_test.go
+++ b/pkg/analyze/node_resources_test.go
@@ -12,40 +12,60 @@ import (
 
 func Test_compareNodeResourceConditionalToActual(t *testing.T) {
 	tests := []struct {
-		name        string
-		conditional string
-		actual      int
-		expected    bool
+		name              string
+		conditional       string
+		matchingNodeCount int
+		totalNodeCount    int
+		expected          bool
 	}{
 		{
-			name:        "=",
-			conditional: "= 5",
-			actual:      5,
-			expected:    true,
+			name:              "=",
+			conditional:       "= 5",
+			matchingNodeCount: 5,
+			totalNodeCount:    1,
+			expected:          true,
 		},
 		{
-			name:        "<= (pass)",
-			conditional: "<= 5",
-			actual:      4,
-			expected:    true,
+			name:              "<= (pass)",
+			conditional:       "<= 5",
+			matchingNodeCount: 4,
+			totalNodeCount:    1,
+			expected:          true,
 		},
 		{
-			name:        "<= (fail)",
-			conditional: "<= 5",
-			actual:      6,
-			expected:    false,
+			name:              "<= (fail)",
+			conditional:       "<= 5",
+			matchingNodeCount: 6,
+			totalNodeCount:    1,
+			expected:          false,
 		},
 		{
-			name:        "> (pass)",
-			conditional: "> 5",
-			actual:      6,
-			expected:    true,
+			name:              "> (pass)",
+			conditional:       "> 5",
+			matchingNodeCount: 6,
+			totalNodeCount:    1,
+			expected:          true,
 		},
 		{
-			name:        ">=(fail)",
-			conditional: ">= 5",
-			actual:      4,
-			expected:    false,
+			name:              ">= (fail)",
+			conditional:       ">= 5",
+			matchingNodeCount: 4,
+			totalNodeCount:    1,
+			expected:          false,
+		},
+		{
+			name:              "min(memoryCapacity) <= 16Gi (pass)",
+			conditional:       "min(memoryCapacity) <= 16Gi",
+			matchingNodeCount: 2,
+			totalNodeCount:    2,
+			expected:          true,
+		},
+		{
+			name:              "min(memoryCapacity) <= 16Gi",
+			conditional:       "min(memoryCapacity) <= 16Gi",
+			matchingNodeCount: 1,
+			totalNodeCount:    2,
+			expected:          false,
 		},
 	}
 
@@ -53,7 +73,7 @@ func Test_compareNodeResourceConditionalToActual(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
 
-			actual, err := compareNodeResourceConditionalToActual(test.conditional, test.actual)
+			actual, err := compareNodeResourceConditionalToActual(test.conditional, test.matchingNodeCount, test.totalNodeCount)
 			req.NoError(err)
 
 			assert.Equal(t, test.expected, actual)

--- a/pkg/analyze/node_resources_test.go
+++ b/pkg/analyze/node_resources_test.go
@@ -361,6 +361,237 @@ func Test_compareNodeResourceConditionalToActual(t *testing.T) {
 			totalNodeCount: 2,
 			expected:       false,
 		},
+		{
+			name:        "max(cpuCapacity) == 12 (false)",
+			conditional: "max(cpuCapacity) == 12",
+			matchingNodes: []corev1.Node{
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("17951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("7951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+			},
+			totalNodeCount: 2,
+			expected:       false,
+		},
+		{
+			name:        "max(cpuCapacity) == 2 (true)",
+			conditional: "max(cpuCapacity) == 2",
+			matchingNodes: []corev1.Node{
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("17951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("7951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("2"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+			},
+			totalNodeCount: 2,
+			expected:       true,
+		},
+		{
+			name:        "sum(cpuCapacity) > 32 (true)",
+			conditional: "sum(cpuCapacity) > 32",
+			matchingNodes: []corev1.Node{
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("17951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node2",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("7951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node3",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("7951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node4",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("7951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+				corev1.Node{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Node",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node5",
+					},
+					Status: corev1.NodeStatus{
+						Capacity: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("20959212Ki"),
+							"memory":            resource.MustParse("7951376Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+						Allocatable: corev1.ResourceList{
+							"cpu":               resource.MustParse("8"),
+							"ephemeral-storage": resource.MustParse("19316009748"),
+							"memory":            resource.MustParse("7848976Ki"),
+							"pods":              resource.MustParse("29"),
+						},
+					},
+				},
+			},
+			totalNodeCount: 2,
+			expected:       true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This adds support for node resource aggregate (min, max, count and sum) functions for cpu, memory, pods and ephemeralStorage: capacity and allocatable.

This operates on the filtered nodes, so you can filter based on a condition, and then aggregate and compare.

Examples:

```yaml
apiVersion: troubleshoot.replicated.com/v1beta1
kind: Preflight
metadata:
  name: sample
spec:
  analyzers:
    - nodeResources:
        checkName: Must have at least 3 nodes in the cluster
        outcomes:
          - fail:
              when: "count() < 3"
              message: This application requires at least 3 nodes
          - warn:
              when: "count() < 5"
              message: This application recommends at last 5 nodes.
          - pass:
              message: This cluster has enough nodes.
```

```yaml
    - nodeResources:
        checkName: Every node in the cluster must have at least 16Gi of memory
        filters:
          allocatableMemory: "16Gi"
        outcomes:
          - fail:
              when: "min(memoryCapacity) < 16Gi"
              message: All nodes must have at least 16 GB of memory
          - pass:
              message: All nodes have at least 16 GB of memory
```

```yaml
    - nodeResources:
        checkName: Total CPU Cores in the cluster is 20 or greater
        outcomes:
          - fail:
              when: "sum(cpuCapacity) < 20"
              message: The cluster must contain at least 20 cores
          - pass:
              message: There are at over 20 cores in the cluster
```

```yaml
    - nodeResources:
        checkName: Nodes that have 6 cores have at least 16 GB of memory also
        filters:
          cpuCapacity: "6"
          outcomes:
            - fail:
                when: "min(memoryCapacity) < 16Gi"
                message: All nodes that have 6 or more cores must have at least 16 GB of memory
            - pass:
                message:  All nodes with 6 or more cores have at least 16 GB of memory
```

```yaml
    - nodeResources:
        checkName: Must have 3 nodes with at least 6 cores
        filters:
          cpuCapacity: "6"
        outcomes:
          - fail:
              when: "count() < 3"
              message: This application requires at least 3 nodes with 6 cores each
          - pass:
              message: This cluster has enough nodes with enough codes
```

```yaml
    - nodeResources:
        checkName: Must have 1 node with 16 GB (available) memory and 5 cores (on a single node)
        filters:
          allocatableMemory: 16Gi
          cpuCapacity: "5"
        outcomes:
          - fail:
              when: "count() < 1"
              message: This application requires at least 1 node with 16GB available memory
          - pass:
              message: This cluster has a node with enough memory.
```
