### PR TITLE
refactor byte array interfaces

### DIFF
--- a/pkg/collect/cluster_info.go
+++ b/pkg/collect/cluster_info.go
@@ -18,28 +18,23 @@ type ClusterInfoOutput struct {
 	Errors         []byte `json:"cluster-info/errors.json,omitempty"`
 }
 
-func ClusterInfo(ctx *Context) ([]byte, error) {
+func ClusterInfo(ctx *Context) (map[string][]byte, error) {
 	client, err := kubernetes.NewForConfig(ctx.ClientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create kubernetes clientset")
 	}
 
-	clusterInfoOutput := ClusterInfoOutput{}
+	clusterInfoOutput := map[string][]byte{}
 
 	// cluster version
 	clusterVersion, clusterErrors := clusterVersion(client)
-	clusterInfoOutput.ClusterVersion = clusterVersion
-	clusterInfoOutput.Errors, err = marshalNonNil(clusterErrors)
+	clusterInfoOutput["cluster-info/cluster_version.json"] = clusterVersion
+	clusterInfoOutput["cluster-info/errors.json"], err = marshalNonNil(clusterErrors)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal errors")
 	}
 
-	b, err := json.MarshalIndent(clusterInfoOutput, "", "  ")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal cluster info")
-	}
-
-	return b, nil
+	return clusterInfoOutput, nil
 }
 
 func clusterVersion(client *kubernetes.Clientset) ([]byte, []string) {

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -40,7 +40,7 @@ func isExcluded(excludeVal multitype.BoolOrString) (bool, error) {
 	return parsed, nil
 }
 
-func (c *Collector) RunCollectorSync() ([]byte, error) {
+func (c *Collector) RunCollectorSync() (map[string][]byte, error) {
 	if c.Collect.ClusterInfo != nil {
 		isExcluded, err := isExcluded(c.Collect.ClusterInfo.Exclude)
 		if err != nil {

--- a/pkg/collect/copy.go
+++ b/pkg/collect/copy.go
@@ -2,7 +2,6 @@ package collect
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 
@@ -15,7 +14,7 @@ import (
 
 type CopyOutput map[string][]byte
 
-func Copy(ctx *Context, copyCollector *troubleshootv1beta1.Copy) ([]byte, error) {
+func Copy(ctx *Context, copyCollector *troubleshootv1beta1.Copy) (map[string][]byte, error) {
 	client, err := kubernetes.NewForConfig(ctx.ClientConfig)
 	if err != nil {
 		return nil, err
@@ -59,12 +58,7 @@ func Copy(ctx *Context, copyCollector *troubleshootv1beta1.Copy) ([]byte, error)
 		}
 	}
 
-	b, err := json.MarshalIndent(copyOutput, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return copyOutput, nil
 }
 
 func copyFiles(ctx *Context, client *kubernetes.Clientset, pod corev1.Pod, copyCollector *troubleshootv1beta1.Copy) (map[string][]byte, map[string]string) {

--- a/pkg/collect/data.go
+++ b/pkg/collect/data.go
@@ -1,7 +1,6 @@
 package collect
 
 import (
-	"encoding/json"
 	"path/filepath"
 
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
@@ -9,16 +8,11 @@ import (
 
 type DataOutput map[string][]byte
 
-func Data(ctx *Context, dataCollector *troubleshootv1beta1.Data) ([]byte, error) {
+func Data(ctx *Context, dataCollector *troubleshootv1beta1.Data) (map[string][]byte, error) {
 	bundlePath := filepath.Join(dataCollector.Name, dataCollector.CollectorName)
 	dataOutput := DataOutput{
 		bundlePath: []byte(dataCollector.Data),
 	}
 
-	b, err := json.MarshalIndent(dataOutput, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return dataOutput, nil
 }

--- a/pkg/collect/http.go
+++ b/pkg/collect/http.go
@@ -25,7 +25,7 @@ type httpError struct {
 	Message string `json:"message"`
 }
 
-func HTTP(ctx *Context, httpCollector *troubleshootv1beta1.HTTP) ([]byte, error) {
+func HTTP(ctx *Context, httpCollector *troubleshootv1beta1.HTTP) (map[string][]byte, error) {
 	var response *http.Response
 	var err error
 
@@ -52,12 +52,7 @@ func HTTP(ctx *Context, httpCollector *troubleshootv1beta1.HTTP) ([]byte, error)
 		filepath.Join(httpCollector.Name, fileName): output,
 	}
 
-	b, err := json.MarshalIndent(httpOutput, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return httpOutput, nil
 }
 
 func doGet(get *troubleshootv1beta1.Get) (*http.Response, error) {

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -2,7 +2,6 @@ package collect
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -18,7 +17,7 @@ import (
 
 type LogsOutput map[string][]byte
 
-func Logs(ctx *Context, logsCollector *troubleshootv1beta1.Logs) ([]byte, error) {
+func Logs(ctx *Context, logsCollector *troubleshootv1beta1.Logs) (map[string][]byte, error) {
 	client, err := kubernetes.NewForConfig(ctx.ClientConfig)
 	if err != nil {
 		return nil, err
@@ -93,12 +92,7 @@ func Logs(ctx *Context, logsCollector *troubleshootv1beta1.Logs) ([]byte, error)
 		}
 	}
 
-	b, err := json.MarshalIndent(logsOutput, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return logsOutput, nil
 }
 
 func listPodsInSelectors(client *kubernetes.Clientset, namespace string, selector []string) ([]corev1.Pod, []string) {

--- a/pkg/collect/mysql.go
+++ b/pkg/collect/mysql.go
@@ -12,7 +12,7 @@ import (
 
 type MysqlOutput map[string][]byte
 
-func Mysql(ctx *Context, databaseCollector *troubleshootv1beta1.Database) ([]byte, error) {
+func Mysql(ctx *Context, databaseCollector *troubleshootv1beta1.Database) (map[string][]byte, error) {
 	databaseConnection := DatabaseConnection{}
 
 	db, err := sql.Open("mysql", databaseCollector.URI)
@@ -44,10 +44,5 @@ func Mysql(ctx *Context, databaseCollector *troubleshootv1beta1.Database) ([]byt
 		fmt.Sprintf("mysql/%s.json", collectorName): b,
 	}
 
-	bb, err := json.Marshal(mysqlOutput)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal mysql output")
-	}
-
-	return bb, nil
+	return mysqlOutput, nil
 }

--- a/pkg/collect/postgres.go
+++ b/pkg/collect/postgres.go
@@ -12,7 +12,7 @@ import (
 
 type PostgresOutput map[string][]byte
 
-func Postgres(ctx *Context, databaseCollector *troubleshootv1beta1.Database) ([]byte, error) {
+func Postgres(ctx *Context, databaseCollector *troubleshootv1beta1.Database) (map[string][]byte, error) {
 	databaseConnection := DatabaseConnection{}
 
 	db, err := sql.Open("postgres", databaseCollector.URI)
@@ -44,10 +44,5 @@ func Postgres(ctx *Context, databaseCollector *troubleshootv1beta1.Database) ([]
 		fmt.Sprintf("postgres/%s.json", collectorName): b,
 	}
 
-	bb, err := json.Marshal(postgresOutput)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal postgres output")
-	}
-
-	return bb, nil
+	return postgresOutput, nil
 }

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -7,11 +7,13 @@ import (
 func redactMap(input map[string][]byte) (map[string][]byte, error) {
 	result := make(map[string][]byte)
 	for k, v := range input {
-		redacted, err := redact.Redact(v)
-		if err != nil {
-			return nil, err
+		if v != nil {
+			redacted, err := redact.Redact(v)
+			if err != nil {
+				return nil, err
+			}
+			result[k] = redacted
 		}
-		result[k] = redacted
 	}
 	return result, nil
 }

--- a/pkg/collect/redis.go
+++ b/pkg/collect/redis.go
@@ -12,7 +12,7 @@ import (
 
 type RedisOutput map[string][]byte
 
-func Redis(ctx *Context, databaseCollector *troubleshootv1beta1.Database) ([]byte, error) {
+func Redis(ctx *Context, databaseCollector *troubleshootv1beta1.Database) (map[string][]byte, error) {
 	databaseConnection := DatabaseConnection{}
 
 	opt, err := redis.ParseURL(databaseCollector.URI)
@@ -55,10 +55,5 @@ func Redis(ctx *Context, databaseCollector *troubleshootv1beta1.Database) ([]byt
 		fmt.Sprintf("redis/%s.json", collectorName): b,
 	}
 
-	bb, err := json.Marshal(redisOutput)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal redis output")
-	}
-
-	return bb, nil
+	return redisOutput, nil
 }


### PR DESCRIPTION
returning `[]byte` instead of `map[string][]byte` is pointless and introduces significant code complexity

(also, more than half of the existing collectors were just marshalling `map[string][]byte` anyways)