### PR TITLE
Report errors connecting to the database

### DIFF
--- a/pkg/analyze/postgres.go
+++ b/pkg/analyze/postgres.go
@@ -39,6 +39,12 @@ func analyzePostgres(analyzer *troubleshootv1beta1.DatabaseAnalyze, getCollected
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/postgres-analyze.svg",
 	}
 
+	if databaseConnection.Error != "" {
+		result.IsFail = true
+		result.Message = databaseConnection.Error
+		return result, nil
+	}
+
 	for _, outcome := range analyzer.Outcomes {
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {


### PR DESCRIPTION
If the postgres collector encounters an error, report it as a failure in the analyzer. Otherwise the error is completely suppressed.

Fixes #187.