### PR TITLE
goreleaser no longer includes .exe in download links

### DIFF
--- a/deploy/krew/preflight.yaml
+++ b/deploy/krew/preflight.yaml
@@ -31,7 +31,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/preflight.exe_windows_amd64.zip" .TagName }}
+    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/preflight_windows_amd64.zip" .TagName }}
     files:
     - from: preflight.exe
       to: .

--- a/deploy/krew/support-bundle.yaml
+++ b/deploy/krew/support-bundle.yaml
@@ -31,7 +31,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/support-bundle.exe_windows_amd64.zip" .TagName }}
+    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/support-bundle_windows_amd64.zip" .TagName }}
     files:
     - from: support-bundle.exe
       to: .


### PR DESCRIPTION
they were added by the issue referred to here, https://github.com/goreleaser/goreleaser/issues/1500 and have now been removed again