### PR TITLE
refactor krew yaml to match upstream format

### DIFF
--- a/deploy/krew/preflight.yaml
+++ b/deploy/krew/preflight.yaml
@@ -40,7 +40,23 @@ spec:
     bin: preflight.exe
   shortDescription: Executes application preflight tests in a cluster
   homepage: https://github.com/replicatedhq/troubleshoot
-  caveats: |
+  description: |
+    This plugin executes application-specific preflight checks and conformance
+    tests against a cluster, prior to installation of an application.
+
+    Application developers can create and host a Preflight manifest that
+    defines the minimum and desired Kubernetes environment for an application.
+    Before installing the application, a cluster admin can use this plugin to
+    execute the application preflight checksto identify any missing
+    components, configuration or incompatibilities between the cluster and the
+    desired environment.
+
+    When executing Preflight tests, the test results will be displayed in a
+    terminal-based UI on the workstation that executed the command.
+
+    For information on creating a Preflight manifest, view the documentation
+    at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/
+
     Usage:
       $ kubectl preflight <uri/path>
 
@@ -59,20 +75,3 @@ spec:
 
       For application developers writing collectors and analyzers:
       https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
-
-  description: |
-    This plugin executes application-specific preflight checks and conformance
-    tests against a cluster, prior to installation of an application.
-
-    Application developers can create and host a Preflight manifest that
-    defines the minimum and desired Kubernetes environment for an application.
-    Before installing the application, a cluster admin can use this plugin to
-    execute the application preflight checksto identify any missing
-    components, configuration or incompatibilities between the cluster and the
-    desired environment.
-
-    When executing Preflight tests, the test results will be displayed in a
-    terminal-based UI on the workstation that executed the command.
-
-    For information on creating a Preflight manifest, view the documentation
-    at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/

--- a/deploy/krew/support-bundle.yaml
+++ b/deploy/krew/support-bundle.yaml
@@ -40,7 +40,20 @@ spec:
     bin: support-bundle.exe
   shortDescription: Creates support bundles for off-cluster analysis
   homepage: https://github.com/replicatedhq/troubleshoot
-  caveats: |
+  description: |
+    This plugin collects information about the cluster, and automatically
+    redacts sensitive data from being collected. This can optionally include
+    application-specific data.  The plugin writes the collected files into a
+    single archive named support-bundle.tar.gz. This archive can be manually
+    inspected or uploaded to https://vendor.replicated.com for automated
+    analysis.
+
+    Application developers can create and host a Collector manifest that
+    defines information to be collected.
+
+    For information on creating a Collector manifest, view the documentation
+    at https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
+
     Usage:
       $ kubectl support-bundle <uri>
 
@@ -60,16 +73,3 @@ spec:
       For application developers writing collectors and analyzers:
       https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
 
-  description: |
-    This plugin collects information about the cluster, and automatically
-    redacts sensitive data from being collected. This can optionally include
-    application-specific data.  The plugin writes the collected files into a
-    single archive named support-bundle.tar.gz. This archive can be manually
-    inspected or uploaded to https://vendor.replicated.com for automated
-    analysis.
-
-    Application developers can create and host a Collector manifest that
-    defines information to be collected.
-
-    For information on creating a Collector manifest, view the documentation
-    at https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/

--- a/deploy/krew/support-bundle.yaml
+++ b/deploy/krew/support-bundle.yaml
@@ -72,4 +72,3 @@ spec:
 
       For application developers writing collectors and analyzers:
       https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
-


### PR DESCRIPTION
krew seems to have removed 'caveats' and merged it into description, so our CI needs to do the same

https://github.com/kubernetes-sigs/krew-index/pull/635