### PR TITLE
Copy collector enhanced

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -420,7 +420,7 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta1.Collect, ad
 
 func saveCollectorOutput(output map[string][]byte, bundlePath string, c *collect.Collector) error {
 	for filename, maybeContents := range output {
-		if strings.Contains(c.GetDisplayName(), "copy") {
+		if c.Collect.Copy != nil {
 			err := untarAndSave(maybeContents, filepath.Join(bundlePath, filepath.Dir(filename)))
 			if err != nil {
 				return errors.Wrap(err, "extract copied files")

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -471,6 +471,10 @@ func untarAndSave(tarFile []byte, bundlePath string) error {
 			return fmt.Errorf("Tar file entry %s contained unsupported file type %v", header.Name, header.FileInfo().Mode())
 		}
 	}
+	//Create directories from base path: <namespace>/<pod name>/containerPath
+	if err := os.MkdirAll(filepath.Join(bundlePath), 0777); err != nil {
+		return errors.Wrap(err, "create output file")
+	}
 	//Order folders stored in variable keys to start always by parent folder. That way folder info is preserved.
 	for k := range dirs {
 		keys = append(keys, k)
@@ -478,7 +482,7 @@ func untarAndSave(tarFile []byte, bundlePath string) error {
 	sort.Strings(keys)
 	//Orderly create folders.
 	for _, k := range keys {
-		if err := os.MkdirAll(filepath.Join(bundlePath, k), dirs[k].FileInfo().Mode().Perm()); err != nil {
+		if err := os.Mkdir(filepath.Join(bundlePath, k), dirs[k].FileInfo().Mode().Perm()); err != nil {
 			return errors.Wrap(err, "create output file")
 		}
 	}

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -1,16 +1,19 @@
 package cli
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -395,7 +398,7 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta1.Collect, ad
 		}
 
 		if result != nil {
-			err = saveCollectorOutput(result, bundlePath)
+			err = saveCollectorOutput(result, bundlePath, collector)
 			if err != nil {
 				progressChan <- fmt.Errorf("failed to parse collector spec %q: %v", collector.GetDisplayName(), err)
 				continue
@@ -415,8 +418,15 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta1.Collect, ad
 	return filename, nil
 }
 
-func saveCollectorOutput(output map[string][]byte, bundlePath string) error {
+func saveCollectorOutput(output map[string][]byte, bundlePath string, c *collect.Collector) error {
 	for filename, maybeContents := range output {
+		if strings.Contains(c.GetDisplayName(), "copy") {
+			err := untarAndSave(maybeContents, filepath.Join(bundlePath, filepath.Dir(filename)))
+			if err != nil {
+				return errors.Wrap(err, "extract copied files")
+			}
+			continue
+		}
 		fileDir, fileName := filepath.Split(filename)
 		outPath := filepath.Join(bundlePath, fileDir)
 
@@ -431,7 +441,55 @@ func saveCollectorOutput(output map[string][]byte, bundlePath string) error {
 
 	return nil
 }
-
+func untarAndSave(tarFile []byte, bundlePath string) error {
+	keys := make([]string, 0)
+	dirs := make(map[string]*tar.Header)
+	files := make(map[string][]byte)
+	fileHeaders := make(map[string]*tar.Header)
+	tarReader := tar.NewReader(bytes.NewBuffer(tarFile))
+	//Extract and separate tar contentes in file and folders, keeping header info from each one.
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			break
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			dirs[header.Name] = header
+		case tar.TypeReg:
+			file := new(bytes.Buffer)
+			_, err = io.Copy(file, tarReader)
+			if err != nil {
+				return err
+			}
+			files[header.Name] = file.Bytes()
+			fileHeaders[header.Name] = header
+		default:
+			return fmt.Errorf("Tar file entry %s contained unsupported file type %v", header.Name, header.FileInfo().Mode())
+		}
+	}
+	//Order folders stored in variable keys to start always by parent folder. That way folder info is preserved.
+	for k := range dirs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	//Orderly create folders.
+	for _, k := range keys {
+		if err := os.MkdirAll(filepath.Join(bundlePath, k), dirs[k].FileInfo().Mode().Perm()); err != nil {
+			return errors.Wrap(err, "create output file")
+		}
+	}
+	//Populate folders with respective files and its permissions stored in the header.
+	for k, v := range files {
+		if err := ioutil.WriteFile(filepath.Join(bundlePath, k), v, fileHeaders[k].FileInfo().Mode().Perm()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func uploadSupportBundle(r *troubleshootv1beta1.ResultRequest, archivePath string) error {
 	contentType := getExpectedContentType(r.URI)
 	if contentType != "" && contentType != "application/tar+gzip" {

--- a/pkg/collect/copy.go
+++ b/pkg/collect/copy.go
@@ -61,7 +61,7 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 	if copyCollector.ContainerName != "" {
 		container = copyCollector.ContainerName
 	}
-	command := []string{"sh", "-c", fmt.Sprintf("tar -C %s  -cf - %s | cat ", filepath.Dir(copyCollector.ContainerPath), filepath.Base(copyCollector.ContainerPath))}
+	command := []string{"tar", "-C", filepath.Dir(copyCollector.ContainerPath), "-cf", "-", filepath.Base(copyCollector.ContainerPath)}
 	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/pkg/collect/copy.go
+++ b/pkg/collect/copy.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path"
 	"path/filepath"
 
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
@@ -14,8 +13,8 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
+//Copy function gets a file or folder from a container specified in the specs.
 func Copy(c *Collector, copyCollector *troubleshootv1beta1.Copy) (map[string][]byte, error) {
-
 	client, err := kubernetes.NewForConfig(c.ClientConfig)
 	if err != nil {
 		return nil, err
@@ -49,7 +48,7 @@ func Copy(c *Collector, copyCollector *troubleshootv1beta1.Copy) (map[string][]b
 			}
 
 			for k, v := range files {
-				copyOutput[filepath.Join(bundlePath, path.Dir(copyCollector.ContainerPath), k)] = v
+				copyOutput[filepath.Join(bundlePath, filepath.Dir(copyCollector.ContainerPath), k)] = v
 			}
 		}
 	}
@@ -62,7 +61,7 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 	if copyCollector.ContainerName != "" {
 		container = copyCollector.ContainerName
 	}
-	command := []string{"sh", "-c", fmt.Sprintf("tar -C %s  -cf - %s | cat ", path.Dir(copyCollector.ContainerPath), path.Base(copyCollector.ContainerPath))}
+	command := []string{"sh", "-c", fmt.Sprintf("tar -C %s  -cf - %s | cat ", filepath.Dir(copyCollector.ContainerPath), filepath.Base(copyCollector.ContainerPath))}
 	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
@@ -110,7 +109,7 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 	}
 
 	return map[string][]byte{
-		path.Base(copyCollector.ContainerPath) + ".tar": output.Bytes(),
+		filepath.Base(copyCollector.ContainerPath) + ".tar": output.Bytes(),
 	}, nil
 }
 

--- a/pkg/collect/copy.go
+++ b/pkg/collect/copy.go
@@ -63,6 +63,8 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 	if copyCollector.ContainerName != "" {
 		container = copyCollector.ContainerName
 	}
+	//Command cd into the path directory, tars the target file or folder into a temp file, cat-copy it and removes the temp file.
+	//Not using a temp file may end up in error "Refusing to write archive contents to terminal"
 	command := []string{"sh", "-c", fmt.Sprintf("tar -C %v  -cf tmp.tar %v; cat tmp.tar; rm tmp.tar", path.Dir(copyCollector.ContainerPath), path.Base(copyCollector.ContainerPath))}
 
 	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")

--- a/pkg/collect/copy.go
+++ b/pkg/collect/copy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,7 @@ import (
 )
 
 func Copy(c *Collector, copyCollector *troubleshootv1beta1.Copy) (map[string][]byte, error) {
+
 	client, err := kubernetes.NewForConfig(c.ClientConfig)
 	if err != nil {
 		return nil, err
@@ -56,12 +58,13 @@ func Copy(c *Collector, copyCollector *troubleshootv1beta1.Copy) (map[string][]b
 }
 
 func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyCollector *troubleshootv1beta1.Copy) (map[string][]byte, map[string]string) {
+	files := make(map[string][]byte)
 	container := pod.Spec.Containers[0].Name
 	if copyCollector.ContainerName != "" {
 		container = copyCollector.ContainerName
 	}
 
-	command := []string{"cat", copyCollector.ContainerPath}
+	command := []string{"find", copyCollector.ContainerPath, "-type", "f"}
 
 	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")
 	scheme := runtime.NewScheme()
@@ -96,6 +99,9 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 		Stderr: &stderr,
 		Tty:    false,
 	})
+
+	filepaths := strings.Split(output.String(), "\n")
+
 	if err != nil {
 		errors := map[string]string{
 			filepath.Join(copyCollector.ContainerPath, "error"): err.Error(),
@@ -109,9 +115,59 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 		return nil, errors
 	}
 
-	return map[string][]byte{
-		copyCollector.ContainerPath: output.Bytes(),
-	}, nil
+	for _, file := range filepaths {
+		if file != "" {
+			command := []string{"cat", file}
+
+			req := client.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				return nil, map[string]string{
+					filepath.Join(copyCollector.ContainerPath, "error"): err.Error(),
+				}
+			}
+			parameterCodec := runtime.NewParameterCodec(scheme)
+			req.VersionedParams(&corev1.PodExecOptions{
+				Command:   command,
+				Container: container,
+				Stdin:     true,
+				Stdout:    false,
+				Stderr:    true,
+				TTY:       false,
+			}, parameterCodec)
+
+			exec, err := remotecommand.NewSPDYExecutor(c.ClientConfig, "POST", req.URL())
+			if err != nil {
+				return nil, map[string]string{
+					filepath.Join(copyCollector.ContainerPath, "error"): err.Error(),
+				}
+			}
+
+			output := new(bytes.Buffer)
+			var stderr bytes.Buffer
+			err = exec.Stream(remotecommand.StreamOptions{
+				Stdin:  nil,
+				Stdout: output,
+				Stderr: &stderr,
+				Tty:    false,
+			})
+			files[file] = output.Bytes()
+
+			if err != nil {
+				errors := map[string]string{
+					filepath.Join(copyCollector.ContainerPath, "error"): err.Error(),
+				}
+				if s := output.String(); len(s) > 0 {
+					errors[filepath.Join(copyCollector.ContainerPath, "stdout")] = s
+				}
+				if s := stderr.String(); len(s) > 0 {
+					errors[filepath.Join(copyCollector.ContainerPath, "stderr")] = s
+				}
+				return nil, errors
+			}
+		}
+	}
+	return files, nil
 }
 
 func getCopyErrosFileName(copyCollector *troubleshootv1beta1.Copy) string {

--- a/pkg/collect/copy.go
+++ b/pkg/collect/copy.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-
 	"path/filepath"
 
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
@@ -63,10 +62,7 @@ func copyFiles(c *Collector, client *kubernetes.Clientset, pod corev1.Pod, copyC
 	if copyCollector.ContainerName != "" {
 		container = copyCollector.ContainerName
 	}
-	//Command cd into the path directory, tars the target file or folder into a temp file, cat-copy it and removes the temp file.
-	//Not using a temp file may end up in error "Refusing to write archive contents to terminal"
-	command := []string{"sh", "-c", fmt.Sprintf("tar -C %v  -cf tmp.tar %v; cat tmp.tar; rm tmp.tar", path.Dir(copyCollector.ContainerPath), path.Base(copyCollector.ContainerPath))}
-
+	command := []string{"sh", "-c", fmt.Sprintf("tar -C %s  -cf - %s | cat ", path.Dir(copyCollector.ContainerPath), path.Base(copyCollector.ContainerPath))}
 	req := client.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec")
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -3,9 +3,11 @@ package collect
 import (
 	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"encoding/binary"
 	"io"
 	"path/filepath"
+	"strings"
 
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/redact"
@@ -17,11 +19,11 @@ func redactMap(input map[string][]byte, additionalRedactors []*troubleshootv1bet
 		if v == nil {
 			continue
 		}
-		//If the file is a .tar file, it must not be redacted. Instead it is decompressed and each file inside the
+		//If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is decompressed and each file inside the
 		//tar is decompressed, redacted and compressed back into the tar.
-		if filepath.Ext(k) == ".tar" {
+		if filepath.Ext(k) == ".tar" || filepath.Ext(k) == ".tgz" || strings.HasSuffix(k, ".tar.gz") {
 			tarFile := bytes.NewBuffer(v)
-			unRedacted, tarHeaders, err := untarFile(tarFile)
+			unRedacted, tarHeaders, err := untarFile(tarFile, k)
 			if err != nil {
 				return nil, err
 			}
@@ -29,7 +31,7 @@ func redactMap(input map[string][]byte, additionalRedactors []*troubleshootv1bet
 			if err != nil {
 				return nil, err
 			}
-			result[k], err = tarFiles(redacted, tarHeaders)
+			result[k], err = tarFiles(redacted, tarHeaders, k)
 			if err != nil {
 				return nil, err
 			}
@@ -45,9 +47,17 @@ func redactMap(input map[string][]byte, additionalRedactors []*troubleshootv1bet
 	return result, nil
 }
 
-func tarFiles(tarContent map[string][]byte, tarHeaders map[string]*tar.Header) ([]byte, error) {
+func tarFiles(tarContent map[string][]byte, tarHeaders map[string]*tar.Header, filename string) ([]byte, error) {
 	buff := new(bytes.Buffer)
-	tw := tar.NewWriter(buff)
+	var tw *tar.Writer
+	var zw *gzip.Writer
+	if filepath.Ext(filename) == ".tgz" || strings.HasSuffix(filename, ".tar.gz") {
+		zw = gzip.NewWriter(buff)
+		tw = tar.NewWriter(zw)
+		defer zw.Close()
+	} else {
+		tw = tar.NewWriter(buff)
+	}
 	defer tw.Close()
 	for p, f := range tarContent {
 		if tarHeaders[p].FileInfo().IsDir() {
@@ -72,12 +82,29 @@ func tarFiles(tarContent map[string][]byte, tarHeaders map[string]*tar.Header) (
 	if err != nil {
 		return nil, err
 	}
+	if filepath.Ext(filename) == ".tgz" || strings.HasSuffix(filename, ".tar.gz") {
+		err = zw.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return buff.Bytes(), nil
 
 }
 
-func untarFile(tarFile *bytes.Buffer) (map[string][]byte, map[string]*tar.Header, error) {
-	tarReader := tar.NewReader(tarFile)
+func untarFile(tarFile *bytes.Buffer, filename string) (map[string][]byte, map[string]*tar.Header, error) {
+	var tarReader *tar.Reader
+	var zr *gzip.Reader
+	var err error
+	if filepath.Ext(filename) == ".tgz" || strings.HasSuffix(filename, ".tar.gz") {
+		zr, err = gzip.NewReader(tarFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		tarReader = tar.NewReader(zr)
+	} else {
+		tarReader = tar.NewReader(tarFile)
+	}
 	tarHeaders := make(map[string]*tar.Header)
 	tarContent := make(map[string][]byte)
 	for {

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -1,6 +1,12 @@
 package collect
 
 import (
+	"archive/tar"
+	"bytes"
+	"encoding/binary"
+	"path"
+	"strings"
+
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/redact"
 )
@@ -8,13 +14,31 @@ import (
 func redactMap(input map[string][]byte, additionalRedactors []*troubleshootv1beta1.Redact) (map[string][]byte, error) {
 	result := make(map[string][]byte)
 	for k, v := range input {
-		if v != nil {
-			redacted, err := redact.Redact(v, k, additionalRedactors)
-			if err != nil {
-				return nil, err
-			}
-			result[k] = redacted
+		if v == nil {
+			continue
 		}
+		if path.Ext(string(k)) == ".tar" || path.Ext(string(k)) == ".tar.gz" {
+			tarFile := bytes.NewBuffer(v)
+			buff := new(bytes.Buffer)
+			unRedacted, fileHeaders, _ := untarFile(tarFile, k+strings.TrimSuffix(path.Base(k), ".tar"))
+
+			files, _ := redactMap(unRedacted, additionalRedactors)
+			tw := tar.NewWriter(buff)
+			for p, f := range files {
+				fileHeaders[p].Size = int64(binary.Size(f))
+				tw.WriteHeader(fileHeaders[p])
+				tw.Write(f)
+			}
+			tw.Close()
+			result[k] = buff.Bytes()
+
+			continue
+		}
+		redacted, err := redact.Redact(v, k, additionalRedactors)
+		if err != nil {
+			return nil, err
+		}
+		result[k] = redacted
 	}
 	return result, nil
 }

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -98,6 +98,7 @@ func decompressFile(tarFile *bytes.Buffer, filename string) (map[string][]byte, 
 	var err error
 	if filepath.Ext(filename) != ".tar" {
 		zr, err = gzip.NewReader(tarFile)
+		defer zr.Close()
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -49,10 +49,9 @@ func tarFiles(tarContent map[string][]byte, tarHeaders map[string]*tar.Header) (
 	buff := new(bytes.Buffer)
 	tw := tar.NewWriter(buff)
 	defer tw.Close()
-	var err error
 	for p, f := range tarContent {
 		if tarHeaders[p].FileInfo().IsDir() {
-			err = tw.WriteHeader(tarHeaders[p])
+			err := tw.WriteHeader(tarHeaders[p])
 			if err != nil {
 				return nil, err
 			}
@@ -60,7 +59,7 @@ func tarFiles(tarContent map[string][]byte, tarHeaders map[string]*tar.Header) (
 		}
 		//File size must be recalculated in case the redactor added some bytes when redacting.
 		tarHeaders[p].Size = int64(binary.Size(f))
-		err = tw.WriteHeader(tarHeaders[p])
+		err := tw.WriteHeader(tarHeaders[p])
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +68,7 @@ func tarFiles(tarContent map[string][]byte, tarHeaders map[string]*tar.Header) (
 			return nil, err
 		}
 	}
-	err = tw.Close()
+	err := tw.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -17,6 +17,8 @@ func redactMap(input map[string][]byte, additionalRedactors []*troubleshootv1bet
 		if v == nil {
 			continue
 		}
+		//If the file is a .tar file, it must not be redacted. Instead it is decompressed and each file inside the
+		//tar is decompressed, redacted and compressed back into the tar.
 		if path.Ext(k) == ".tar" {
 			tarFile := bytes.NewBuffer(v)
 			buff := new(bytes.Buffer)
@@ -37,6 +39,7 @@ func redactMap(input map[string][]byte, additionalRedactors []*troubleshootv1bet
 			}
 			tw.Close()
 			result[k] = buff.Bytes()
+			//Tar file must not be redacted, the files inside were already redacted. Continue to next file.
 			continue
 		}
 		redacted, err := redact.Redact(v, k, additionalRedactors)

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -61,7 +61,10 @@ func tarFiles(files map[string][]byte, fileHeaders map[string]*tar.Header) ([]by
 			return nil, err
 		}
 	}
-	tw.Close()
+	err = tw.Close()
+	if err != nil {
+		return nil, err
+	}
 	return buff.Bytes(), err
 
 }

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -98,10 +98,10 @@ func decompressFile(tarFile *bytes.Buffer, filename string) (map[string][]byte, 
 	var err error
 	if filepath.Ext(filename) != ".tar" {
 		zr, err = gzip.NewReader(tarFile)
-		defer zr.Close()
 		if err != nil {
 			return nil, nil, err
 		}
+		defer zr.Close()
 		tarReader = tar.NewReader(zr)
 	} else {
 		tarReader = tar.NewReader(tarFile)


### PR DESCRIPTION
Hi there! To copy all the files in a given directory, I added this three steps:

1. Execute `find <folder or file path specified> -type f` in the container console, which finds all the files and returns each path
2. I then split the result and store it in an arrange of strings, variable file
3. Lastly I made a loop in the Copy function to cat the file in each path.

I've already tested it with different pods, and with multiple copy statements in the yaml file referencing different containers. Files are stored as before, under namespace/pod.name/containerpath/<subfolders>/ filename in the support-bundle. 

Let me know if there is something you would like to edit/add! 

Fix #212 