### PR TITLE
K8s events

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -27,7 +27,6 @@ func ClusterResources(c *Collector) (map[string][]byte, error) {
 	clusterResourcesOutput := map[string][]byte{}
 	// namespaces
 	var namespaceNames []string
-
 	if c.Namespace == "" {
 		namespaces, namespaceList, namespaceErrors := namespaces(ctx, client)
 		clusterResourcesOutput["cluster-resources/namespaces.json"] = namespaces

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -27,6 +27,13 @@ func ClusterResources(c *Collector) (map[string][]byte, error) {
 	clusterResourcesOutput := map[string][]byte{}
 	// namespaces
 	var namespaceNames []string
+
+	options := metav1.ListOptions{}
+	//a, err := client.EventsV1beta1().Events("").List(ctx, options)
+	events, err := client.CoreV1().Events("").List(ctx, options)
+	parsedEvents, err := json.MarshalIndent(events.Items, "", "  ")
+	clusterResourcesOutput["cluster-resources/events.json"] = parsedEvents
+
 	if c.Namespace == "" {
 		namespaces, namespaceList, namespaceErrors := namespaces(ctx, client)
 		clusterResourcesOutput["cluster-resources/namespaces.json"] = namespaces


### PR DESCRIPTION
@marccampbell Here goes the PR to add the events to the support bundle. They are added in a separate folder inside the bundle, separated by namespace, just as the stateful sets and some other resources. Let me now what you think! Fix issue #103 