### PR TITLE
selector:MatchLabel

### DIFF
--- a/pkg/analyze/node_resources.go
+++ b/pkg/analyze/node_resources.go
@@ -319,6 +319,13 @@ func nodeMatchesFilters(node corev1.Node, filters *troubleshootv1beta1.NodeResou
 	}
 
 	// all filters must pass for this to pass
+	if filters.Selector != nil {
+		for k, v := range filters.Selector.MatchLabel {
+			if l, found := node.Labels[k]; !found || l != v {
+				return false, errors.New(fmt.Sprintf("failed to match label %s", k))
+			}
+		}
+	}
 
 	if filters.CPUCapacity != "" {
 		parsed, err := resource.ParseQuantity(filters.CPUCapacity)

--- a/pkg/analyze/node_resources.go
+++ b/pkg/analyze/node_resources.go
@@ -322,7 +322,7 @@ func nodeMatchesFilters(node corev1.Node, filters *troubleshootv1beta1.NodeResou
 	if filters.Selector != nil {
 		for k, v := range filters.Selector.MatchLabel {
 			if l, found := node.Labels[k]; !found || l != v {
-				return false, errors.New(fmt.Sprintf("failed to match label %s", k))
+				return false, errors.Errorf("failed to match label %s", k)
 			}
 		}
 	}

--- a/pkg/apis/troubleshoot/v1beta1/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta1/analyzer_shared.go
@@ -84,14 +84,19 @@ type NodeResources struct {
 }
 
 type NodeResourceFilters struct {
-	CPUCapacity                 string `json:"cpuCapacity,omitempty" yaml:"cpuCapacity,omitempty"`
-	CPUAllocatable              string `json:"cpuAllocatable,omitempty" yaml:"cpuAllocatable,omitempty"`
-	MemoryCapacity              string `json:"memoryCapacity,omitempty" yaml:"memoryCapacity,omitempty"`
-	MemoryAllocatable           string `json:"memoryAllocatable,omitempty" yaml:"memoryAllocatable,omitempty"`
-	PodCapacity                 string `json:"podCapacity,omitempty" yaml:"podCapacity,omitempty"`
-	PodAllocatable              string `json:"podAllocatable,omitempty" yaml:"podAllocatable,omitempty"`
-	EphemeralStorageCapacity    string `json:"ephemeralStorageCapacity,omitempty" yaml:"ephemeralStorageCapacity,omitempty"`
-	EphemeralStorageAllocatable string `json:"ephemeralStorageAllocatable,omitempty" yaml:"ephemeralStorageAllocatable,omitempty"`
+	CPUCapacity                 string                 `json:"cpuCapacity,omitempty" yaml:"cpuCapacity,omitempty"`
+	CPUAllocatable              string                 `json:"cpuAllocatable,omitempty" yaml:"cpuAllocatable,omitempty"`
+	MemoryCapacity              string                 `json:"memoryCapacity,omitempty" yaml:"memoryCapacity,omitempty"`
+	MemoryAllocatable           string                 `json:"memoryAllocatable,omitempty" yaml:"memoryAllocatable,omitempty"`
+	PodCapacity                 string                 `json:"podCapacity,omitempty" yaml:"podCapacity,omitempty"`
+	PodAllocatable              string                 `json:"podAllocatable,omitempty" yaml:"podAllocatable,omitempty"`
+	EphemeralStorageCapacity    string                 `json:"ephemeralStorageCapacity,omitempty" yaml:"ephemeralStorageCapacity,omitempty"`
+	EphemeralStorageAllocatable string                 `json:"ephemeralStorageAllocatable,omitempty" yaml:"ephemeralStorageAllocatable,omitempty"`
+	Selector                    *NodeResourceSelectors `json:"selector,omitempty" yaml:"selector,omitempty"`
+}
+
+type NodeResourceSelectors struct {
+	MatchLabel map[string]string `json:"matchLabel,omitempty" yaml:"matchLabel,omitempty"`
 }
 
 type TextAnalyze struct {


### PR DESCRIPTION
@marccampbell @divolgin @dexhorthy Morning! I am sending a PR to solve issue #159 . I desing the selector label to accept further expansions in the future. Under matchLabel, multiple labels can be used to filter the nodes. The final structure would be something like this:
```YAML
- nodeResources:
        checkName: Must have at least 3 nodes in the cluster, with cpuCapacity of 2 and label kubernetes.io/hostname=docker-desktop
        filters:
            cpuCapacity: "2"
            selector: 
                matchLabel: 
                    kubernetes.io/hostname  : docker-desktop
        outcomes:
        - fail:
            when: "count() < 3"
            message: This application requires at least 3 nodes.
            uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
        - warn:
            when: "count() < 5"
            message: This application recommends at last 5 nodes.
            uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
        - pass:
            message: This cluster has enough nodes.
```