### PR TITLE
Add or create ImagePullSecret  in a run collector 

### DIFF
--- a/pkg/apis/troubleshoot/v1beta1/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta1/collector_shared.go
@@ -52,13 +52,20 @@ type Data struct {
 
 type Run struct {
 	CollectorMeta   `json:",inline" yaml:",inline"`
-	Name            string   `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace       string   `json:"namespace" yaml:"namespace"`
-	Image           string   `json:"image" yaml:"image"`
-	Command         []string `json:"command,omitempty" yaml:"command,omitempty"`
-	Args            []string `json:"args,omitempty" yaml:"args,omitempty"`
-	Timeout         string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	ImagePullPolicy string   `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace       string            `json:"namespace" yaml:"namespace"`
+	Image           string            `json:"image" yaml:"image"`
+	Command         []string          `json:"command,omitempty" yaml:"command,omitempty"`
+	Args            []string          `json:"args,omitempty" yaml:"args,omitempty"`
+	Timeout         string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	ImagePullPolicy string            `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	ImagePullSecret *ImagePullSecrets `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
+}
+
+type ImagePullSecrets struct {
+	Name       string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Data       map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+	SecretType string            `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
 type Exec struct {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -52,13 +52,20 @@ type Data struct {
 
 type Run struct {
 	CollectorMeta   `json:",inline" yaml:",inline"`
-	Name            string   `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace       string   `json:"namespace" yaml:"namespace"`
-	Image           string   `json:"image" yaml:"image"`
-	Command         []string `json:"command,omitempty" yaml:"command,omitempty"`
-	Args            []string `json:"args,omitempty" yaml:"args,omitempty"`
-	Timeout         string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	ImagePullPolicy string   `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace       string            `json:"namespace" yaml:"namespace"`
+	Image           string            `json:"image" yaml:"image"`
+	Command         []string          `json:"command,omitempty" yaml:"command,omitempty"`
+	Args            []string          `json:"args,omitempty" yaml:"args,omitempty"`
+	Timeout         string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	ImagePullPolicy string            `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	ImagePullSecret *ImagePullSecrets `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
+}
+
+type ImagePullSecrets struct {
+	Name       string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Data       map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+	SecretType string            `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
 type Exec struct {

--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -183,7 +183,7 @@ func createSecret(ctx context.Context, client *kubernetes.Clientset, imagePullSe
 				//Client only accepts Json formated files as data, so we decode and indent it (indentation is required)
 				parsedConfig, err := base64.StdEncoding.DecodeString(v)
 				if err != nil {
-					return errors.Wrap(err, "Secret's config file not found or unable to parse encoded data.")
+					return errors.Wrap(err, "Secret's config file not found or unable to decode data.")
 				}
 				err = json.Indent(&out, parsedConfig, "", "\t")
 				if err != nil {

--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -1,7 +1,11 @@
 package collect
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
 	"time"
 
 	"github.com/pkg/errors"
@@ -30,7 +34,15 @@ func Run(c *Collector, runCollector *troubleshootv1beta2.Run) (map[string][]byte
 			logger.Printf("Failed to delete pod %s: %v\n", pod.Name, err)
 		}
 	}()
-
+	if runCollector.ImagePullSecret.Data != nil {
+		defer func() {
+			for _, k := range pod.Spec.ImagePullSecrets {
+				if err := client.CoreV1().Secrets(pod.Namespace).Delete(ctx, k.Name, metav1.DeleteOptions{}); err != nil {
+					logger.Printf("Failed to delete secret %s: %v\n", k.Name, err)
+				}
+			}
+		}()
+	}
 	if runCollector.Timeout == "" {
 		return runWithoutTimeout(ctx, c, pod, runCollector)
 	}
@@ -137,10 +149,79 @@ func runPod(ctx context.Context, client *kubernetes.Clientset, runCollector *tro
 		},
 	}
 
+	if runCollector.ImagePullSecret != nil {
+		err := createSecret(ctx, client, runCollector.ImagePullSecret, &pod)
+		if err != nil {
+			return nil, err
+		}
+	}
 	created, err := client.CoreV1().Pods(namespace).Create(ctx, &pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create pod")
 	}
 
 	return created, nil
+}
+func createSecret(ctx context.Context, client *kubernetes.Clientset, imagePullSecret *troubleshootv1beta2.ImagePullSecrets, pod *corev1.Pod) error {
+	//In case a new secret needs to be created
+	if imagePullSecret.Data != nil {
+		var out bytes.Buffer
+		data := make(map[string][]byte)
+		if imagePullSecret.SecretType == "kubernetes.io/dockerconfigjson" {
+			//If secret type is dockerconfigjson, check if required field in data exists
+			v, found := imagePullSecret.Data[".dockerconfigjson"]
+			if !found {
+				return errors.Errorf("Secret type kubernetes.io/dockerconfigjson requires argument \".dockerconfigjson\"")
+			}
+			if len(imagePullSecret.Data) > 1 {
+				return errors.Errorf("Secret type kubernetes.io/dockerconfigjson accepts only one argument \".dockerconfigjson\"")
+			}
+			//Then, if data is a path to a config file, it is opened
+			configFile, err := ioutil.ReadFile(v)
+			if err != nil {
+				//If data is not a valid path, we assume data is a base64 encoded config.json file
+				//Client only accepts Json formated files as data, so we decode and indent it (indentation is required)
+				parsedConfig, err := base64.StdEncoding.DecodeString(v)
+				if err != nil {
+					return err
+				}
+				err = json.Indent(&out, parsedConfig, "", "\t")
+				if err != nil {
+					return errors.Errorf("Secret's config file not found or unable to parse encoded data.")
+				}
+				data[".dockerconfigjson"] = out.Bytes()
+			} else {
+				data[".dockerconfigjson"] = configFile
+			}
+		} else {
+			for k, v := range imagePullSecret.Data {
+				data[k] = []byte(v)
+			}
+		}
+		secret := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:         imagePullSecret.Name,
+				GenerateName: "tmpsecret",
+				Namespace:    pod.Namespace,
+			},
+			Data: data,
+			Type: corev1.SecretType(imagePullSecret.SecretType),
+		}
+		created, err := client.CoreV1().Secrets(pod.Namespace).Create(ctx, &secret, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+		pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: created.Name})
+		return nil
+	}
+	//In case secret must only be added to the specs.
+	if imagePullSecret.Name != "" {
+		pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: imagePullSecret.Name})
+		return nil
+	}
+	return errors.Errorf("Secret must at least have a Name")
 }


### PR DESCRIPTION
@marccampbell @dexhorthy regarding issue #247   I added the possibility to either add an existing secret :

```yaml
- run
     ...
     imagePullSecret:
         name: mysecret
```
or to create a secret. In this case there are various options:
- add an opaque secret, with one or many data fields in it
- optionally add a name to the secret. If none is provided a random name is generated 
- provide a type kubernetes.io/dockerconfigjson secret, in which case there are two options
   - provide the path to the config file. The client parses and encodes it automatically.
   - provide an already base64-encoded configfile. Though it is not actually an option when using the k8s client, I dealt with this because it is the suggested way in kubernetes official docs (but it only works when using yaml). What I did was to decode the string, indent it to rebuild the json, and put it into the secret. Base64 does not takes into consideration white spaces or tabs, making this algorithm independent of  the original config file's indentation. All this thinking in making it more familiar to the user.

I handle the secret's data as []byte because it is safer according to what I read.
```yaml
- run
      ...
      imagePullSecret:
          name: mysecret
          data: 
            .dockerconfigjson: path/.docker/config.json
          type: kubernetes.io/dockerconfigjson
```
```yaml
- run
      ...
      imagePullSecret:
          name: mysecret
          data: 
            .dockerconfigjson: woJICJhdXRocyI6IHsKCQkiaHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEvIjoge30KCX0sCgkiSHR0cEhlYWRlcnMiOiB7CgkJIlVzZXItQWdlbnQiOiAiRG9ja2VyLUNsaWVudC8xOS4wMy4xMiAoZGFyd2luKSIKCX0sCgkiY3JlZHNTdG9yZSI6ICJkZXNrdG9wIiwKCSJleHBlcmltZW50YWwiOiAiZGlzYWJsZWQiLAoJInN0YWNrT3JjaGVzdHJhdG9yIjogInN3YXJtIgp9
          type: kubernetes.io/dockerconfigjson
```
                         

```yaml
- run
      ...
      imagePullSecret:
          data: 
            a: foo
            b: bar
```
Let me know what you think of the solution! 