### PR TITLE
Abort run collector on ImagePullBackoff

### DIFF
--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -89,6 +89,13 @@ func runWithoutTimeout(ctx context.Context, c *Collector, pod *corev1.Pod, runCo
 			status.Status.Phase == corev1.PodSucceeded {
 			break
 		}
+		if status.Status.Phase == corev1.PodPending {
+			for k := range status.Status.ContainerStatuses {
+				if status.Status.ContainerStatuses[k].State.Waiting.Reason == "ImagePullBackOff" {
+					return nil, errors.Errorf("run pod aborted after getting pod status 'ImagePullBackOff'")
+				}
+			}
+		}
 		time.Sleep(time.Second * 1)
 	}
 

--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -90,8 +90,8 @@ func runWithoutTimeout(ctx context.Context, c *Collector, pod *corev1.Pod, runCo
 			break
 		}
 		if status.Status.Phase == corev1.PodPending {
-			for k := range status.Status.ContainerStatuses {
-				if status.Status.ContainerStatuses[k].State.Waiting.Reason == "ImagePullBackOff" {
+			for _, v := range status.Status.ContainerStatuses {
+				if v.State.Waiting.Reason == "ImagePullBackOff" {
 					return nil, errors.Errorf("run pod aborted after getting pod status 'ImagePullBackOff'")
 				}
 			}


### PR DESCRIPTION
@areed Hi andrew, this would terminate the pod and delete the imagepullsecret (if it was created together with the pod) when status is 'ImagePullBackoff'. We could also add an internal timeout  when this state is reached. Further error-status  may be handled too. For example if pod was evicted for any reason. An explanatory message provided by k8s may be added to the error. 
Closes #257 
Let me know what you think! 