### PR TITLE
Error Parsing Postgres Version 

### DIFF
--- a/pkg/analyze/database_shared.go
+++ b/pkg/analyze/database_shared.go
@@ -35,6 +35,18 @@ func compareDatabaseConditionalToActual(conditional string, result *collect.Data
 		return false, errors.New("unable to parse postgres connected analyzer")
 
 	case "version":
+		//semver requires major.minor.patch format to successqfully compare versions.
+		if compVer := strings.Split(parts[2], "."); len(compVer) == 2 {
+			parts[2] = fmt.Sprintf("%s.%s.0", compVer[0], compVer[1])
+		} else if len(compVer) == 1 {
+			parts[2] = fmt.Sprintf("%s.0.0", compVer[0])
+		}
+		if compVer := strings.Split(result.Version, "."); len(compVer) == 2 {
+			result.Version = fmt.Sprintf("%s.%s.0", compVer[0], compVer[1])
+		} else if len(compVer) == 1 {
+			result.Version = fmt.Sprintf("%s.0.0", compVer[0])
+		}
+
 		expectedRange, err := semver.ParseRange(fmt.Sprintf("%s %s", parts[1], parts[2]))
 		if err != nil {
 			return false, errors.Wrap(err, "failed to parse semver range")
@@ -42,7 +54,7 @@ func compareDatabaseConditionalToActual(conditional string, result *collect.Data
 
 		actual, err := semver.Parse(result.Version)
 		if err != nil {
-			return false, errors.Wrap(err, "failed to parse actual psotgres version")
+			return false, errors.Wrap(err, "failed to parse actual postgres version")
 		}
 
 		return expectedRange(actual), nil


### PR DESCRIPTION
@areed Hi! Regarding issue #254, the problem was that the semver version used only accepts version format major.minor.patch (eg. 10.2.3). This PR fix #254 

According to Postgres Versioning Policy, starting with version 10 on the version string will only have 2 parts, major.minor, that would make possible to simply add a 0 after the versions entered by the user and the one collected, but I think this solution is more robust.

I tested it against a dockerized Postgres DB and worked just fine.