### PR TITLE
Distribution enhacement

### DIFF
--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -214,10 +214,9 @@ func analyzeDistribution(analyzer *troubleshootv1beta2.Distribution, getCollecte
 		}
 	}
 
-	if !result.IsFail && !result.IsPass && !result.IsWarn {
-		result.IsWarn = true
-		result.Message = "None of the conditionals were met"
-	}
+	result.IsWarn = true
+	result.Message = "None of the conditionals were met"
+
 	return result, nil
 }
 

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -215,12 +215,11 @@ func analyzeDistribution(analyzer *troubleshootv1beta2.Distribution, getCollecte
 
 		}
 	}
-	if unknownDistribution != "" {
-		result.IsWarn = true
-		result.Message = result.Message + unknownDistribution
 
+	result.IsWarn = true
+	if unknownDistribution != "" {
+		result.Message = unknownDistribution
 	} else {
-		result.IsWarn = true
 		result.Message = "None of the conditionals were met"
 	}
 
@@ -245,7 +244,7 @@ func compareDistributionConditionalToActual(conditional string, actual providers
 	normalizedName := mustNormalizeDistributionName(parts[1])
 
 	if normalizedName == unknown {
-		*unknownDistribution = *unknownDistribution + fmt.Sprintf("- Unknown distribution: %s ", parts[1])
+		*unknownDistribution += fmt.Sprintf("- Unknown distribution: %s ", parts[1])
 		return false, nil
 	}
 

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -165,6 +165,7 @@ func analyzeDistribution(analyzer *troubleshootv1beta2.Distribution, getCollecte
 				result.IsFail = true
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
+
 				return result, nil
 			}
 		} else if outcome.Warn != nil {
@@ -215,7 +216,7 @@ func analyzeDistribution(analyzer *troubleshootv1beta2.Distribution, getCollecte
 
 	if !result.IsFail && !result.IsPass && !result.IsWarn {
 		result.IsWarn = true
-		result.Message = "None of the conditionals was met"
+		result.Message = "None of the conditionals were met"
 	}
 	return result, nil
 }

--- a/pkg/analyze/distribution_test.go
+++ b/pkg/analyze/distribution_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func Test_compareDistributionConditionalToActual(t *testing.T) {
+	var unknownDistribution string
 	tests := []struct {
 		name        string
 		conditional string
@@ -46,7 +47,7 @@ func Test_compareDistributionConditionalToActual(t *testing.T) {
 			defer scopetest.End()
 			req := require.New(t)
 
-			actual, err := compareDistributionConditionalToActual(test.conditional, test.input)
+			actual, err := compareDistributionConditionalToActual(test.conditional, test.input, &unknownDistribution)
 			req.NoError(err)
 
 			assert.Equal(t, test.expected, actual)


### PR DESCRIPTION
Hi @marccampbell , based on the node description in the issues, I used providerID to identify ibm, and a label to identify Minikube (minikube annotates the nodes with this label to help identifying the node was created by minikube).

I added a warning message in case none of the conditional are met. I found out that there is no error/warning message when  the provider in the conditional is not in the internal provider list (either because it is not considered or because there is a typo), in which case the user would receive an empty message in the interactive display. Maybe a warning may help the user to revise the  conditionals.

Closes #234 Closes #243 