### PR TITLE
Support semver

### DIFF
--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -289,6 +289,9 @@ func parseConditional(conditional string) (*Conditional, error) {
 			return nil, errors.Errorf("Unable to parse semverCompare expresion \"%s\". Correct format is \"semverCompare(variable operator expectedVersion)\"", conditional)
 		}
 		parts := strings.Split(strings.TrimSpace(rs[1]), " ")
+		if len(parts) != 3 {
+			return nil, errors.Errorf("unable to parse conditional expresion in semverCompare. Expected \"variable operator version\", found  %s", rs[1])
+		}
 		parsedConditional.method = "semverCompare"
 		parsedConditional.lookForMatchName = parts[0]
 		parsedConditional.operator = parts[1]
@@ -300,7 +303,6 @@ func parseConditional(conditional string) (*Conditional, error) {
 		if rs == nil {
 			return nil, errors.Errorf("Unable to parse semverRange expresion \"%s\". Correct format is \"semverRange(variable, \"expectedRange\")\"", conditional)
 		}
-
 		parsedConditional.method = "semverRange"
 		parsedConditional.lookForMatchName = rs[1]
 		parsedConditional.operator = ""

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -268,11 +268,11 @@ func compareInt(operator string, foundValueInt int, lookForValueInt int) (bool, 
 func compareSemVer(operator string, foundValue string, lookForValue string) (bool, error) {
 	expected, err := semver.ParseTolerant(strings.Replace(lookForValue, "x", "0", -1))
 	if err != nil {
-		return false, errors.Wrap(err, "failed to parse postgres db expected version")
+		return false, errors.Wrap(err, "failed to parse expected semantic version")
 	}
 	actual, err := semver.ParseTolerant(strings.Replace(foundValue, "x", "0", -1))
 	if err != nil {
-		return false, errors.Wrap(err, "failed to parse postgres db actual version")
+		return false, errors.Wrap(err, "failed to parse found semantic version")
 	}
 	expectedRange, err := semver.ParseRange(fmt.Sprintf("%s %s", operator, expected.String()))
 	if err != nil {

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -283,7 +283,7 @@ func compareSemVer(operator string, foundValue string, lookForValue string) (boo
 func parseConditional(conditional string) (*Conditional, error) {
 	parsedConditional := new(Conditional)
 	if strings.Contains(conditional, "semverCompare") {
-		rgx := regexp.MustCompile(`semverCompare\((?P<cond>[a-z"|<>=& ,0-9]+)\)`)
+		rgx := regexp.MustCompile(`semverCompare\((?P<cond>[a-z<>= .!0-9]+)\)`)
 		rs := rgx.FindStringSubmatch(conditional)
 		if rs == nil {
 			return nil, errors.Errorf("Unable to parse semverCompare expresion \"%s\". Correct format is \"semverCompare(variable operator expectedVersion)\"", conditional)
@@ -298,7 +298,7 @@ func parseConditional(conditional string) (*Conditional, error) {
 		parsedConditional.lookForValue = parts[2]
 
 	} else if strings.Contains(conditional, "semverRange") {
-		rgx := regexp.MustCompile(`semverRange\((?P<cond>[a-z"|<>=&,0-9]+) ?, ?\"(?P<cond2>[a-z|<>=& .!,0-9]+)\"\)`)
+		rgx := regexp.MustCompile(`semverRange\((?P<var>[a-z\_\-.0-9]+) ?, ?\"(?P<cond>[a-z|<>=& \-.!0-9]+)\"\)`)
 		rs := rgx.FindStringSubmatch(conditional)
 		if rs == nil {
 			return nil, errors.Errorf("Unable to parse semverRange expresion \"%s\". Correct format is \"semverRange(variable, \"expectedRange\")\"", conditional)

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -12,6 +12,13 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
+type Conditional struct {
+	method           string
+	lookForMatchName string
+	operator         string
+	lookForValue     string
+}
+
 func analyzeTextAnalyze(analyzer *troubleshootv1beta2.TextAnalyze, getCollectedFileContents func(string) (map[string][]byte, error)) ([]*AnalyzeResult, error) {
 	fullPath := filepath.Join(analyzer.CollectorName, analyzer.FileName)
 	collected, err := getCollectedFileContents(fullPath)
@@ -204,40 +211,29 @@ func analyzeRegexGroups(pattern string, collected []byte, outcomes []*troublesho
 }
 
 func compareRegex(conditional string, foundMatches map[string]string) (bool, error) {
-	compare := ""
-	parts := strings.Split(strings.TrimSpace(conditional), " ")
-
-	if len(parts) != 3 {
-		if len(parts) == 4 && parts[0] != "semverCompare" {
-			return false, errors.Errorf("unable to parse regex conditional. %s is not a supported comparison method", parts[0])
-		}
-		return false, errors.New("unable to parse regex conditional")
+	parsedConditional, err := parseConditional(conditional)
+	if err != nil {
+		return false, err
 	}
 
-	if len(parts) == 4 {
-		compare = parts[0]
-		parts = parts[1:]
-	}
-	lookForMatchName := parts[0]
-	operator := parts[1]
-	lookForValue := parts[2]
-
-	foundValue, ok := foundMatches[lookForMatchName]
+	foundValue, ok := foundMatches[parsedConditional.lookForMatchName]
 	if !ok {
 		// not an error, just wasn't matched
 		return false, nil
 	}
 
-	if compare == "semverCompare" {
-		return compareSemVer(operator, foundValue, lookForValue)
-	} else if lookForValueInt, err := strconv.Atoi(lookForValue); err == nil {
+	if parsedConditional.method == "semverCompare" {
+		return compareSemVer(parsedConditional.operator, foundValue, parsedConditional.lookForValue)
+	} else if parsedConditional.method == "semverRange" {
+		return compareSemVer("", foundValue, parsedConditional.lookForValue)
+	} else if lookForValueInt, err := strconv.Atoi(parsedConditional.lookForValue); err == nil {
 		// if the value side of the conditional is an int, we assume it's an int
 		foundValueInt, err := strconv.Atoi(foundValue)
 		if err != nil {
 			// not an error but maybe it should be...
 			return false, nil
 		}
-		switch operator {
+		switch parsedConditional.operator {
 		case "=":
 			fallthrough
 		case "==":
@@ -258,25 +254,67 @@ func compareRegex(conditional string, foundMatches map[string]string) (bool, err
 			return foundValueInt >= lookForValueInt, nil
 		}
 	}
-	if operator != "=" && operator != "==" && operator != "===" {
-		return false, fmt.Errorf("unexpected operator %q in regex comparator, cannot compare %q and %q", operator, foundValue, lookForValue)
+	if parsedConditional.operator != "=" && parsedConditional.operator != "==" && parsedConditional.operator != "===" {
+		return false, fmt.Errorf("unexpected operator %q in regex comparator, cannot compare %q and %q", parsedConditional.operator, foundValue, parsedConditional.lookForValue)
 	}
 
-	return foundValue == lookForValue, nil
+	return foundValue == parsedConditional.lookForValue, nil
 }
 
 func compareSemVer(operator string, foundValue string, lookForValue string) (bool, error) {
-	expected, err := semver.ParseTolerant(strings.Replace(lookForValue, "x", "0", -1))
-	if err != nil {
-		return false, errors.Wrap(err, "failed to parse expected semantic version")
+	if operator != "" {
+		expected, err := semver.ParseTolerant(strings.Replace(lookForValue, "x", "0", -1))
+		if err != nil {
+			return false, errors.Wrap(err, "failed to parse expected semantic version")
+		}
+		lookForValue = fmt.Sprintf("%s %s", operator, expected.String())
 	}
 	actual, err := semver.ParseTolerant(strings.Replace(foundValue, "x", "0", -1))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to parse found semantic version")
 	}
-	expectedRange, err := semver.ParseRange(fmt.Sprintf("%s %s", operator, expected.String()))
+	expectedRange, err := semver.ParseRange(lookForValue)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to parse semver range")
 	}
 	return expectedRange(actual), nil
+}
+
+func parseConditional(conditional string) (*Conditional, error) {
+	parsedConditional := new(Conditional)
+	if strings.Contains(conditional, "semverCompare") {
+		rgx := regexp.MustCompile(`semverCompare\((?P<cond>[a-z"|<>=& ,0-9]+)\)`)
+		rs := rgx.FindStringSubmatch(conditional)
+		if rs == nil {
+			return nil, errors.Errorf("Unable to parse semverCompare expresion \"%s\". Correct format is \"semverCompare(variable operator expectedVersion)\"", conditional)
+		}
+		parts := strings.Split(strings.TrimSpace(rs[1]), " ")
+		parsedConditional.method = "semverCompare"
+		parsedConditional.lookForMatchName = parts[0]
+		parsedConditional.operator = parts[1]
+		parsedConditional.lookForValue = parts[2]
+
+	} else if strings.Contains(conditional, "semverRange") {
+		rgx := regexp.MustCompile(`semverRange\((?P<cond>[a-z"|<>=&,0-9]+) ?, ?\"(?P<cond2>[a-z|<>=& .!,0-9]+)\"\)`)
+		rs := rgx.FindStringSubmatch(conditional)
+		if rs == nil {
+			return nil, errors.Errorf("Unable to parse semverRange expresion \"%s\". Correct format is \"semverRange(variable, \"expectedRange\")\"", conditional)
+		}
+
+		parsedConditional.method = "semverRange"
+		parsedConditional.lookForMatchName = rs[1]
+		parsedConditional.operator = ""
+		parsedConditional.lookForValue = rs[2]
+
+	} else {
+		parts := strings.Split(strings.TrimSpace(conditional), " ")
+		if len(parts) != 3 {
+			return nil, errors.New("unable to parse regex conditional")
+		}
+		parsedConditional.method = "default"
+		parsedConditional.lookForMatchName = parts[0]
+		parsedConditional.operator = parts[1]
+		parsedConditional.lookForValue = parts[2]
+	}
+	return parsedConditional, nil
 }

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -283,7 +283,7 @@ func compareSemVer(operator string, foundValue string, lookForValue string) (boo
 func parseConditional(conditional string) (*Conditional, error) {
 	parsedConditional := new(Conditional)
 	if strings.Contains(conditional, "semverCompare") {
-		rgx := regexp.MustCompile(`semverCompare\((?P<cond>[a-z<>= .!0-9]+)\)`)
+		rgx := regexp.MustCompile(`semverCompare\((?P<cond>[a-z<>=\_\- .!0-9]+)\)`)
 		rs := rgx.FindStringSubmatch(conditional)
 		if rs == nil {
 			return nil, errors.Errorf("Unable to parse semverCompare expresion \"%s\". Correct format is \"semverCompare(variable operator expectedVersion)\"", conditional)

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -267,6 +267,9 @@ func compareInt(operator string, foundValueInt int, lookForValueInt int) (bool, 
 }
 func compareSemVer(operator string, foundValue string, lookForValue string) (bool, error) {
 	expected, err := semver.ParseTolerant(strings.Replace(lookForValue, "x", "0", -1))
+	if err != nil {
+		return false, errors.Wrap(err, "failed to parse postgres db expected version")
+	}
 	actual, err := semver.ParseTolerant(strings.Replace(foundValue, "x", "0", -1))
 	if err != nil {
 		return false, errors.Wrap(err, "failed to parse postgres db actual version")

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -119,9 +119,6 @@ func analyzeRegexGroups(pattern string, collected []byte, outcomes []*troublesho
 	}
 
 	match := re.FindStringSubmatch(string(collected))
-	if match == nil {
-		return nil, errors.Errorf("No matchs found.")
-	}
 	result := &AnalyzeResult{
 		Title:   checkName,
 		IconKey: "kubernetes_text_analyze",


### PR DESCRIPTION
@areed @divolgin Hi, I added the possibility to compare semversions. The group containing the version must be called "version" or "Version". If it is the case, the text analyzer runs a semver analysis. Fix #275.