### PR TITLE
use '_' instead of ':' in support bundle name format

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -455,7 +455,7 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, ad
 		}
 	}
 
-	filename, err := findFileName("support-bundle-"+time.Now().Format("2006-01-02T15:04:05"), "tar.gz")
+	filename, err := findFileName("support-bundle-"+time.Now().Format("2006-01-02T15_04_05"), "tar.gz")
 	if err != nil {
 		return "", errors.Wrap(err, "find file name")
 	}


### PR DESCRIPTION
fixes #282 