### PR TITLE
fixed runCollector filepath

### DIFF
--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -52,7 +52,7 @@ type Data struct {
 
 type Run struct {
 	CollectorMeta   `json:",inline" yaml:",inline"`
-	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
+	PodName         string            `json:"podName,omitempty" yaml:"podName,omitempty"`
 	Namespace       string            `json:"namespace" yaml:"namespace"`
 	Image           string            `json:"image" yaml:"image"`
 	Command         []string          `json:"command,omitempty" yaml:"command,omitempty"`

--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -24,8 +24,12 @@ func Run(c *Collector, runCollector *troubleshootv1beta2.Run) (map[string][]byte
 		return nil, errors.Wrap(err, "failed to create client from config")
 	}
 	if runCollector.PodName == "" {
-		imageName := strings.Split(runCollector.Image, ":")
-		runCollector.PodName = imageName[0]
+		if runCollector.Image != "" {
+			imageName := strings.Split(runCollector.Image, ":")
+			runCollector.PodName = imageName[0]
+		} else {
+			return nil, errors.Errorf("failed to run pod: runcollector.Image field is required")
+		}
 	}
 
 	pod, err := runPod(ctx, client, runCollector, c.Namespace)

--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -113,7 +114,7 @@ func runWithoutTimeout(ctx context.Context, c *Collector, pod *corev1.Pod, runCo
 		MaxLines: 10000,
 	}
 	if runCollector.CollectorName == "" {
-		runCollector.CollectorName = "run-collector-pod-" + pod.Name
+		runCollector.CollectorName = fmt.Sprintf("run-collector-pod-%s", pod.Name)
 	}
 	podLogs, err := getPodLogs(ctx, client, *pod, runCollector.CollectorName, "", &limits, true)
 	if err != nil {


### PR DESCRIPTION
@laverya @dexhorthy @divolgin The use of the run collector together with  the text analyzer, the filepath handling and the fields of the run collector where not entirely clear. I will modify the docks once the PR is merged. I did some changes:

- `CollectorName` field was used as the pod's name and the `name` field was used as collector name, preceding the file path.
- Changed the `name` field to `PodName` and used it as the pod's name.
- Log file is stored under `runCollector.CollectorName/runCollector.PodName.log`, previously it was stored under `runCollector.Name/runCollector.CollectorName.log`. This change makes it compatible with the text analyzer. 
- As CollectorName and PodName are optional, I made PodName default to the image name, and collector name default to "run-collector-pod-"+PodName.

This change is only noticeable when using the text analyzer,  which will now work in a more logical way now, making it also easier to use. The text analyzer looks for the files under `collectorName/filename`, the other way around as how the run collector was saving the file, which made it tricky to use.

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: Preflight
metadata:
  name: example
spec:
  collectors:
    - run:
        collectorName: "run-ping"
        image: busybox:1
        podName: ping
        namespace: default
        command: ["ping"]
        args: ["-w", "10", "-c", "10", "-i", "0.3", "www.google.com"]
  analyzers:
    - textAnalyze:
        checkName: "run-ping"
        fileName: "ping.log"
        regexGroup: '(?P<Transmitted>\d+) packets? transmitted, (?P<Received>\d+) packets? received, (?P<Loss>\d+)(\.\d+)?% packet loss'
        outcomes:
          - pass:
              when: "Loss < 5"
              message: Solid connection to google.com
          - fail:
              message: High packet loss
```

Fix #189 