### PR TITLE
added flag --since-time for Logs Collectors

### DIFF
--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -35,6 +35,7 @@ that a cluster meets the requirements to run an application.`,
 	cmd.Flags().String("collector-image", "", "the full name of the collector image to use")
 	cmd.Flags().String("collector-pullpolicy", "", "the pull policy of the collector image")
 	cmd.Flags().Bool("collect-without-permissions", false, "always run preflight checks even if some require permissions that preflight does not have")
+	cmd.Flags().String("since-time", "", "forces pod's logs collectors to return logs after a specific date (RFC3339)")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -36,7 +36,7 @@ that a cluster meets the requirements to run an application.`,
 	cmd.Flags().String("collector-pullpolicy", "", "the pull policy of the collector image")
 	cmd.Flags().Bool("collect-without-permissions", false, "always run preflight checks even if some require permissions that preflight does not have")
 	cmd.Flags().String("since-time", "", "forces pod's logs collectors to return logs after a specific date (RFC3339)")
-	cmd.Flags().String("since", "", "forces pod's logs collectors to  return logs newer than a relative duration like 5s, 2m, or 3h.")
+	cmd.Flags().String("since", "", "forces pod's logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -35,7 +35,7 @@ that a cluster meets the requirements to run an application.`,
 	cmd.Flags().String("collector-image", "", "the full name of the collector image to use")
 	cmd.Flags().String("collector-pullpolicy", "", "the pull policy of the collector image")
 	cmd.Flags().Bool("collect-without-permissions", false, "always run preflight checks even if some require permissions that preflight does not have")
-	cmd.Flags().String("since-time", "", "forces pod's logs collectors to return logs after a specific date (RFC3339)")
+	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))

--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -36,6 +36,7 @@ that a cluster meets the requirements to run an application.`,
 	cmd.Flags().String("collector-pullpolicy", "", "the pull policy of the collector image")
 	cmd.Flags().Bool("collect-without-permissions", false, "always run preflight checks even if some require permissions that preflight does not have")
 	cmd.Flags().String("since-time", "", "forces pod's logs collectors to return logs after a specific date (RFC3339)")
+	cmd.Flags().String("since", "", "forces pod's logs collectors to  return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -36,7 +36,7 @@ that a cluster meets the requirements to run an application.`,
 	cmd.Flags().String("collector-pullpolicy", "", "the pull policy of the collector image")
 	cmd.Flags().Bool("collect-without-permissions", false, "always run preflight checks even if some require permissions that preflight does not have")
 	cmd.Flags().String("since-time", "", "forces pod's logs collectors to return logs after a specific date (RFC3339)")
-	cmd.Flags().String("since", "", "forces pod's logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
+	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -181,12 +181,12 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors []
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("unable to parse date and time %s as YYYY-MM-DDTHH:MM:SSZHH:MM, e.g.:\"2006-01-02T15:04:05Z07:00\"", v.GetString("since-time")))
+			return errors.Wrap(err, "unable to parse --since-time flag")
 		}
 	} else {
 		parsedDuration, err := time.ParseDuration(v.GetString("since"))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("unable to parse time duration %s", v.GetString("since")))
+			return errors.Wrap(err, "unable to parse --since flag")
 		}
 		now := time.Now()
 		sinceTime = now.Add(0 - parsedDuration)

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -129,6 +129,14 @@ func runPreflights(v *viper.Viper, arg string) error {
 		KubernetesRestConfig:   restConfig,
 	}
 
+	if v.GetString("since-time") != "" {
+		for _, collectors := range preflightSpec.Spec.Collectors {
+			if collectors.Logs != nil {
+				collectors.Logs.Limits.SinceTime = v.GetString("since-time")
+			}
+		}
+	}
+
 	collectResults, err := preflight.Collect(collectOpts, preflightSpec)
 	if err != nil {
 		if !collectResults.IsRBACAllowed {

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -133,15 +133,21 @@ func runPreflights(v *viper.Viper, arg string) error {
 		if v.GetString("since") != "" {
 			progressChan <- errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
 		}
-		for _, collectors := range preflightSpec.Spec.Collectors {
-			if collectors.Logs != nil {
-				collectors.Logs.Limits.SinceTime = v.GetString("since-time")
+		for _, collector := range preflightSpec.Spec.Collectors {
+			if collector.Logs != nil {
+				if collector.Logs.Limits == nil {
+					collector.Logs.Limits = new(troubleshootv1beta2.LogLimits)
+				}
+				collector.Logs.Limits.SinceTime = v.GetString("since-time")
 			}
 		}
 	} else if v.GetString("since") != "" {
-		for _, collectors := range preflightSpec.Spec.Collectors {
-			if collectors.Logs != nil {
-				collectors.Logs.Limits.Since = v.GetString("since")
+		for _, collector := range preflightSpec.Spec.Collectors {
+			if collector.Logs != nil {
+				if collector.Logs.Limits == nil {
+					collector.Logs.Limits = new(troubleshootv1beta2.LogLimits)
+				}
+				collector.Logs.Limits.Since = v.GetString("since")
 			}
 		}
 	}

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -177,7 +177,7 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors []
 	)
 	if v.GetString("since-time") != "" {
 		if v.GetString("since") != "" {
-			progressChan <- errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
+			return errors.Errorf("at most one of `sinceTime` or `sinceSeconds` may be specified")
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/specs"
 	"github.com/spf13/viper"
 	spin "github.com/tj/go-spin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -195,7 +196,7 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors []
 			if collector.Logs.Limits == nil {
 				collector.Logs.Limits = new(troubleshootv1beta2.LogLimits)
 			}
-			collector.Logs.Limits.SinceTime = sinceTime
+			collector.Logs.Limits.SinceTime = metav1.NewTime(sinceTime)
 		}
 	}
 	return nil

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -177,7 +177,7 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors []
 	)
 	if v.GetString("since-time") != "" {
 		if v.GetString("since") != "" {
-			return errors.Errorf("at most one of `sinceTime` or `sinceSeconds` may be specified")
+			return errors.Errorf("at most one of `sinceTime` or `since` may be specified")
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -181,12 +181,12 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors []
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {
-			return errors.Errorf("unable to parse date and time %s as YYYY-MM-DDTHH:MM:SSZHH:MM, e.g.:\"2006-01-02T15:04:05Z07:00\"", v.GetString("since-time"))
+			return errors.Wrap(err, fmt.Sprintf("unable to parse date and time %s as YYYY-MM-DDTHH:MM:SSZHH:MM, e.g.:\"2006-01-02T15:04:05Z07:00\"", v.GetString("since-time")))
 		}
 	} else {
 		parsedDuration, err := time.ParseDuration(v.GetString("since"))
 		if err != nil {
-			return errors.Errorf("unable to parse time duration %s", v.GetString("since"))
+			return errors.Wrap(err, fmt.Sprintf("unable to parse time duration %s", v.GetString("since")))
 		}
 		now := time.Now()
 		sinceTime = now.Add(0 - parsedDuration)

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -130,9 +130,18 @@ func runPreflights(v *viper.Viper, arg string) error {
 	}
 
 	if v.GetString("since-time") != "" {
+		if v.GetString("since") != "" {
+			progressChan <- errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
+		}
 		for _, collectors := range preflightSpec.Spec.Collectors {
 			if collectors.Logs != nil {
 				collectors.Logs.Limits.SinceTime = v.GetString("since-time")
+			}
+		}
+	} else if v.GetString("since") != "" {
+		for _, collectors := range preflightSpec.Spec.Collectors {
+			if collectors.Logs != nil {
+				collectors.Logs.Limits.Since = v.GetString("since")
 			}
 		}
 	}

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -39,6 +39,7 @@ from a server that can be used to assist when troubleshooting a Kubernetes clust
 	cmd.Flags().StringSlice("redactors", []string{}, "names of the additional redactors to use")
 	cmd.Flags().Bool("redact", true, "enable/disable default redactions")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
+	cmd.Flags().String("since-time", "", "forces pods logs collectors to return logs after a specific date (RFC3339)")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -40,7 +40,7 @@ from a server that can be used to assist when troubleshooting a Kubernetes clust
 	cmd.Flags().Bool("redact", true, "enable/disable default redactions")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
 	cmd.Flags().String("since-time", "", "forces pods logs collectors to return logs after a specific date (RFC3339)")
-	cmd.Flags().String("since", "", "forces pod's logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
+	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -39,7 +39,7 @@ from a server that can be used to assist when troubleshooting a Kubernetes clust
 	cmd.Flags().StringSlice("redactors", []string{}, "names of the additional redactors to use")
 	cmd.Flags().Bool("redact", true, "enable/disable default redactions")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
-	cmd.Flags().String("since-time", "", "forces pods logs collectors to return logs after a specific date (RFC3339)")
+	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -40,7 +40,7 @@ from a server that can be used to assist when troubleshooting a Kubernetes clust
 	cmd.Flags().Bool("redact", true, "enable/disable default redactions")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
 	cmd.Flags().String("since-time", "", "forces pods logs collectors to return logs after a specific date (RFC3339)")
-	cmd.Flags().String("since", "", "forces pod's logs collectors to  return logs newer than a relative duration like 5s, 2m, or 3h.")
+	cmd.Flags().String("since", "", "forces pod's logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -40,6 +40,7 @@ from a server that can be used to assist when troubleshooting a Kubernetes clust
 	cmd.Flags().Bool("redact", true, "enable/disable default redactions")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
 	cmd.Flags().String("since-time", "", "forces pods logs collectors to return logs after a specific date (RFC3339)")
+	cmd.Flags().String("since", "", "forces pod's logs collectors to  return logs newer than a relative duration like 5s, 2m, or 3h.")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -443,15 +443,21 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, ad
 		if v.GetString("since") != "" {
 			progressChan <- errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
 		}
-		for _, collectors := range cleanedCollectors {
-			if collectors.Collect.Logs != nil {
-				collectors.Collect.Logs.Limits.SinceTime = v.GetString("since-time")
+		for _, collector := range cleanedCollectors {
+			if collector.Collect.Logs != nil {
+				if collector.Collect.Logs.Limits == nil {
+					collector.Collect.Logs.Limits = new(troubleshootv1beta2.LogLimits)
+				}
+				collector.Collect.Logs.Limits.SinceTime = v.GetString("since-time")
 			}
 		}
 	} else if v.GetString("since") != "" {
-		for _, collectors := range cleanedCollectors {
-			if collectors.Collect.Logs != nil {
-				collectors.Collect.Logs.Limits.Since = v.GetString("since")
+		for _, collector := range cleanedCollectors {
+			if collector.Collect.Logs != nil {
+				if collector.Collect.Logs.Limits == nil {
+					collector.Collect.Logs.Limits = new(troubleshootv1beta2.LogLimits)
+				}
+				collector.Collect.Logs.Limits.Since = v.GetString("since")
 			}
 		}
 	}

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -451,7 +451,7 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, ad
 	} else if v.GetString("since") != "" {
 		for _, collectors := range cleanedCollectors {
 			if collectors.Collect.Logs != nil {
-				collectors.Collect.Logs.Limits.SinceTime = v.GetString("since-time")
+				collectors.Collect.Logs.Limits.Since = v.GetString("since")
 			}
 		}
 	}

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -440,6 +440,15 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, ad
 	}
 
 	if v.GetString("since-time") != "" {
+		if v.GetString("since") != "" {
+			progressChan <- errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
+		}
+		for _, collectors := range cleanedCollectors {
+			if collectors.Collect.Logs != nil {
+				collectors.Collect.Logs.Limits.SinceTime = v.GetString("since-time")
+			}
+		}
+	} else if v.GetString("since") != "" {
 		for _, collectors := range cleanedCollectors {
 			if collectors.Collect.Logs != nil {
 				collectors.Collect.Logs.Limits.SinceTime = v.GetString("since-time")

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -698,12 +698,12 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors *c
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("unable to parse date and time %s as YYYY-MM-DDTHH:MM:SSZHH:MM, e.g.:\"2006-01-02T15:04:05Z07:00\"", v.GetString("since-time")))
+			return errors.Wrap(err, "unable to parse --since-time flag")
 		}
 	} else {
 		parsedDuration, err := time.ParseDuration(v.GetString("since"))
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("unable to parse time duration %s", v.GetString("since")))
+			return errors.Wrap(err, "unable to parse --since flag")
 		}
 		now := time.Now()
 		sinceTime = now.Add(0 - parsedDuration)

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -439,6 +439,14 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, ad
 		globalRedactors = additionalRedactors.Spec.Redactors
 	}
 
+	if v.GetString("since-time") != "" {
+		for _, collectors := range cleanedCollectors {
+			if collectors.Collect.Logs != nil {
+				collectors.Collect.Logs.Limits.SinceTime = v.GetString("since-time")
+			}
+		}
+	}
+
 	// Run preflights collectors synchronously
 	for _, collector := range cleanedCollectors {
 		if len(collector.RBACErrors) > 0 {

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -694,7 +694,7 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors *c
 	)
 	if v.GetString("since-time") != "" {
 		if v.GetString("since") != "" {
-			progressChan <- errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
+			return errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -713,7 +713,7 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors *c
 			if collector.Collect.Logs.Limits == nil {
 				collector.Collect.Logs.Limits = new(troubleshootv1beta2.LogLimits)
 			}
-			collector.Collect.Logs.Limits.SinceTime = sinceTime
+			collector.Collect.Logs.Limits.SinceTime = metav1.NewTime(sinceTime)
 		}
 	}
 	return nil

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -698,12 +698,12 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors *c
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {
-			return errors.Errorf("unable to parse date and time %s as YYYY-MM-DDTHH:MM:SSZHH:MM, e.g.:\"2006-01-02T15:04:05Z07:00\"", v.GetString("since-time"))
+			return errors.Wrap(err, fmt.Sprintf("unable to parse date and time %s as YYYY-MM-DDTHH:MM:SSZHH:MM, e.g.:\"2006-01-02T15:04:05Z07:00\"", v.GetString("since-time")))
 		}
 	} else {
 		parsedDuration, err := time.ParseDuration(v.GetString("since"))
 		if err != nil {
-			return errors.Errorf("unable to parse time duration %s", v.GetString("since"))
+			return errors.Wrap(err, fmt.Sprintf("unable to parse time duration %s", v.GetString("since")))
 		}
 		now := time.Now()
 		sinceTime = now.Add(0 - parsedDuration)

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -694,7 +694,7 @@ func parseTimeFlags(v *viper.Viper, progressChan chan interface{}, collectors *c
 	)
 	if v.GetString("since-time") != "" {
 		if v.GetString("since") != "" {
-			return errors.Errorf("Only one of since-time / since may be used. The flag since-time will be used.")
+			return errors.Errorf("at most one of `sinceTime` or `since` may be specified")
 		}
 		sinceTime, err = time.Parse(time.RFC3339, v.GetString("since-time"))
 		if err != nil {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -34,6 +34,7 @@ type LogLimits struct {
 	MaxAge    string `json:"maxAge,omitempty" yaml:"maxAge,omitempty"`
 	MaxLines  int64  `json:"maxLines,omitempty" yaml:"maxLines,omitempty"`
 	SinceTime string
+	Since     string
 }
 
 type Logs struct {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -3,10 +3,10 @@ package v1beta2
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CollectorMeta struct {
@@ -34,7 +34,7 @@ type Secret struct {
 type LogLimits struct {
 	MaxAge    string `json:"maxAge,omitempty" yaml:"maxAge,omitempty"`
 	MaxLines  int64  `json:"maxLines,omitempty" yaml:"maxLines,omitempty"`
-	SinceTime time.Time
+	SinceTime metav1.Time
 }
 
 type Logs struct {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -3,6 +3,7 @@ package v1beta2
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -33,8 +34,7 @@ type Secret struct {
 type LogLimits struct {
 	MaxAge    string `json:"maxAge,omitempty" yaml:"maxAge,omitempty"`
 	MaxLines  int64  `json:"maxLines,omitempty" yaml:"maxLines,omitempty"`
-	SinceTime string
-	Since     string
+	SinceTime time.Time
 }
 
 type Logs struct {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -31,8 +31,9 @@ type Secret struct {
 }
 
 type LogLimits struct {
-	MaxAge   string `json:"maxAge,omitempty" yaml:"maxAge,omitempty"`
-	MaxLines int64  `json:"maxLines,omitempty" yaml:"maxLines,omitempty"`
+	MaxAge    string `json:"maxAge,omitempty" yaml:"maxAge,omitempty"`
+	MaxLines  int64  `json:"maxLines,omitempty" yaml:"maxLines,omitempty"`
+	SinceTime string
 }
 
 type Logs struct {

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -138,11 +138,10 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		fmt.Println("time", t)
 		if err != nil {
 			logger.Printf("unable to parse --since-time=%s\n", limits.SinceTime)
+		} else {
+			sinceTime := metav1.NewTime(t)
+			podLogOpts.SinceTime = &sinceTime
 		}
-
-		sinceTime := metav1.NewTime(t)
-		podLogOpts.SinceTime = &sinceTime
-
 	}
 	fileKey := fmt.Sprintf("%s/%s", name, pod.Name)
 	if container != "" {

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -117,16 +117,7 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		podLogOpts.TailLines = &limits.MaxLines
 	}
 
-	if limits != nil && limits.SinceTime != "" {
-		t, err := time.Parse(time.RFC3339, limits.SinceTime)
-		if err != nil {
-			logger.Printf("unable to parse --since-time=%s\n", limits.SinceTime)
-		}
-
-		sinceTime := metav1.NewTime(t)
-		podLogOpts.SinceTime = &sinceTime
-
-	} else if limits != nil && (limits.MaxAge != "" || limits.Since != "") {
+	if limits != nil && (limits.MaxAge != "" || limits.Since != "") {
 		if limits.Since != "" {
 			limits.MaxAge = limits.Since
 		}
@@ -142,6 +133,17 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		}
 	}
 
+	if limits != nil && limits.SinceTime != "" {
+		t, err := time.Parse(time.RFC3339, limits.SinceTime)
+		fmt.Println("time", t)
+		if err != nil {
+			logger.Printf("unable to parse --since-time=%s\n", limits.SinceTime)
+		}
+
+		sinceTime := metav1.NewTime(t)
+		podLogOpts.SinceTime = &sinceTime
+
+	}
 	fileKey := fmt.Sprintf("%s/%s", name, pod.Name)
 	if container != "" {
 		fileKey = fmt.Sprintf("%s/%s/%s", name, pod.Name, container)

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -120,7 +120,6 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 	if limits != nil && limits.SinceTime != "" {
 		t, err := time.Parse(time.RFC3339, limits.SinceTime)
 		if err != nil {
-			//should this return an error?
 			logger.Printf("unable to parse --since-time=%s\n", limits.SinceTime)
 		}
 
@@ -128,6 +127,9 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		podLogOpts.SinceTime = &sinceTime
 
 	} else if limits != nil && limits.MaxAge != "" {
+		if limits.Since != "" {
+			limits.MaxAge = limits.Since
+		}
 		parsedDuration, err := time.ParseDuration(limits.MaxAge)
 		if err != nil {
 			logger.Printf("unable to parse time duration %s\n", limits.MaxAge)

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -126,7 +126,7 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		sinceTime := metav1.NewTime(t)
 		podLogOpts.SinceTime = &sinceTime
 
-	} else if limits != nil && limits.MaxAge != "" {
+	} else if limits != nil && (limits.MaxAge != "" || limits.Since != "") {
 		if limits.Since != "" {
 			limits.MaxAge = limits.Since
 		}

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -117,8 +117,7 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		podLogOpts.TailLines = &limits.MaxLines
 	}
 	if limits != nil && !limits.SinceTime.IsZero() {
-		sinceTime := metav1.NewTime(limits.SinceTime)
-		podLogOpts.SinceTime = &sinceTime
+		podLogOpts.SinceTime = &limits.SinceTime
 
 	} else if limits != nil && limits.MaxAge != "" {
 		parsedDuration, err := time.ParseDuration(limits.MaxAge)

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -117,7 +117,17 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		podLogOpts.TailLines = &limits.MaxLines
 	}
 
-	if limits != nil && limits.MaxAge != "" {
+	if limits != nil && limits.SinceTime != "" {
+		t, err := time.Parse(time.RFC3339, limits.SinceTime)
+		if err != nil {
+			//should this return an error?
+			logger.Printf("unable to parse --since-time=%s\n", limits.SinceTime)
+		}
+
+		sinceTime := metav1.NewTime(t)
+		podLogOpts.SinceTime = &sinceTime
+
+	} else if limits != nil && limits.MaxAge != "" {
 		parsedDuration, err := time.ParseDuration(limits.MaxAge)
 		if err != nil {
 			logger.Printf("unable to parse time duration %s\n", limits.MaxAge)

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -116,11 +116,11 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 	} else {
 		podLogOpts.TailLines = &limits.MaxLines
 	}
+	if limits != nil && !limits.SinceTime.IsZero() {
+		sinceTime := metav1.NewTime(limits.SinceTime)
+		podLogOpts.SinceTime = &sinceTime
 
-	if limits != nil && (limits.MaxAge != "" || limits.Since != "") {
-		if limits.Since != "" {
-			limits.MaxAge = limits.Since
-		}
+	} else if limits != nil && limits.MaxAge != "" {
 		parsedDuration, err := time.ParseDuration(limits.MaxAge)
 		if err != nil {
 			logger.Printf("unable to parse time duration %s\n", limits.MaxAge)
@@ -133,16 +133,6 @@ func getPodLogs(ctx context.Context, client *kubernetes.Clientset, pod corev1.Po
 		}
 	}
 
-	if limits != nil && limits.SinceTime != "" {
-		t, err := time.Parse(time.RFC3339, limits.SinceTime)
-		fmt.Println("time", t)
-		if err != nil {
-			logger.Printf("unable to parse --since-time=%s\n", limits.SinceTime)
-		} else {
-			sinceTime := metav1.NewTime(t)
-			podLogOpts.SinceTime = &sinceTime
-		}
-	}
 	fileKey := fmt.Sprintf("%s/%s", name, pod.Name)
 	if container != "" {
 		fileKey = fmt.Sprintf("%s/%s/%s", name, pod.Name, container)


### PR DESCRIPTION
@markpundsack @divolgin Hi, this is the first approach for a flag to determine a point of time, from which the logs collector should start collecting logs. It overrides all the logs collectors, and keeps the maxLine parameter from the original specs. Let me know what you think of it. Fix #277 An example:
```SHELL
    $ kubectl support-bundle --since-time="2020-10-19T12:36:23Z" file_or_url 
```