### PR TITLE
conditional NodeResourceAnalyzer

### DIFF
--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -79,8 +79,16 @@ type Distribution struct {
 
 type NodeResources struct {
 	AnalyzeMeta `json:",inline" yaml:",inline"`
-	Outcomes    []*Outcome           `json:"outcomes" yaml:"outcomes"`
-	Filters     *NodeResourceFilters `json:"filters,omitempty" yaml:"filters,omitempty"`
+	Outcomes    []*Outcome                `json:"outcomes" yaml:"outcomes"`
+	Filters     *NodeResourceFilters      `json:"filters,omitempty" yaml:"filters,omitempty"`
+	Deployment  *DeploymentStatus         `json:"deployment,omitempty" yaml:"deployment,omitempty"`
+	OnInstall   *NodeResourcesConditional `json:"onInstall,omitempty" yaml:"onInstall,omitempty"`
+	OnUpdate    *NodeResourcesConditional `json:"onUpdate,omitempty" yaml:"onUpdate,omitempty"`
+}
+
+type NodeResourcesConditional struct {
+	Outcomes []*Outcome           `json:"outcomes" yaml:"outcomes"`
+	Filters  *NodeResourceFilters `json:"filters,omitempty" yaml:"filters,omitempty"`
 }
 
 type NodeResourceFilters struct {


### PR DESCRIPTION
@markpundsack @divolgin The idea is to make NodeResourceAnalyzer more flexible when working with allocatable resources. As stated in issue #210, in the case of updates the allocatable resources needed are not the same as in new installs. I added the possibility to check if a given deployment exists in a namespace, and to separate the resources needed whether it is a new install or an update. To this purpose I created three new fields, `deployment`, containing the name and namespace of the deployment, `onInstall`, where the filters and outcomes for new installs are provided, and `onUpgrade`, where in case the deployment already exists other filters and outcomes may be provided. 

This does not changes the way the analyzer functioned originally. An example would be as follow:

```YAML
- nodeResources:
        checkName: check allocatable resources for new installs or updates
        deployment:
          name: myapp
          namespace: default
        onInstall:
          filters:
            cpuAllocatable: "5"
            memoryAllocatable: 5Gi
          outcomes:
            - fail:
                when: "count() < 1"
                message: On new installs, this application requires at least 1 node with 5 allocatable cpus and 5Gb of allocatable memory.
                uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
            - warn:
                when: "count() < 2"
                message: On new installs, this application requires at least 2 nodes with 5 allocatable cpus and 5Gb of allocatable memory.
                uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
            - pass:
                message: This cluster has enough nodes
        onUpdate:
          filters:
            cpuAllocatable: "2"
            memoryAllocatable: 2Gi
          outcomes:
            - fail:
                when: "count() < 1"
                message: On updates, this application requires at least 1 node with 2 allocatable cpus and 2Gb of allocatable memory.
                uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
            - warn:
                when: "count() < 2"
                message: This application recommends at last 2 nodes with 2 allocatable cpus and 2Gb of allocatable memory.
                uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
            - pass:
                message: This cluster has enough nodes to update.
```
Fix #210