### PR TITLE
Prevent failure

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -147,7 +147,7 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 		}
 	}()
 
-	archivePath, err := runCollectors(v, supportBundleSpec.Spec.Collectors, additionalRedactors, progressChan)
+	archivePath, err := runCollectors(v, supportBundleSpec.Spec.Collectors, supportBundleSpec.Spec.Analyzers, additionalRedactors, progressChan)
 	if err != nil {
 		return errors.Wrap(err, "run collectors")
 	}
@@ -375,7 +375,7 @@ func canTryInsecure() bool {
 	return true
 }
 
-func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, additionalRedactors *troubleshootv1beta2.Redactor, progressChan chan interface{}) (string, error) {
+func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, analyzers []*troubleshootv1beta2.Analyze, additionalRedactors *troubleshootv1beta2.Redactor, progressChan chan interface{}) (string, error) {
 	tmpDir, err := ioutil.TempDir("", "troubleshoot")
 	if err != nil {
 		return "", errors.Wrap(err, "create temp dir")
@@ -457,7 +457,7 @@ func runCollectors(v *viper.Viper, collectors []*troubleshootv1beta2.Collect, ad
 
 		progressChan <- collector.GetDisplayName()
 
-		result, err := collector.RunCollectorSync(globalRedactors)
+		result, err := collector.RunCollectorSync(globalRedactors, analyzers, progressChan)
 		if err != nil {
 			progressChan <- fmt.Errorf("failed to run collector %q: %v", collector.GetDisplayName(), err)
 			continue

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -164,7 +164,7 @@ func ClusterResources(c *Collector, analyzers []*troubleshootv1beta2.Analyze) (m
 	}
 	clusterResourcesOutput["cluster-resources/auth-cani-list-errors.json"], err = marshalNonNil(authCanIErrors)
 	if err != nil {
-		errs["limitranges"] = err
+		errs["authcani"] = err
 	}
 
 	//Events

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -111,13 +111,14 @@ func ClusterResources(c *Collector, analyzers []*troubleshootv1beta2.Analyze) (m
 	// crds
 	crdClient, err := apiextensionsv1beta1clientset.NewForConfig(c.ClientConfig)
 	if err != nil {
-		errs["namespace"] = err
-	}
-	customResourceDefinitions, crdErrors := crds(ctx, crdClient)
-	clusterResourcesOutput["cluster-resources/custom-resource-definitions.json"] = customResourceDefinitions
-	clusterResourcesOutput["cluster-resources/custom-resource-definitions-errors.json"], err = marshalNonNil(crdErrors)
-	if err != nil {
 		errs["crds"] = err
+	} else {
+		customResourceDefinitions, crdErrors := crds(ctx, crdClient)
+		clusterResourcesOutput["cluster-resources/custom-resource-definitions.json"] = customResourceDefinitions
+		clusterResourcesOutput["cluster-resources/custom-resource-definitions-errors.json"], err = marshalNonNil(crdErrors)
+		if err != nil {
+			errs["crds"] = err
+		}
 	}
 
 	// imagepullsecrets

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -177,12 +177,14 @@ func (c *Collector) RunCollectorSync(globalRedactors []*troubleshootv1beta2.Reda
 	} else if c.Collect.ClusterResources != nil {
 		errs := make(map[string]error)
 		result, errs = ClusterResources(c, analyzers)
-		collector, isRequired := isCollectorRequired(errs, analyzers)
-		if isRequired {
-			return nil, errs[collector]
-		}
-		for collector, err := range errs {
-			progressChan <- errors.Errorf("default collector %s failed: %v", collector, err)
+		if errs != nil {
+			collector, isRequired := isCollectorRequired(errs, analyzers)
+			if isRequired {
+				return result, errs[collector]
+			}
+			for collector, err := range errs {
+				progressChan <- errors.Errorf("default collector %s failed: %v", collector, err)
+			}
 		}
 	} else if c.Collect.Secret != nil {
 		result, err = Secret(c, c.Collect.Secret)

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -284,10 +284,10 @@ func (cs Collectors) CheckRBAC(ctx context.Context) error {
 }
 
 func isCollectorRequired(errs map[string]error, analyzers []*troubleshootv1beta2.Analyze) (string, bool) {
+	if _, ok := errs["client"]; ok {
+		return "client", true
+	}
 	if analyzers != nil {
-		if _, ok := errs["client"]; ok {
-			return "client", true
-		}
 		for _, analyzer := range analyzers {
 			if _, ok := errs["namespace"]; ok && analyzer.ContainerRuntime != nil {
 				return "namespace", true
@@ -309,7 +309,6 @@ func isCollectorRequired(errs map[string]error, analyzers []*troubleshootv1beta2
 				return "apiresources", true
 			}
 		}
-		return "", false
 	}
-
+	return "", false
 }


### PR DESCRIPTION
@marccampbell  @divolgin I would like your opinion on this. I kept working on preventing failure on unnecessary default collectors, either RBAC errors or errors of other kind. 

 - in case of RBAC errors, the not-allowed resource is checked against the analyzers in the spec. If no analyzer will use that resource, then it is not considered an error.
 - in case of failure of any of the collectors in the cluster resources, the collector (namespace, deployments, etc...) is checked against the analyzers. The error is only informed if  there is no analyzer using that collector, or an error is sent if the collector is required. 

Issues #239 #227 