### PR TITLE
hide spinner if interactive false

### DIFF
--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -91,30 +91,32 @@ func runPreflights(v *viper.Viper, arg string) error {
 	finishedCh := make(chan bool, 1)
 	progressCh := make(chan interface{}, 0) // non-zero buffer will result in missed messages
 
-	s := spin.New()
-	go func() {
-		for {
-			select {
-			case msg, ok := <-progressCh:
-				if !ok {
-					continue
-				}
-				switch msg := msg.(type) {
-				case error:
-					c := color.New(color.FgHiRed)
-					c.Println(fmt.Sprintf("%s\r * %v", cursor.ClearEntireLine(), msg))
-				case string:
-					c := color.New(color.FgCyan)
-					c.Println(fmt.Sprintf("%s\r * %s", cursor.ClearEntireLine(), msg))
-				}
-			case <-time.After(time.Millisecond * 100):
-				fmt.Printf("\r  \033[36mRunning Preflight checks\033[m %s ", s.Next())
-			case <-finishedCh:
-				fmt.Printf("\r%s\r", cursor.ClearEntireLine())
-				return
-			}
-		}
-	}()
+	if v.GetBool("interactive") {
+        s := spin.New()
+        go func() {
+            for {
+                select {
+                case msg, ok := <-progressCh:
+                    if !ok {
+                        continue
+                    }
+                    switch msg := msg.(type) {
+                    case error:
+                        c := color.New(color.FgHiRed)
+                        c.Println(fmt.Sprintf("%s\r * %v", cursor.ClearEntireLine(), msg))
+                    case string:
+                        c := color.New(color.FgCyan)
+                        c.Println(fmt.Sprintf("%s\r * %s", cursor.ClearEntireLine(), msg))
+                    }
+                case <-time.After(time.Millisecond * 100):
+                    fmt.Printf("\r  \033[36mRunning Preflight checks\033[m %s ", s.Next())
+                case <-finishedCh:
+                    fmt.Printf("\r%s\r", cursor.ClearEntireLine())
+                    return
+                }
+            }
+        }()
+    }
 
 	defer func() {
 		close(finishedCh)

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -91,37 +91,37 @@ func runPreflights(v *viper.Viper, arg string) error {
 	finishedCh := make(chan bool, 1)
 	progressCh := make(chan interface{}, 0) // non-zero buffer will result in missed messages
 
-  if v.GetBool("interactive") {
-    s := spin.New()
-    go func() {
-      lastMsg := ""
-      for {
-        select {
-        case msg, ok := <-progressCh:
-          if !ok {
-            continue
-          }
-          switch msg := msg.(type) {
-          case error:
-            c := color.New(color.FgHiRed)
-            c.Println(fmt.Sprintf("%s\r * %v", cursor.ClearEntireLine(), msg))
-          case string:
-            if lastMsg == msg {
-              break
-            }
-            lastMsg = msg
-            c := color.New(color.FgCyan)
-            c.Println(fmt.Sprintf("%s\r * %s", cursor.ClearEntireLine(), msg))
-          }
-        case <-time.After(time.Millisecond * 100):
-          fmt.Printf("\r  \033[36mRunning Preflight checks\033[m %s ", s.Next())
-        case <-finishedCh:
-          fmt.Printf("\r%s\r", cursor.ClearEntireLine())
-          return
-        }
-      }
-    }()
-  }
+	if v.GetBool("interactive") {
+		s := spin.New()
+		go func() {
+			lastMsg := ""
+			for {
+				select {
+				case msg, ok := <-progressCh:
+					if !ok {
+						continue
+					}
+					switch msg := msg.(type) {
+					case error:
+						c := color.New(color.FgHiRed)
+						c.Println(fmt.Sprintf("%s\r * %v", cursor.ClearEntireLine(), msg))
+					case string:
+						if lastMsg == msg {
+							break
+						}
+						lastMsg = msg
+						c := color.New(color.FgCyan)
+						c.Println(fmt.Sprintf("%s\r * %s", cursor.ClearEntireLine(), msg))
+					}
+				case <-time.After(time.Millisecond * 100):
+					fmt.Printf("\r  \033[36mRunning Preflight checks\033[m %s ", s.Next())
+				case <-finishedCh:
+					fmt.Printf("\r%s\r", cursor.ClearEntireLine())
+					return
+				}
+			}
+		}()
+	}
 
 	defer func() {
 		close(finishedCh)


### PR DESCRIPTION
Currently, json output can't be piped to jq or other tools due to the spinner:

    kubectl preflight https://preflight.replicated.com  --interactive=false --format=json  | jq .
    parse error: Invalid numeric literal at line 1, column 2

Can now run either human/json output with no spinner

        $ go run ./cmd/preflight https://preflight.replicated.com --interactive=false

           --- PASS Required Kubernetes Version
              --- Your cluster meets the recommended and required versions of Kubernetes.
           --- FAIL: Ingress
              --- Contour ingress not found!
           --- PASS Container Runtime
              --- Docker container runtime was found.
           --- FAIL: Required storage classes
              --- Could not find a storage class called default.
           --- PASS Kubernetes Distribution
              --- GKE is a supported distribution
           --- FAIL: Must have at least 3 nodes in the cluster, with 5 recommended
              --- This application requires at least 3 nodes.
           --- WARN: Every node in the cluster must have at least 10 GB of memory, with 32 GB recommended
              --- All nodes are recommended to have at least 32 GB of memory.
           --- PASS Total CPU Cores in the cluster is 4 or greater
              --- There are at least 4 cores in the cluster
           --- WARN: Every node in the cluster must have at least 40 GB of ephemeral storage, with 100 GB recommended
              --- All nodes are recommended to have at least 100 GB of ephemeral storage.
        --- FAIL   example
        FAILED

     $ go run ./cmd/preflight https://preflight.replicated.com --interactive=false --format=json
     {
          "pass": [
            {
              "title": "Required Kubernetes Version",
              "message": "Your cluster meets the recommended and required versions of Kubernetes."
            },
            {
              "title": "Container Runtime",
              "message": "Docker container runtime was found."
            },
            {
              "title": "Kubernetes Distribution",
              "message": "GKE is a supported distribution"
            },
            {
              "title": "Total CPU Cores in the cluster is 4 or greater",
              "message": "There are at least 4 cores in the cluster"
            }
          ],
          "warn": [
            {
              "title": "Every node in the cluster must have at least 10 GB of memory, with 32 GB recommended",
              "message": "All nodes are recommended to have at least 32 GB of memory.",
              "uri": "https://kurl.sh/docs/install-with-kurl/system-requirements"
            },
            {
              "title": "Every node in the cluster must have at least 40 GB of ephemeral storage, with 100 GB recommended",
              "message": "All nodes are recommended to have at least 100 GB of ephemeral storage.",
              "uri": "https://kurl.sh/docs/install-with-kurl/system-requirements"
            }
          ],
          "fail": [
            {
              "title": "Ingress",
              "message": "Contour ingress not found!"
            },
            {
              "title": "Required storage classes",
              "message": "Could not find a storage class called default."
            },
            {
              "title": "Must have at least 3 nodes in the cluster, with 5 recommended",
              "message": "This application requires at least 3 nodes.",
              "uri": "https://kurl.sh/docs/install-with-kurl/adding-nodes"
            }
          ]
        }