### PR TITLE
Benchmark write latency with background IOPS

### DIFF
--- a/examples/preflight/host/filesystem-performance.yaml
+++ b/examples/preflight/host/filesystem-performance.yaml
@@ -10,22 +10,25 @@ spec:
         fileSize: 22Mi
         operationSizeBytes: 2300
         datasync: true
+        enableBackgroundIOPS: true
+        backgroundIOPSWarmupSeconds: 60
+        backgroundWriteIOPS: 300
+        backgroundWriteIOPSJobs: 6
+        backgroundReadIOPS: 50
+        backgroundReadIOPSJobs: 1
   analyzers:
     - filesystemPerformance:
         collectorName: etcd-perf
         outcomes:
-          - fail:
-              when: "iops < 50"
-              message: Insufficient random read IOPS
           - pass:
               when: "p99 < 3ms"
-              message: Write latency is great!
+              message: "Write latency is great! (p99: {{ .P99 }})"
           - pass:
               when: "p99 < 5ms"
-              message: Write latency is ok
+              message: "Write latency is ok (p99: {{ .P99 }})"
           - warn:
               when: "p99 < 8ms"
-              message: Write latency is high
+              message: "Write latency is high {{ .String }}"
           - fail:
               when: "p99 >= 8ms"
-              message: Write latency is too high
+              message: "Write latency is too high {{ .String }}"

--- a/pkg/analyze/host_filesystem_performance_test.go
+++ b/pkg/analyze/host_filesystem_performance_test.go
@@ -20,51 +20,6 @@ func TestAnalyzeHostFilesystemPerformance(t *testing.T) {
 		expectErr    bool
 	}{
 		{
-			name: "IOPS",
-			fsPerf: &collect.FSPerfResults{
-				IOPS: 50,
-			},
-			hostAnalyzer: &troubleshootv1beta2.FilesystemPerformanceAnalyze{
-				Outcomes: []*troubleshootv1beta2.Outcome{
-					{
-						Fail: &troubleshootv1beta2.SingleOutcome{
-							When:    "iops < 20",
-							Message: "IOPS < 20",
-						},
-					},
-					{
-						Fail: &troubleshootv1beta2.SingleOutcome{
-							When:    "iops <= 20",
-							Message: "IOPS <= 30",
-						},
-					},
-					{
-						Fail: &troubleshootv1beta2.SingleOutcome{
-							When:    "iops > 70",
-							Message: "IOPS > 70",
-						},
-					},
-					{
-						Fail: &troubleshootv1beta2.SingleOutcome{
-							When:    "iops >= 100",
-							Message: "IOPS >= 100",
-						},
-					},
-					{
-						Pass: &troubleshootv1beta2.SingleOutcome{
-							When:    "iops == 50",
-							Message: "IOPS == 50",
-						},
-					},
-				},
-			},
-			result: &AnalyzeResult{
-				Title:   "Filesystem Performance",
-				IsPass:  true,
-				Message: "IOPS == 50",
-			},
-		},
-		{
 			name: "Cover",
 			fsPerf: &collect.FSPerfResults{
 				Min:     200 * time.Nanosecond,

--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -73,13 +73,43 @@ type TCPConnect struct {
 	Timeout           string `json:"timeout,omitempty"`
 }
 
+// FilesystemPerformance benchmarks sequential write latency on a single file.
+// The optional background IOPS feature attempts to mimic real-world conditions by running read and
+// write workloads prior to and during benchmark execution.
 type FilesystemPerformance struct {
-	HostCollectorMeta  `json:",inline" yaml:",inline"`
+	HostCollectorMeta `json:",inline" yaml:",inline"`
+	// The size of each write operation performed while benchmarking. This does not apply to the
+	// background IOPS feature if enabled, since those must be fixed at 4096.
 	OperationSizeBytes uint64 `json:"operationSize,omitempty"`
-	Directory          string `json:"directory,omitempty"`
-	FileSize           string `json:"fileSize,omitempty"`
-	Sync               bool   `json:"sync,omitempty"`
-	Datasync           bool   `json:"datasync,omitempty"`
+	// The directory where the benchmark will create files.
+	Directory string `json:"directory,omitempty"`
+	// The size of the file used in the benchmark. The number of IO operations for the benchmark
+	// will be FileSize / OperationSizeBytes. Accepts valid Kubernetes resource units such as Mi.
+	FileSize string `json:"fileSize,omitempty"`
+	// Whether to call sync on the file after each write. Does not apply to background IOPS task.
+	Sync bool `json:"sync,omitempty"`
+	// Whether to call datasync on the file after each write. Skipped if Sync is also true. Does not
+	// apply to background IOPS task.
+	Datasync bool `json:"datasync,omitempty"`
+
+	// Enable the background IOPS feature.
+	EnableBackgroundIOPS bool `json:"enableBackgroundIOPS"`
+	// How long to run the background IOPS read and write workloads prior to starting the benchmarks.
+	BackgroundIOPSWarmupSeconds int `json:"backgroundIOPSWarmupSeconds"`
+	// The target write IOPS to run while benchmarking. This is a limit and there is no guarantee
+	// it will be reached. This is the total IOPS for all background write jobs.
+	BackgroundWriteIOPS int `json:"backgroundWriteIOPS"`
+	// The target read IOPS to run while benchmarking. This is a limit and there is no guarantee
+	// it will be reached. This is the total IOPS for all background read jobs.
+	BackgroundReadIOPS int `json:"backgroundReadIOPS"`
+	// Number of threads to use for background write IOPS. This should be set high enough to reach
+	// the target specified in BackgroundWriteIOPS.
+	// Example: If BackgroundWriteIOPS is 100 and write latency is 10ms then a single job would
+	// barely be able to reach 100 IOPS so this should be at least 2.
+	BackgroundWriteIOPSJobs int `json:"backgroundWriteIOPSJobs"`
+	// Number of threads to use for background read IOPS. This should be set high enough to reach
+	// the target specified in BackgrounReadIOPS.
+	BackgroundReadIOPSJobs int `json:"backgroundReadIOPSJobs"`
 }
 
 type Certificate struct {

--- a/pkg/collect/host_filesystem_performance.go
+++ b/pkg/collect/host_filesystem_performance.go
@@ -1,8 +1,10 @@
 package collect
 
 import (
+	"bytes"
 	"math"
 	"math/rand"
+	"text/template"
 	"time"
 
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -49,7 +51,6 @@ type FSPerfResults struct {
 	P999    time.Duration
 	P9995   time.Duration
 	P9999   time.Duration
-	IOPS    int
 }
 
 func getPercentileIndex(p float64, items int) int {
@@ -57,4 +58,34 @@ func getPercentileIndex(p float64, items int) int {
 		return items - 1
 	}
 	return int(math.Ceil(p*float64(items))) - 1
+}
+
+var fsPerfTmpl = template.Must(template.New("").Parse(`
+   Min: {{ .Min }}
+   Max: {{ .Max }}
+   Avg: {{ .Average }}
+    p1: {{ .P1 }}
+    p5: {{ .P5 }}
+   p10: {{ .P10 }}
+   p20: {{ .P20 }}
+   p30: {{ .P30 }}
+   p40: {{ .P40 }}
+   p50: {{ .P50 }}
+   p60: {{ .P60 }}
+   p70: {{ .P70 }}
+   p80: {{ .P80 }}
+   p90: {{ .P90 }}
+   p95: {{ .P95 }}
+   p99: {{ .P99 }}
+ p99.5: {{ .P995 }}
+ p99.9: {{ .P999 }}
+p99.95: {{ .P9995 }}
+p99.99: {{ .P9999 }}`))
+
+func (f FSPerfResults) String() string {
+	var buf bytes.Buffer
+
+	fsPerfTmpl.Execute(&buf, f)
+
+	return buf.String()
 }


### PR DESCRIPTION
Add a background IOPS feature to the filesystem performance collector
that specifies separate read and write background IOPS to perform while
measuring latency. This allows for better assessment of whether etcd
will be stable when running alongside other workloads on the same
cluster.

Also add templating to the outcome message of the filesystem performance
analyzers to allow printing individual latency percentiles or the entire
table.

Remove the random IOPS benchmark since it was attempting to perform
unaligned direct I/O.