### PR TITLE
collect rook block device disk stats

### DIFF
--- a/pkg/collect/ceph.go
+++ b/pkg/collect/ceph.go
@@ -75,11 +75,17 @@ var CephCommands = []CephCommand{
 		Format:  "json",
 	},
 	{
-		ID:             "rgw-stats",
+		ID:             "rgw-stats", // the disk usage (and other stats) of each object store bucket
 		Command:        []string{"radosgw-admin", "bucket", "stats"},
 		Args:           []string{"--rgw-cache-enabled=false"},
-		Format:         "json",
+		Format:         "txt",
 		DefaultTimeout: "30s", // include a default timeout because this command will hang if the RGW daemon isn't running/is unhealthy
+	},
+	{
+		ID:      "rbd-du", // the disk usage of each PVC
+		Command: []string{"rbd", "du"},
+		Args:    []string{"--pool=replicapool"},
+		Format:  "txt",
 	},
 }
 


### PR DESCRIPTION
this contains both max size and currently used size for each PV

example output (rook 1.0.6):
```
# rbd --pool=replicapool du
warning: fast-diff map is not enabled for pvc-03568c3e-f191-4697-ba2a-6d7a15c1e239. operation may be slow.
warning: fast-diff map is not enabled for pvc-17aaeee4-e09b-4f21-9466-5ff722ed2bba. operation may be slow.
warning: fast-diff map is not enabled for pvc-8784ca08-522c-41dd-8237-e97ce506a957. operation may be slow.
warning: fast-diff map is not enabled for pvc-ef8ba793-8345-41d8-86be-768ed35549e2. operation may be slow.
NAME                                     PROVISIONED USED
pvc-03568c3e-f191-4697-ba2a-6d7a15c1e239       2 GiB  72 MiB
pvc-17aaeee4-e09b-4f21-9466-5ff722ed2bba      10 GiB     0 B
pvc-8784ca08-522c-41dd-8237-e97ce506a957      10 GiB 196 MiB
pvc-ef8ba793-8345-41d8-86be-768ed35549e2      10 GiB 168 MiB
<TOTAL>                                       32 GiB 436 MiB
```