### PR TITLE
Include result if not nil regardless of error

### DIFF
--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -83,9 +83,7 @@ func CollectHost(opts CollectOpts, p *troubleshootv1beta2.HostPreflight) (Collec
 		result, err := collector.Collect(opts.ProgressChan)
 		if err != nil {
 			opts.ProgressChan <- errors.Errorf("failed to run collector: %s: %v", collector.Title(), err)
-			continue
 		}
-
 		if result != nil {
 			for k, v := range result {
 				allCollectedData[k] = v


### PR DESCRIPTION
Outcomes that result in an error do not work. This is because a returned result is not appended if error is not nil. This changes the logic so that if a collector returns a result and an error the result will be appended to the results array regardless of error.

For example:

```yaml
  analyzers:
    - tcpLoadBalancer:
        collectorName: loadbalancer
        outcomes:
          - fail:
              when: "error"
              message: Unexpected port status
```

![image (2)](https://user-images.githubusercontent.com/371319/116339899-1b00cb00-a793-11eb-80ab-ed73ea626ae2.png)
