### PR TITLE
fix: always print support-bundle filename after generation

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -196,6 +196,11 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 named %s. Please upload it on the Troubleshoot page of
 the %s Admin Console to begin analysis.`
 			msg = fmt.Sprintf(f, appName, archivePath, appName)
+		} else {
+			f := `A support bundle has been created in this directory
+named %s. Please upload it on the Troubleshoot page of
+the Admin Console to begin analysis.`
+			msg = fmt.Sprintf(f, archivePath)
 		}
 
 		fmt.Printf("%s\n", msg)

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -196,11 +196,6 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 named %s. Please upload it on the Troubleshoot page of
 the %s Admin Console to begin analysis.`
 			msg = fmt.Sprintf(f, appName, archivePath, appName)
-		} else {
-			f := `A support bundle has been created in this directory
-named %s. Please upload it on the Troubleshoot page of
-the Admin Console to begin analysis.`
-			msg = fmt.Sprintf(f, archivePath)
 		}
 
 		fmt.Printf("%s\n", msg)

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -158,7 +158,7 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 	if err != nil {
 		c := color.New(color.FgHiRed)
 		c.Printf("%s\r * %v\n", cursor.ClearEntireLine(), err)
-		return errors.Wrap(err, "failed to process bundle after collection")
+		// don't die
 	}
 
 	analyzeResults, err := supportbundle.AnalyzeAndExtractSupportBundle(&supportBundle.Spec, archivePath)


### PR DESCRIPTION
Closes https://app.clubhouse.io/replicated/story/33985/kubectl-support-bundle-should-always-print-the-filename-after-generating-a-bundle