### PR TITLE
Modify Host Preflights To Return Multiple Analyze Results

### DIFF
--- a/examples/preflight/host/ntp.yaml
+++ b/examples/preflight/host/ntp.yaml
@@ -17,6 +17,13 @@ spec:
           - warn:
               when: "ntp == synchronized+inactive"
               message: NTP not active
+          - warn: 
+              when: "timezone != UTC"
+              message: "Non UTC timezone can interfere with system function"      
           - pass:
               when: "ntp == synchronized+active"
               message: System clock is synchronized
+          - pass: 
+              when: "timezone == UTC"
+              message: "timezone set to UTC"
+        

--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -56,7 +56,7 @@ func HostAnalyze(hostAnalyzer *troubleshootv1beta2.HostAnalyze, getFile getColle
 	if err != nil {
 		return NewAnalyzeResultError(analyzer, errors.Wrap(err, "analyze"))
 	}
-	return []*AnalyzeResult{result}
+	return result
 }
 
 func NewAnalyzeResultError(analyzer HostAnalyzer, err error) []*AnalyzeResult {

--- a/pkg/analyze/host_analyzer.go
+++ b/pkg/analyze/host_analyzer.go
@@ -5,7 +5,7 @@ import troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubl
 type HostAnalyzer interface {
 	Title() string
 	IsExcluded() (bool, error)
-	Analyze(getFile func(string) ([]byte, error)) (*AnalyzeResult, error)
+	Analyze(getFile func(string) ([]byte, error)) ([]*AnalyzeResult, error)
 }
 
 func GetHostAnalyzer(analyzer *troubleshootv1beta2.HostAnalyze) (HostAnalyzer, bool) {
@@ -48,4 +48,20 @@ func hostAnalyzerTitleOrDefault(meta troubleshootv1beta2.AnalyzeMeta, defaultTit
 		return meta.CheckName
 	}
 	return defaultTitle
+}
+
+type resultCollector struct {
+	results []*AnalyzeResult
+}
+
+func (c *resultCollector) push(result *AnalyzeResult) {
+	c.results = append(c.results, result)
+}
+
+// We need to return at least one result with a title to preserve compatability
+func (c *resultCollector) get(title string) []*AnalyzeResult {
+	if len(c.results) > 0 {
+		return c.results
+	}
+	return []*AnalyzeResult{{Title: title, IsWarn: true, Message: "no results"}}
 }

--- a/pkg/analyze/host_block_devices.go
+++ b/pkg/analyze/host_block_devices.go
@@ -24,7 +24,7 @@ func (a *AnalyzeHostBlockDevices) IsExcluded() (bool, error) {
 	return isExcluded(a.hostAnalyzer.Exclude)
 }
 
-func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) ([]byte, error)) ([]*AnalyzeResult, error) {
 	hostAnalyzer := a.hostAnalyzer
 
 	contents, err := getCollectedFileContents("system/block_devices.json")
@@ -48,7 +48,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				return &result, nil
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostBlockDevicesConditionalToActual(outcome.Fail.When, hostAnalyzer.MinimumAcceptableSize, hostAnalyzer.IncludeUnmountedPartitions, devices)
@@ -61,7 +61,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				return &result, nil
+				return []*AnalyzeResult{&result}, nil
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -69,7 +69,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				return &result, nil
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostBlockDevicesConditionalToActual(outcome.Warn.When, hostAnalyzer.MinimumAcceptableSize, hostAnalyzer.IncludeUnmountedPartitions, devices)
@@ -82,7 +82,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				return &result, nil
+				return []*AnalyzeResult{&result}, nil
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -90,7 +90,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				return &result, nil
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostBlockDevicesConditionalToActual(outcome.Pass.When, hostAnalyzer.MinimumAcceptableSize, hostAnalyzer.IncludeUnmountedPartitions, devices)
@@ -103,12 +103,12 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				return &result, nil
+				return []*AnalyzeResult{&result}, nil
 			}
 		}
 	}
 
-	return &result, nil
+	return []*AnalyzeResult{&result}, nil
 }
 
 // <regexp> <op> <count>

--- a/pkg/analyze/host_block_devices_test.go
+++ b/pkg/analyze/host_block_devices_test.go
@@ -15,7 +15,7 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 		name         string
 		devices      []collect.BlockDeviceInfo
 		hostAnalyzer *troubleshootv1beta2.BlockDevicesAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -39,10 +39,12 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Block Devices",
-				IsPass:  true,
-				Message: "Block device available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Block Devices",
+					IsPass:  true,
+					Message: "Block device available",
+				},
 			},
 		},
 		{
@@ -79,10 +81,12 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Block Devices",
-				IsFail:  true,
-				Message: "No block device available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Block Devices",
+					IsFail:  true,
+					Message: "No block device available",
+				},
 			},
 		},
 		{
@@ -112,10 +116,12 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Block Devices",
-				IsFail:  true,
-				Message: "No block device available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Block Devices",
+					IsFail:  true,
+					Message: "No block device available",
+				},
 			},
 		},
 		{
@@ -143,10 +149,12 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Block Devices",
-				IsFail:  true,
-				Message: "No block device available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Block Devices",
+					IsFail:  true,
+					Message: "No block device available",
+				},
 			},
 		},
 		{
@@ -179,10 +187,12 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Block Devices",
-				IsPass:  true,
-				Message: "Block device or partition available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Block Devices",
+					IsPass:  true,
+					Message: "Block device or partition available",
+				},
 			},
 		},
 		{
@@ -234,10 +244,12 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Block Devices",
-				IsPass:  true,
-				Message: "Two block devices or partitions of >10gb size available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Block Devices",
+					IsPass:  true,
+					Message: "Two block devices or partitions of >10gb size available",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_certificate_test.go
+++ b/pkg/analyze/host_certificate_test.go
@@ -14,7 +14,7 @@ func TestAnalyzeCertificate(t *testing.T) {
 		name         string
 		status       string
 		hostAnalyzer *troubleshootv1beta2.CertificateAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -60,10 +60,12 @@ func TestAnalyzeCertificate(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Certificate Key Pair",
-				IsPass:  true,
-				Message: "Certificate key pair is valid",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Certificate Key Pair",
+					IsPass:  true,
+					Message: "Certificate key pair is valid",
+				},
 			},
 		},
 		{
@@ -109,10 +111,12 @@ func TestAnalyzeCertificate(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Certificate Key Pair",
-				IsFail:  true,
-				Message: "Certificate key pair is invalid",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Certificate Key Pair",
+					IsFail:  true,
+					Message: "Certificate key pair is invalid",
+				},
 			},
 		},
 		{
@@ -158,10 +162,12 @@ func TestAnalyzeCertificate(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Certificate Key Pair",
-				IsFail:  true,
-				Message: "Certificate key pair not found",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Certificate Key Pair",
+					IsFail:  true,
+					Message: "Certificate key pair not found",
+				},
 			},
 		},
 		{
@@ -207,10 +213,12 @@ func TestAnalyzeCertificate(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Certificate Key Pair",
-				IsFail:  true,
-				Message: "Public and private keys switched",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Certificate Key Pair",
+					IsFail:  true,
+					Message: "Public and private keys switched",
+				},
 			},
 		},
 		{
@@ -256,10 +264,12 @@ func TestAnalyzeCertificate(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Certificate Key Pair",
-				IsFail:  true,
-				Message: "Private key is encrypted",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Certificate Key Pair",
+					IsFail:  true,
+					Message: "Private key is encrypted",
+				},
 			},
 		},
 		{
@@ -305,10 +315,12 @@ func TestAnalyzeCertificate(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Certificate Key Pair",
-				IsFail:  true,
-				Message: "Public and private keys don't match",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Certificate Key Pair",
+					IsFail:  true,
+					Message: "Public and private keys don't match",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_disk_usage_test.go
+++ b/pkg/analyze/host_disk_usage_test.go
@@ -235,7 +235,7 @@ func TestAnalyzeHostDiskUsage(t *testing.T) {
 		name          string
 		diskUsageInfo *collect.DiskUsageInfo
 		hostAnalyzer  *troubleshootv1beta2.DiskUsageAnalyze
-		result        *AnalyzeResult
+		result        []*AnalyzeResult
 		expectErr     bool
 	}{
 		{
@@ -261,10 +261,12 @@ func TestAnalyzeHostDiskUsage(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Disk Usage ephemeral",
-				IsFail:  true,
-				Message: "/var/lib/kubelet requires at least 10Gi",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Disk Usage ephemeral",
+					IsFail:  true,
+					Message: "/var/lib/kubelet requires at least 10Gi",
+				},
 			},
 		},
 		{
@@ -290,10 +292,12 @@ func TestAnalyzeHostDiskUsage(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Disk Usage ephemeral",
-				IsFail:  true,
-				Message: "/var/lib/kubelet is more than 80% full",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Disk Usage ephemeral",
+					IsFail:  true,
+					Message: "/var/lib/kubelet is more than 80% full",
+				},
 			},
 		},
 		{
@@ -325,10 +329,12 @@ func TestAnalyzeHostDiskUsage(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Disk Usage ephemeral",
-				IsWarn:  true,
-				Message: "/var/lib/kubelet has more than 100Gi used",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Disk Usage ephemeral",
+					IsWarn:  true,
+					Message: "/var/lib/kubelet has more than 100Gi used",
+				},
 			},
 		},
 		{
@@ -348,10 +354,12 @@ func TestAnalyzeHostDiskUsage(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Disk Usage ephemeral",
-				IsPass:  true,
-				Message: "/var/lib/kubelet has at least 10Gi available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Disk Usage ephemeral",
+					IsPass:  true,
+					Message: "/var/lib/kubelet has at least 10Gi available",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_filesystem_performance_test.go
+++ b/pkg/analyze/host_filesystem_performance_test.go
@@ -16,7 +16,7 @@ func TestAnalyzeHostFilesystemPerformance(t *testing.T) {
 		name         string
 		fsPerf       *collect.FSPerfResults
 		hostAnalyzer *troubleshootv1beta2.FilesystemPerformanceAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -288,10 +288,12 @@ func TestAnalyzeHostFilesystemPerformance(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Filesystem Performance",
-				IsPass:  true,
-				Message: "Acceptable write latency",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Filesystem Performance",
+					IsPass:  true,
+					Message: "Acceptable write latency",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_http_test.go
+++ b/pkg/analyze/host_http_test.go
@@ -15,7 +15,7 @@ func TestAnalyzeHostHTTP(t *testing.T) {
 		name         string
 		httpResult   *httpResult
 		hostAnalyzer *troubleshootv1beta2.HTTPAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -36,10 +36,12 @@ func TestAnalyzeHostHTTP(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "HTTP Request",
-				IsFail:  true,
-				Message: "Failed to reach replicated.registry.com",
+			result: []*AnalyzeResult{
+				{
+					Title:   "HTTP Request",
+					IsFail:  true,
+					Message: "Failed to reach replicated.registry.com",
+				},
 			},
 		},
 		{
@@ -72,10 +74,12 @@ func TestAnalyzeHostHTTP(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "HTTP Request",
-				IsPass:  true,
-				Message: "Successfully reached registry",
+			result: []*AnalyzeResult{
+				{
+					Title:   "HTTP Request",
+					IsPass:  true,
+					Message: "Successfully reached registry",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_httploadbalancer.go
+++ b/pkg/analyze/host_httploadbalancer.go
@@ -22,7 +22,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) IsExcluded() (bool, error) {
 	return isExcluded(a.hostAnalyzer.Exclude)
 }
 
-func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(string) ([]byte, error)) ([]*AnalyzeResult, error) {
 	hostAnalyzer := a.hostAnalyzer
 
 	collectorName := hostAnalyzer.CollectorName
@@ -40,18 +40,18 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 		return nil, errors.Wrap(err, "failed to unmarshal collected")
 	}
 
-	result := AnalyzeResult{}
-
-	result.Title = a.Title()
+	var coll resultCollector
 
 	for _, outcome := range hostAnalyzer.Outcomes {
+		result := &AnalyzeResult{Title: a.Title()}
+
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
 				result.IsFail = true
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -59,7 +59,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -67,7 +67,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -75,7 +75,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -83,7 +83,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 
 			if string(actual.Status) == outcome.Pass.When {
@@ -91,10 +91,10 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 		}
 	}
 
-	return &result, nil
+	return coll.get(a.Title()), nil
 }

--- a/pkg/analyze/host_ipv4interfaces_test.go
+++ b/pkg/analyze/host_ipv4interfaces_test.go
@@ -15,7 +15,7 @@ func TestAnalyzeIPV4Interfaces(t *testing.T) {
 		name         string
 		interfaces   []net.Interface
 		hostAnalyzer *troubleshootv1beta2.IPV4InterfacesAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -37,10 +37,12 @@ func TestAnalyzeIPV4Interfaces(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "IPv4 Interfaces",
-				IsFail:  true,
-				Message: "No IPv4 interfaces detected",
+			result: []*AnalyzeResult{
+				{
+					Title:   "IPv4 Interfaces",
+					IsFail:  true,
+					Message: "No IPv4 interfaces detected",
+				},
 			},
 		},
 		{
@@ -69,10 +71,12 @@ func TestAnalyzeIPV4Interfaces(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "IPv4 Interfaces",
-				IsPass:  true,
-				Message: "IPv4 interface available",
+			result: []*AnalyzeResult{
+				{
+					Title:   "IPv4 Interfaces",
+					IsPass:  true,
+					Message: "IPv4 interface available",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_memory_test.go
+++ b/pkg/analyze/host_memory_test.go
@@ -79,7 +79,7 @@ func TestAnalyzeHostMemory(t *testing.T) {
 		name         string
 		memoryInfo   *collect.MemoryInfo
 		hostAnalyzer *troubleshootv1beta2.MemoryAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -97,10 +97,12 @@ func TestAnalyzeHostMemory(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Amount of Memory",
-				IsPass:  true,
-				Message: "System has at least 4Gi of memory",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Amount of Memory",
+					IsPass:  true,
+					Message: "System has at least 4Gi of memory",
+				},
 			},
 		},
 		{
@@ -118,10 +120,12 @@ func TestAnalyzeHostMemory(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Amount of Memory",
-				IsFail:  true,
-				Message: "System requires at least 16Gi of memory",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Amount of Memory",
+					IsFail:  true,
+					Message: "System requires at least 16Gi of memory",
+				},
 			},
 		},
 		{
@@ -145,10 +149,12 @@ func TestAnalyzeHostMemory(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Amount of Memory",
-				IsWarn:  true,
-				Message: "System performs best with more than 8Gi of memory",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Amount of Memory",
+					IsWarn:  true,
+					Message: "System performs best with more than 8Gi of memory",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_services_test.go
+++ b/pkg/analyze/host_services_test.go
@@ -15,7 +15,7 @@ func TestAnalyzeHostServices(t *testing.T) {
 		name         string
 		info         []collect.ServiceInfo
 		hostAnalyzer *troubleshootv1beta2.HostServicesAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -36,10 +36,12 @@ func TestAnalyzeHostServices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Host Services",
-				IsFail:  true,
-				Message: "the service 'a' is active",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Host Services",
+					IsFail:  true,
+					Message: "the service 'a' is active",
+				},
 			},
 		},
 		{
@@ -70,10 +72,12 @@ func TestAnalyzeHostServices(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "Host Services",
-				IsPass:  true,
-				Message: "service 'b' is not active",
+			result: []*AnalyzeResult{
+				{
+					Title:   "Host Services",
+					IsPass:  true,
+					Message: "service 'b' is not active",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_tcp_connect.go
+++ b/pkg/analyze/host_tcp_connect.go
@@ -22,7 +22,7 @@ func (a *AnalyzeHostTCPConnect) IsExcluded() (bool, error) {
 	return isExcluded(a.hostAnalyzer.Exclude)
 }
 
-func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([]byte, error)) ([]*AnalyzeResult, error) {
 	hostAnalyzer := a.hostAnalyzer
 
 	fullPath := path.Join("connect", fmt.Sprintf("%s.json", hostAnalyzer.CollectorName))
@@ -36,18 +36,18 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 		return nil, errors.Wrap(err, "failed to unmarshal collected")
 	}
 
-	result := AnalyzeResult{}
-
-	result.Title = a.Title()
+	var coll resultCollector
 
 	for _, outcome := range hostAnalyzer.Outcomes {
+		result := &AnalyzeResult{Title: a.Title()}
+
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
 				result.IsFail = true
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -55,7 +55,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -63,7 +63,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -71,7 +71,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -79,7 +79,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 
 			if string(actual.Status) == outcome.Pass.When {
@@ -87,10 +87,10 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				return &result, nil
+				coll.push(result)
 			}
 		}
 	}
 
-	return &result, nil
+	return coll.get(a.Title()), nil
 }

--- a/pkg/analyze/host_tcp_connect_test.go
+++ b/pkg/analyze/host_tcp_connect_test.go
@@ -15,7 +15,7 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 		name         string
 		info         *collect.NetworkStatusResult
 		hostAnalyzer *troubleshootv1beta2.TCPConnectAnalyze
-		result       *AnalyzeResult
+		result       []*AnalyzeResult
 		expectErr    bool
 	}{
 		{
@@ -33,10 +33,12 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "TCP Connection Attempt",
-				IsFail:  true,
-				Message: "Connection was refused",
+			result: []*AnalyzeResult{
+				{
+					Title:   "TCP Connection Attempt",
+					IsFail:  true,
+					Message: "Connection was refused",
+				},
 			},
 		},
 		{
@@ -60,10 +62,12 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 					},
 				},
 			},
-			result: &AnalyzeResult{
-				Title:   "TCP Connection Attempt",
-				IsPass:  true,
-				Message: "Connection was successful",
+			result: []*AnalyzeResult{
+				{
+					Title:   "TCP Connection Attempt",
+					IsPass:  true,
+					Message: "Connection was successful",
+				},
 			},
 		},
 	}

--- a/pkg/analyze/host_time_test.go
+++ b/pkg/analyze/host_time_test.go
@@ -206,6 +206,12 @@ func TestAnalyzeHostTime(t *testing.T) {
 							Message: "Timezone is not set to UTC",
 						},
 					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "timezone == UTC",
+							Message: "Timezone is set to UTC",
+						},
+					},
 				},
 			},
 			result: []*AnalyzeResult{
@@ -235,6 +241,18 @@ func TestAnalyzeHostTime(t *testing.T) {
 						Warn: &troubleshootv1beta2.SingleOutcome{
 							When:    "ntp == unsynchronized+active",
 							Message: "System clock not yet synchronized",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "timezone == UTC",
+							Message: "Timezone is set to UTC",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "ntp == synchronized+active",
+							Message: "System clock is synchronized",
 						},
 					},
 				},

--- a/pkg/analyze/host_time_test.go
+++ b/pkg/analyze/host_time_test.go
@@ -205,9 +205,6 @@ func TestAnalyzeHostTime(t *testing.T) {
 							When:    "timezone != UTC",
 							Message: "Timezone is not set to UTC",
 						},
-						Pass: &troubleshootv1beta2.SingleOutcome{
-							Message: "Timezone is set to UTC",
-						},
 					},
 				},
 			},
@@ -233,19 +230,11 @@ func TestAnalyzeHostTime(t *testing.T) {
 							When:    "timezone != UTC",
 							Message: "timezone is not set to UTC",
 						},
-						Pass: &troubleshootv1beta2.SingleOutcome{
-							When:    "timezone == UTC",
-							Message: "timezone set to UTC",
-						},
 					},
 					{
 						Warn: &troubleshootv1beta2.SingleOutcome{
 							When:    "ntp == unsynchronized+active",
 							Message: "System clock not yet synchronized",
-						},
-						Pass: &troubleshootv1beta2.SingleOutcome{
-							When:    "ntp == synchronized+active",
-							Message: "System clock synchronized",
 						},
 					},
 				},

--- a/pkg/collect/host_time.go
+++ b/pkg/collect/host_time.go
@@ -55,6 +55,8 @@ func (c *CollectHostTime) Collect(progressChan chan<- interface{}) (map[string][
 		timeInfo.Timezone = "UTC"
 	}
 
+	timeInfo.Timezone = strings.ToUpper(timeInfo.Timezone)
+
 	prop = "org.freedesktop.timedate1.NTPSynchronized"
 	variant, err = conn.Object("org.freedesktop.timedate1", "/org/freedesktop/timedate1").GetProperty(prop)
 	if err != nil {


### PR DESCRIPTION
Reference issue [31673 Add Preflight Check for NTP](https://app.clubhouse.io/replicated/story/34340/clock-skew-or-ntp-analyzer-or-preflight) this change addresses a problem that can result in host preflights where, in an analyzer with multiple outcomes, a single outcome, the first one where the predicate evaluates to true is the only one that is returned. This is a problem because if a pass predicate is true, it is returned to the user, and any subsequent warnings or fails are missed.  Note that cluster preflights already return multiple outcomes so this change makes host preflights consistent.  