### PR TITLE
Log progress when interactive=false

### DIFF
--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -139,7 +139,7 @@ func runPreflights(v *viper.Viper, arg string) error {
 					if !ok {
 						return
 					}
-					fmt.Fprintln(os.Stderr, msg)
+					fmt.Fprintf(os.Stderr, "%v\n", msg)
 				case <-finishedCh:
 					return
 				}

--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -135,10 +135,11 @@ func runPreflights(v *viper.Viper, arg string) error {
 		go func() {
 			for {
 				select {
-				case _, ok := <-progressCh:
+				case msg, ok := <-progressCh:
 					if !ok {
 						return
 					}
+					fmt.Fprintln(os.Stderr, msg)
 				case <-finishedCh:
 					return
 				}


### PR DESCRIPTION
This will print progress to stderr. Example below:

```$ ./bin/preflight host-preflight.yaml --interactive=false 
[Kubernetes API Server Load Balancer] Running collector...
failed to run collector: Kubernetes API Server Load Balancer: failed to dial: dial tcp: lookup asdf@adf: no such host
[CPU Info] Running collector...
[Amount of Memory] Running collector...

   --- FAIL: Kubernetes API Server Load Balancer
      --- Analyzer Failed: analyze: failed to read collected file name: tcpLoadBalancer/Kubernetes API Server Load Balancer.json: file tcpLoadBalancer/Kubernetes API Server Load Balancer.json was not collected
--- FAIL   kurl-builtin
FAILED```