### PR TITLE
Fixed bugs introduced by handling multiple results in host preflights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ vendor
 
 dist
 try.sh
+
+.vscode/
+workspace.*

--- a/examples/preflight/host/sample.yaml
+++ b/examples/preflight/host/sample.yaml
@@ -235,4 +235,5 @@ spec:
               when: "timezone == UTC"
               message: Timezone is UTC
           - fail:
+              when: "timezone != UTC"
               message: Timezone is not UTC

--- a/examples/preflight/host/timezone.yaml
+++ b/examples/preflight/host/timezone.yaml
@@ -12,4 +12,5 @@ spec:
               when: "timezone == UTC"
               message: Timezone is UTC
           - fail:
+              when: "timezone != UTC"
               message: Timezone is not UTC

--- a/pkg/analyze/host_cpu.go
+++ b/pkg/analyze/host_cpu.go
@@ -35,10 +35,11 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 		return nil, errors.Wrap(err, "failed to unmarshal cpu info")
 	}
 
-	var coll resultCollector
+	result := AnalyzeResult{
+		Title: a.Title(),
+	}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
-		result := &AnalyzeResult{Title: a.Title()}
 
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -46,7 +47,7 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostCPUConditionalToActual(outcome.Fail.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount)
@@ -59,7 +60,7 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -67,7 +68,7 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostCPUConditionalToActual(outcome.Warn.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount)
@@ -80,7 +81,7 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -88,7 +89,7 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostCPUConditionalToActual(outcome.Pass.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount)
@@ -101,13 +102,12 @@ func (a *AnalyzeHostCPU) Analyze(getCollectedFileContents func(string) ([]byte, 
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
-
+				return []*AnalyzeResult{&result}, nil
 			}
 		}
 	}
 
-	return coll.get(a.Title()), nil
+	return []*AnalyzeResult{&result}, nil
 }
 
 func compareHostCPUConditionalToActual(conditional string, logicalCount int, physicalCount int) (res bool, err error) {

--- a/pkg/analyze/host_disk_usage.go
+++ b/pkg/analyze/host_disk_usage.go
@@ -50,6 +50,7 @@ func (a *AnalyzeHostDiskUsage) Analyze(getCollectedFileContents func(string) ([]
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostDiskUsageConditionalToActual(outcome.Fail.When, diskUsageInfo.TotalBytes, diskUsageInfo.UsedBytes)
@@ -71,6 +72,7 @@ func (a *AnalyzeHostDiskUsage) Analyze(getCollectedFileContents func(string) ([]
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostDiskUsageConditionalToActual(outcome.Warn.When, diskUsageInfo.TotalBytes, diskUsageInfo.UsedBytes)
@@ -92,6 +94,7 @@ func (a *AnalyzeHostDiskUsage) Analyze(getCollectedFileContents func(string) ([]
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostDiskUsageConditionalToActual(outcome.Pass.When, diskUsageInfo.TotalBytes, diskUsageInfo.UsedBytes)
@@ -106,6 +109,7 @@ func (a *AnalyzeHostDiskUsage) Analyze(getCollectedFileContents func(string) ([]
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/pkg/analyze/host_disk_usage_test.go
+++ b/pkg/analyze/host_disk_usage_test.go
@@ -362,6 +362,42 @@ func TestAnalyzeHostDiskUsage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Pass with empty When and warning",
+			diskUsageInfo: &collect.DiskUsageInfo{
+				TotalBytes: 9 * 1024 * 1024 * 1024,
+				UsedBytes:  1 * 1024 * 1024 * 1024,
+			},
+			hostAnalyzer: &troubleshootv1beta2.DiskUsageAnalyze{
+				CollectorName: "ephemeral",
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "available < 10Gi",
+							Message: "/var/lib/kubelet less than 10Gi available",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "/var/lib/kubelet passed",
+						},
+					},
+				},
+			},
+			result: []*AnalyzeResult{
+				{
+					Title:   "Disk Usage ephemeral",
+					IsWarn:  true,
+					Message: "/var/lib/kubelet less than 10Gi available",
+				},
+				{
+					Title:   "Disk Usage ephemeral",
+					IsPass:  true,
+					Message: "/var/lib/kubelet passed",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/analyze/host_filesystem_performance.go
+++ b/pkg/analyze/host_filesystem_performance.go
@@ -57,6 +57,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostFilesystemPerformanceConditionalToActual(outcome.Fail.When, fsPerf)
@@ -78,6 +79,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostFilesystemPerformanceConditionalToActual(outcome.Warn.When, fsPerf)
@@ -99,6 +101,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostFilesystemPerformanceConditionalToActual(outcome.Pass.When, fsPerf)
@@ -113,6 +116,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/pkg/analyze/host_http.go
+++ b/pkg/analyze/host_http.go
@@ -58,6 +58,7 @@ func (a *AnalyzeHostHTTP) Analyze(getCollectedFileContents func(string) ([]byte,
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostHTTPConditionalToActual(outcome.Fail.When, httpInfo)
@@ -79,6 +80,7 @@ func (a *AnalyzeHostHTTP) Analyze(getCollectedFileContents func(string) ([]byte,
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostHTTPConditionalToActual(outcome.Warn.When, httpInfo)
@@ -100,6 +102,7 @@ func (a *AnalyzeHostHTTP) Analyze(getCollectedFileContents func(string) ([]byte,
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostHTTPConditionalToActual(outcome.Pass.When, httpInfo)
@@ -114,6 +117,7 @@ func (a *AnalyzeHostHTTP) Analyze(getCollectedFileContents func(string) ([]byte,
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/pkg/analyze/host_httploadbalancer.go
+++ b/pkg/analyze/host_httploadbalancer.go
@@ -52,6 +52,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -68,6 +69,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -84,6 +86,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			if string(actual.Status) == outcome.Pass.When {
@@ -93,6 +96,7 @@ func (a *AnalyzeHostHTTPLoadBalancer) Analyze(getCollectedFileContents func(stri
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/pkg/analyze/host_ipv4interfaces.go
+++ b/pkg/analyze/host_ipv4interfaces.go
@@ -48,6 +48,7 @@ func (a *AnalyzeHostIPV4Interfaces) Analyze(getCollectedFileContents func(string
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostIPV4InterfacesConditionalToActual(outcome.Fail.When, ipv4Interfaces)
@@ -69,6 +70,7 @@ func (a *AnalyzeHostIPV4Interfaces) Analyze(getCollectedFileContents func(string
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostIPV4InterfacesConditionalToActual(outcome.Warn.When, ipv4Interfaces)
@@ -90,6 +92,7 @@ func (a *AnalyzeHostIPV4Interfaces) Analyze(getCollectedFileContents func(string
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostIPV4InterfacesConditionalToActual(outcome.Pass.When, ipv4Interfaces)
@@ -104,6 +107,7 @@ func (a *AnalyzeHostIPV4Interfaces) Analyze(getCollectedFileContents func(string
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/pkg/analyze/host_memory.go
+++ b/pkg/analyze/host_memory.go
@@ -36,10 +36,11 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 		return nil, errors.Wrap(err, "failed to unmarshal memory info")
 	}
 
-	var coll resultCollector
+	result := AnalyzeResult{
+		Title: a.Title(),
+	}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
-		result := &AnalyzeResult{Title: a.Title()}
 
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -47,7 +48,7 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostMemoryConditionalToActual(outcome.Fail.When, memoryInfo.Total)
@@ -60,7 +61,7 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -68,7 +69,7 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostMemoryConditionalToActual(outcome.Warn.When, memoryInfo.Total)
@@ -81,7 +82,7 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -89,7 +90,7 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 
 			isMatch, err := compareHostMemoryConditionalToActual(outcome.Pass.When, memoryInfo.Total)
@@ -102,12 +103,12 @@ func (a *AnalyzeHostMemory) Analyze(getCollectedFileContents func(string) ([]byt
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{&result}, nil
 			}
 		}
 	}
 
-	return coll.get(a.Title()), nil
+	return []*AnalyzeResult{&result}, nil
 }
 
 func compareHostMemoryConditionalToActual(conditional string, total uint64) (res bool, err error) {

--- a/pkg/analyze/host_services.go
+++ b/pkg/analyze/host_services.go
@@ -47,6 +47,7 @@ func (a *AnalyzeHostServices) Analyze(getCollectedFileContents func(string) ([]b
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostServicesConditionalToActual(outcome.Fail.When, services)
@@ -68,6 +69,7 @@ func (a *AnalyzeHostServices) Analyze(getCollectedFileContents func(string) ([]b
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostServicesConditionalToActual(outcome.Warn.When, services)
@@ -89,6 +91,7 @@ func (a *AnalyzeHostServices) Analyze(getCollectedFileContents func(string) ([]b
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostServicesConditionalToActual(outcome.Pass.When, services)
@@ -103,6 +106,7 @@ func (a *AnalyzeHostServices) Analyze(getCollectedFileContents func(string) ([]b
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/pkg/analyze/host_tcp_connect.go
+++ b/pkg/analyze/host_tcp_connect.go
@@ -48,6 +48,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -64,6 +65,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -80,6 +82,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+
 			}
 
 			if string(actual.Status) == outcome.Pass.When {

--- a/pkg/analyze/host_time.go
+++ b/pkg/analyze/host_time.go
@@ -54,6 +54,7 @@ func (a *AnalyzeHostTime) Analyze(getCollectedFileContents func(string) ([]byte,
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostTimeStatusToActual(outcome.Fail.When, timeInfo)
@@ -75,6 +76,7 @@ func (a *AnalyzeHostTime) Analyze(getCollectedFileContents func(string) ([]byte,
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostTimeStatusToActual(outcome.Warn.When, timeInfo)
@@ -89,6 +91,7 @@ func (a *AnalyzeHostTime) Analyze(getCollectedFileContents func(string) ([]byte,
 
 				coll.push(result)
 			}
+
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
 				result.IsPass = true
@@ -96,6 +99,7 @@ func (a *AnalyzeHostTime) Analyze(getCollectedFileContents func(string) ([]byte,
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				continue
 			}
 
 			isMatch, err := compareHostTimeStatusToActual(outcome.Pass.When, timeInfo)
@@ -110,6 +114,7 @@ func (a *AnalyzeHostTime) Analyze(getCollectedFileContents func(string) ([]byte,
 
 				coll.push(result)
 			}
+
 		}
 	}
 

--- a/scripts/host-preflight-integration-test.sh
+++ b/scripts/host-preflight-integration-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+function say() {
+    echo
+    echo "---------------------------------------------------------------"
+    echo $1
+    echo "---------------------------------------------------------------"
+    echo
+}
+
+
+if [ "$EUID" -ne 0 ]
+  then say "Use sudo to run this script"
+  exit
+fi
+
+for FILE in $(find ../examples/preflight/host/*.yaml)
+do
+    if [ "${FILE}" = "../examples/preflight/host/tcp-load-balancer.yaml" ]
+        then say "Skipping ${FILE}"
+	continue
+    fi
+
+    say "Running Test ${FILE}"
+
+    ../bin/preflight --interactive=false  $FILE 
+done
+
+


### PR DESCRIPTION
Fixed bug caused by host preflights not handling empty when clauses, this cropped up because we now handle multiple host preflight results. Also expanded test coverage and added integration test script.