### PR TITLE
Accumulate all longhorn pass results

### DIFF
--- a/pkg/analyze/longhorn.go
+++ b/pkg/analyze/longhorn.go
@@ -131,7 +131,7 @@ func longhorn(analyzer *troubleshootv1beta2.LonghornAnalyze, getCollectedFileCon
 		}
 	}
 
-	return results, nil
+	return simplifyLonghornResults(results), nil
 }
 
 func analyzeLonghornNodeSchedulable(node *longhornv1beta1.Node) *AnalyzeResult {
@@ -242,4 +242,26 @@ func analyzeLonghornReplicaChecksums(volumeName string, checksums []map[string]s
 	result.Message = "No replica corruption detected"
 
 	return result
+}
+
+// Keep warn/error results. Return a single pass result if there are no warn/errors.
+func simplifyLonghornResults(results []*AnalyzeResult) []*AnalyzeResult {
+	out := []*AnalyzeResult{}
+
+	for _, result := range results {
+		if result.IsPass {
+			continue
+		}
+		out = append(out, result)
+	}
+
+	if len(out) == 0 {
+		out = append(out, &AnalyzeResult{
+			Title:   "Longhorn Health Status",
+			IsPass:  true,
+			Message: "Longhorn is healthy",
+		})
+	}
+
+	return out
 }

--- a/pkg/analyze/longhorn_test.go
+++ b/pkg/analyze/longhorn_test.go
@@ -382,3 +382,78 @@ func TestAnalyzeLonghornReplicaChecksums(t *testing.T) {
 		})
 	}
 }
+
+func TestSimplifyLonghornResults(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []*AnalyzeResult
+		expect []*AnalyzeResult
+	}{
+		{
+			name: "All pass",
+			input: []*AnalyzeResult{
+				{
+					Title:   "Replica 1",
+					IsPass:  true,
+					Message: "Replica 1 ok",
+				},
+				{
+					Title:   "Node 1",
+					IsPass:  true,
+					Message: "Node 1 ok",
+				},
+			},
+			expect: []*AnalyzeResult{
+				{
+					Title:   "Longhorn Health Status",
+					IsPass:  true,
+					Message: "Longhorn is healthy",
+				},
+			},
+		},
+		{
+			name: "Mixed results",
+			input: []*AnalyzeResult{
+				{
+					Title:   "Replica 1",
+					IsPass:  true,
+					Message: "Replica 1 ok",
+				},
+				{
+					Title:   "Replica 2",
+					IsWarn:  true,
+					Message: "Replica 1 is down",
+				},
+				{
+					Title:   "Node 1",
+					IsPass:  true,
+					Message: "Node 1 ok",
+				},
+				{
+					Title:   "Node 2",
+					IsFail:  true,
+					Message: "Node 2 is down",
+				},
+			},
+			expect: []*AnalyzeResult{
+				{
+					Title:   "Replica 2",
+					IsWarn:  true,
+					Message: "Replica 1 is down",
+				},
+				{
+					Title:   "Node 2",
+					IsFail:  true,
+					Message: "Node 2 is down",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := simplifyLonghornResults(test.input)
+
+			assert.Equal(t, test.expect, got)
+		})
+	}
+}


### PR DESCRIPTION
If there are any error or warning results then return those. Otherwise
return a single healthy pass result.