### PR TITLE
Fix for warnings and passes being displayed in same check.

### DIFF
--- a/pkg/analyze/host_filesystem_performance.go
+++ b/pkg/analyze/host_filesystem_performance.go
@@ -45,10 +45,11 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 		return nil, errors.Wrapf(err, "failed to unmarshal filesystem performance results from %s", name)
 	}
 
-	var coll resultCollector
+	result := &AnalyzeResult{
+		Title: a.Title(),
+	}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
-		result := &AnalyzeResult{Title: a.Title()}
 
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -56,8 +57,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.Message = renderFSPerfOutcome(outcome.Fail.Message, fsPerf)
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
-				continue
+				return []*AnalyzeResult{result}, nil
 			}
 
 			isMatch, err := compareHostFilesystemPerformanceConditionalToActual(outcome.Fail.When, fsPerf)
@@ -70,7 +70,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.Message = renderFSPerfOutcome(outcome.Fail.Message, fsPerf)
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -78,8 +78,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.Message = renderFSPerfOutcome(outcome.Warn.Message, fsPerf)
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
-				continue
+				return []*AnalyzeResult{result}, nil
 			}
 
 			isMatch, err := compareHostFilesystemPerformanceConditionalToActual(outcome.Warn.When, fsPerf)
@@ -92,7 +91,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.Message = renderFSPerfOutcome(outcome.Warn.Message, fsPerf)
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -100,8 +99,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.Message = renderFSPerfOutcome(outcome.Pass.Message, fsPerf)
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
-				continue
+				return []*AnalyzeResult{result}, nil
 			}
 
 			isMatch, err := compareHostFilesystemPerformanceConditionalToActual(outcome.Pass.When, fsPerf)
@@ -114,13 +112,13 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(getCollectedFileContents func
 				result.Message = renderFSPerfOutcome(outcome.Pass.Message, fsPerf)
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 
 		}
 	}
 
-	return coll.get(a.Title()), nil
+	return []*AnalyzeResult{result}, nil
 }
 
 func compareHostFilesystemPerformanceConditionalToActual(conditional string, fsPerf collect.FSPerfResults) (res bool, err error) {

--- a/pkg/analyze/host_filesystem_performance_test.go
+++ b/pkg/analyze/host_filesystem_performance_test.go
@@ -296,6 +296,42 @@ func TestAnalyzeHostFilesystemPerformance(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip warn if pass first",
+			fsPerf: &collect.FSPerfResults{
+				P99: 9 * time.Millisecond,
+			},
+			hostAnalyzer: &troubleshootv1beta2.FilesystemPerformanceAnalyze{
+				CollectorName: "file system performance",
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "p99 < 10ms",
+							Message: "Acceptable write latency",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "p99 < 20ms",
+							Message: "Warn write latency",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "p99 >= 20ms",
+							Message: "fail",
+						},
+					},
+				},
+			},
+			result: []*AnalyzeResult{
+				{
+					Title:   "Filesystem Performance",
+					IsPass:  true,
+					Message: "Acceptable write latency",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/analyze/host_tcpportstatus.go
+++ b/pkg/analyze/host_tcpportstatus.go
@@ -10,6 +10,8 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
 )
 
+// AnalyzeHostTCPPortStatus is an analyzer that will return only one matching result, or a warning if nothing matches. The first
+// match that is encountered is the one that is returned.
 type AnalyzeHostTCPPortStatus struct {
 	hostAnalyzer *troubleshootv1beta2.TCPPortStatusAnalyze
 }
@@ -39,10 +41,9 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 		return nil, errors.Wrap(err, "failed to unmarshal collected")
 	}
 
-	var coll resultCollector
+	result := &AnalyzeResult{Title: a.Title()}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
-		result := &AnalyzeResult{Title: a.Title()}
 
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -50,7 +51,7 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -58,7 +59,7 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -66,7 +67,7 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -74,7 +75,7 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 				result.Message = outcome.Warn.Message
 				result.URI = outcome.Warn.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -82,7 +83,7 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 
 			if string(actual.Status) == outcome.Pass.When {
@@ -90,10 +91,10 @@ func (a *AnalyzeHostTCPPortStatus) Analyze(getCollectedFileContents func(string)
 				result.Message = outcome.Pass.Message
 				result.URI = outcome.Pass.URI
 
-				coll.push(result)
+				return []*AnalyzeResult{result}, nil
 			}
 		}
 	}
 
-	return coll.get(a.Title()), nil
+	return []*AnalyzeResult{result}, nil
 }

--- a/pkg/analyze/host_tcpportstatus_test.go
+++ b/pkg/analyze/host_tcpportstatus_test.go
@@ -1,0 +1,104 @@
+package analyzer
+
+import (
+	"encoding/json"
+	"testing"
+
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeTCPPortStatus(t *testing.T) {
+	tt := []struct {
+		name      string
+		collected collect.NetworkStatusResult
+		analyzer  troubleshootv1beta2.TCPPortStatusAnalyze
+		results   []*AnalyzeResult
+		wantErr   bool
+	}{
+		{
+			name: "pass expect single result",
+			collected: collect.NetworkStatusResult{
+				Status: "connected",
+			},
+			analyzer: troubleshootv1beta2.TCPPortStatusAnalyze{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "Kubernetes API TCP Port Status",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "connected",
+							Message: "Port 6443 is open",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "Unexpected port status",
+						},
+					},
+				},
+			},
+			results: []*AnalyzeResult{
+				{
+					Title:   "Kubernetes API TCP Port Status",
+					IsPass:  true,
+					Message: "Port 6443 is open",
+				},
+			},
+		},
+
+		{
+			name: "get warn if no match",
+			collected: collect.NetworkStatusResult{
+				Status: "connected",
+			},
+			analyzer: troubleshootv1beta2.TCPPortStatusAnalyze{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "Kubernetes API TCP Port Status",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "foo",
+							Message: "Port 6443 is open",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "Unexpected port status",
+						},
+					},
+				},
+			},
+			results: []*AnalyzeResult{
+				{
+					Title:   "Kubernetes API TCP Port Status",
+					IsWarn:  true,
+					Message: "Unexpected port status",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := func(_ string) ([]byte, error) {
+				return json.Marshal(&tc.collected)
+			}
+			analyzer := AnalyzeHostTCPPortStatus{
+				hostAnalyzer: &tc.analyzer,
+			}
+			results, err := analyzer.Analyze(fn)
+			if tc.wantErr {
+				require.NotNil(t, err)
+				return
+			}
+
+			require.Nil(t, err)
+			require.Equal(t, tc.results, results)
+		})
+	}
+
+}


### PR DESCRIPTION
See [clubhouse issue](https://app.clubhouse.io/replicated/story/35811/host-preflights-show-warns-and-pass-for-same-check).  Some analyzers are written such that empty when clauses are a type of a default return value if no other when clauses are evaluated as true.  The problem is, now that we can return more than one result, these warns are always returned.  To fix this, these analyzers exit in the case that any when clause returns true, in other works, they will only return the first result that the when clause is true. 