### PR TITLE
fix: allow passing empty namespace again for clusterResources

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -48,10 +48,6 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 	}
 
 	namespace := v.GetString("namespace")
-	if namespace == "" {
-		kubeconfig := k8sutil.GetKubeconfig()
-		namespace, _, _ = kubeconfig.Namespace()
-	}
 
 	var sinceTime *time.Time
 	if v.GetString("since-time") != "" || v.GetString("since") != "" {

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -221,6 +222,10 @@ func (c *Collector) RunCollectorSync(clientConfig *rest.Config, client kubernete
 		if namespace == "" {
 			namespace = c.Namespace
 		}
+		if namespace == "" {
+			kubeconfig := k8sutil.GetKubeconfig()
+			namespace, _, _ = kubeconfig.Namespace()
+		}
 		result, err = CopyFromHost(ctx, namespace, clientConfig, client, c.Collect.CopyFromHost)
 	} else if c.Collect.HTTP != nil {
 		result, err = HTTP(c, c.Collect.HTTP)
@@ -235,6 +240,10 @@ func (c *Collector) RunCollectorSync(clientConfig *rest.Config, client kubernete
 		namespace := c.Collect.Collectd.Namespace
 		if namespace == "" {
 			namespace = c.Namespace
+		}
+		if namespace == "" {
+			kubeconfig := k8sutil.GetKubeconfig()
+			namespace, _, _ = kubeconfig.Namespace()
 		}
 		result, err = Collectd(ctx, namespace, clientConfig, client, c.Collect.Collectd)
 	} else if c.Collect.Ceph != nil {


### PR DESCRIPTION
[A recent commit](https://github.com/replicatedhq/troubleshoot/pull/391/commits/2889e1ffe79ce3db4d3e5b48726aae5240cbbe8e) broke previous behavior of being able to collect `clusterResources: {}` from all namespaces.

From the [docs](https://troubleshoot.sh/docs/collect/cluster-resources/)
> This will attempt to collect information from all namespaces

Tested with:
```
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: namespace-bug
spec:
  collectors:
    - clusterInfo: {}
    - clusterResources: {}
```

Ran it with this fix (see output snippet):
```
➜ tree support-bundle-2021-08-12T16_45_04/cluster-resources
support-bundle-2021-08-12T16_45_04/cluster-resources
├── deployments
│   ├── calico-system.json
│   ├── default.json
│   ├── kube-node-lease.json
│   ├── kube-public.json
│   ├── kube-system.json
│   ├── node-feature-discovery.json
│   └── tigera-operator.json
```

And with latest release
```
➜ ./support-bundle version
Replicated Troubleshoot 0.13.7
➜  tree support-bundle-2021-08-12T16_46_11/cluster-resources/
support-bundle-2021-08-12T16_46_11/cluster-resources/
├── deployments
│   └── default.json
```

