### PR TITLE
fix: cluster-res collector fixed to one namespace

### DIFF
--- a/cmd/preflight/cli/run.go
+++ b/cmd/preflight/cli/run.go
@@ -220,14 +220,8 @@ func collectInCluster(preflightSpec *troubleshootv1beta2.Preflight, progressCh c
 		return nil, errors.Wrap(err, "failed to convert kube flags to rest config")
 	}
 
-	namespace := v.GetString("namespace")
-	if namespace == "" {
-		kubeconfig := k8sutil.GetKubeconfig()
-		namespace, _, _ = kubeconfig.Namespace()
-	}
-
 	collectOpts := preflight.CollectOpts{
-		Namespace:              namespace,
+		Namespace:              v.GetString("namespace"),
 		IgnorePermissionErrors: v.GetBool("collect-without-permissions"),
 		ProgressChan:           progressCh,
 		KubernetesRestConfig:   restConfig,

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -47,12 +47,6 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 		return errors.Wrap(err, "failed to convert kube flags to rest config")
 	}
 
-	namespace := v.GetString("namespace")
-	if namespace == "" {
-		kubeconfig := k8sutil.GetKubeconfig()
-		namespace, _, _ = kubeconfig.Namespace()
-	}
-
 	var sinceTime *time.Time
 	if v.GetString("since-time") != "" || v.GetString("since") != "" {
 		sinceTime, err = parseTimeFlags(v)
@@ -156,7 +150,7 @@ func runTroubleshoot(v *viper.Viper, arg string) error {
 		CollectorProgressCallback: collectorCB,
 		CollectWithoutPermissions: v.GetBool("collect-without-permissions"),
 		KubernetesRestConfig:      restConfig,
-		Namespace:                 namespace,
+		Namespace:                 v.GetString("namespace"),
 		ProgressChan:              progressChan,
 		SinceTime:                 sinceTime,
 	}

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -218,7 +219,10 @@ func (c *Collector) RunCollectorSync(clientConfig *rest.Config, client kubernete
 		result, err = Copy(c, c.Collect.Copy)
 	} else if c.Collect.CopyFromHost != nil {
 		namespace := c.Collect.CopyFromHost.Namespace
-		if namespace == "" {
+		if namespace == "" && c.Namespace == "" {
+			kubeconfig := k8sutil.GetKubeconfig()
+			namespace, _, _ = kubeconfig.Namespace()
+		} else if namespace == "" {
 			namespace = c.Namespace
 		}
 		result, err = CopyFromHost(ctx, namespace, clientConfig, client, c.Collect.CopyFromHost)
@@ -233,7 +237,10 @@ func (c *Collector) RunCollectorSync(clientConfig *rest.Config, client kubernete
 	} else if c.Collect.Collectd != nil {
 		// TODO: see if redaction breaks these
 		namespace := c.Collect.Collectd.Namespace
-		if namespace == "" {
+		if namespace == "" && c.Namespace == "" {
+			kubeconfig := k8sutil.GetKubeconfig()
+			namespace, _, _ = kubeconfig.Namespace()
+		} else if namespace == "" {
 			namespace = c.Namespace
 		}
 		result, err = Collectd(ctx, namespace, clientConfig, client, c.Collect.Collectd)


### PR DESCRIPTION
Setting the namespace to a non-empty string modifies the existing behavior of the `cluster-resource` collector, where it should visit every namespace when one is not explicitly defined.

Partially reverts PR#391.