### PR TITLE
Add signed SBOM to troubleshoot

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -114,7 +114,9 @@ jobs:
         with:
           go-version: "1.14"
 
-      - uses: sigstore/cosign-installer@v1.1.0
+      - uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: "v1.2.1"
 
       - name: Generate SBOM
         run: |

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -113,6 +113,15 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: "1.14"
+
+      - uses: sigstore/cosign-installer@v1.1.0
+
+      - name: Generate SBOM
+        run: |
+          COSIGN_PASSWORD=$COSIGNPASSWORD COSIGN_KEY=$COSIGN_KEY make sbom
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
    
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ try.sh
 
 .vscode/
 workspace.*
+
+cosign.key
+sbom/

--- a/README.md
+++ b/README.md
@@ -39,3 +39,16 @@ For details on creating the custom resource files that drive support-bundle coll
 # Community
 
 For questions about using Troubleshoot, there's a [Replicated Community](https://help.replicated.com/community) forum, and a [#app-troubleshoot channel in Kubernetes Slack](https://kubernetes.slack.com/channels/app-troubleshoot).
+
+# Software Bill of Materials 
+A signed SBOM  that includes Troubleshoot dependencies is included in each release. 
+- **troubleshoot-sbom.tgz** contains a software bill of materials for Troubleshoot. 
+- **troubleshoot-sbom.tgz.sig** is the digital signature for troubleshoot-sbom.tgz
+- **key.pub** is the public key from the key pair used to sign troubleshoot-sbom.tgz
+
+The following example illustrates using [cosign](https://github.com/sigstore/cosign) to verify that **troubleshoot-sbom.tgz** has
+not been tampered with.
+```shell
+$ cosign verify-blob -key key.pub -signature troubleshoot-sbom.tgz.sig troubleshoot-sbom.tgz
+Verified OK
+```

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -58,6 +58,7 @@ archives:
       - README*
       - changelog*
       - CHANGELOG*
+      - sbom/assets/*
   - id: support-bundle
     builds:
       - support-bundle

--- a/scripts/initialize-sbom-build.sh
+++ b/scripts/initialize-sbom-build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -n "${COSIGN_KEY}" ]
+then 
+	echo "Writing cosign key to file"
+	echo "${COSIGN_KEY}" | base64 -d > ./cosign.key
+else 
+	echo "ERROR: Missing COSIGN_KEY!"
+fi
+
+if ! command -v spdx-sbom-generator &> /dev/null
+then
+	echo "Installing spdx-sbom-generator"
+        curl -L https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz -o ./sbom/spdx-sbom-generator.tar.gz
+        curl -L https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz.md5 -o ./sbom/spdx-sbom-generator.tar.gz.md5
+        md5sum ./sbom/spdx-sbom-generator.tar.gz | cut --bytes=1-32 > ./sbom/checksum
+
+        if ! cmp ./sbom/checksum ./sbom/spdx-sbom-generator.tar.gz.md5
+	then
+        	echo "ERROR: spdx-sbom-generator.tar.gz md5 sum does not match!"
+		exit 1
+	fi
+
+	tar -xzvf ./sbom/spdx-sbom-generator.tar.gz -C sbom
+fi


### PR DESCRIPTION
See [Clubhouse Issue](https://app.clubhouse.io/replicated/story/37032/when-troubleshoot-is-released-an-sbom-will-be-generated-and-included-in-the-release-notes) This change will generate a signed software bill of materials and add it to the repository release archives when the project is released.    Note: before merge a repository owner will need to add two secrets to the repository by a repository owner. These secrets are `COSIGN_KEY` and `COSIGN_PASSWORD`.  The `COSIGN_KEY` is a base 64 encoded private key, and the `COSIGN_PASSWORD` is the password used to generate the key.  [cosign](https://github.com/sigstore/cosign) is used to generate these as follows:
```
cosign generate-key-pair
cat cosign.key | base64 | pbcopy
```