### PR TITLE
Added missing cosign.key

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -118,9 +118,15 @@ jobs:
         with:
           cosign-release: "v1.2.1"
 
+      - name: Get Cosign Key
+        run: |
+          echo $COSIGN_KEY | base64 -d > ./cosign.key
+        env:
+          COSIGN_KEY: ${{secrets.COSIGN_KEY}}
+          
       - name: Generate SBOM
         run: |
-          COSIGN_PASSWORD=$COSIGNPASSWORD COSIGN_KEY=$COSIGN_KEY make sbom
+          make sbom
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}


### PR DESCRIPTION
SBOM generation was failing because it missed a step to generate the private key needed for SBOM signing from Github secret. 