### PR TITLE
add toleration to copy-from-host daemonset to allow collection from CP nodes

### DIFF
--- a/pkg/collect/copy_from_host.go
+++ b/pkg/collect/copy_from_host.go
@@ -126,6 +126,13 @@ func copyFromHostCreateDaemonSet(ctx context.Context, client kubernetes.Interfac
 							},
 						},
 					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+					},
 					Volumes: []corev1.Volume{
 						{
 							Name: "host",


### PR DESCRIPTION
Currently, the daemonset which allows 'copy-from-host' will not launch on the master nodes, due to the presence of the taint "node-role.kubernetes.io/master:NoSchedule" on those nodes.

Adding toleration of this taint to the daemonset will allow 'copy-from-host' to execute on the control plane nodes as well as the worker nodes.

An interesting follow-on would be adding node selectors to the copy-from-host collector, allow specific copy-from-hosts to be executed, say, only on CP nodes; or only on nodes of a certain OS. Would be interested to learn more about any plans for this that ya'll have.

### testing

`make support-bundle && cp ./bin/support-bundle /usr/local/bin && support-bundle bundle.yaml --kubeconfig mine.kubeconfig`, when `bundle.yaml` has a `copyFromHost` collector, collects from all nodes in cluster.