### PR TITLE
Handle k8s api deprecations

### DIFF
--- a/pkg/k8sutil/discovery/discovery.go
+++ b/pkg/k8sutil/discovery/discovery.go
@@ -1,0 +1,25 @@
+package discovery
+
+import (
+	"k8s.io/client-go/discovery"
+)
+
+// HasResource takes an api version and a kind of a resource and checks if the resource
+// is supported by the k8s api server.
+func HasResource(dc discovery.DiscoveryInterface, apiVersion, kind string) (bool, error) {
+	_, apiLists, err := dc.ServerGroupsAndResources()
+	if err != nil {
+		return false, err
+	}
+	// Compare the resource api version and kind and find the resource.
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == apiVersion {
+			for _, r := range apiList.APIResources {
+				if r.Kind == kind {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/k8sutil/discovery/discovery_test.go
+++ b/pkg/k8sutil/discovery/discovery_test.go
@@ -1,0 +1,80 @@
+package discovery
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestHasResource(t *testing.T) {
+	testKind := "Foo"
+	testKindGroupVersion := "v1"
+
+	testcases := []struct {
+		name            string
+		apiResourceList []*metav1.APIResourceList
+		wantResult      bool
+	}{
+		{
+			name:            "empty api resource list",
+			apiResourceList: []*metav1.APIResourceList{},
+			wantResult:      false,
+		},
+		{
+			name: "have resource",
+			apiResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{
+							Kind: "Foo",
+						},
+						{
+							Kind: "Bar",
+						},
+					},
+				},
+			},
+			wantResult: true,
+		},
+		{
+			name: "have resource but different version",
+			apiResourceList: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v2",
+					APIResources: []metav1.APIResource{
+						{
+							Kind: "Foo",
+						},
+						{
+							Kind: "Bar",
+						},
+					},
+				},
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			client := fakeclientset.NewSimpleClientset()
+			fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+			if !ok {
+				t.Fatalf("could not convert Discovery() to *FakeDiscovery")
+			}
+			fakeDiscovery.Resources = tc.apiResourceList
+
+			exists, err := HasResource(fakeDiscovery, testKindGroupVersion, testKind)
+			if err != nil {
+				t.Fatalf("failed to check if resource exists: %v", err)
+			}
+			if exists != tc.wantResult {
+				t.Errorf("unexpected result for HasResource:\n\t(WNT) %t\n\t(GOT) %t", tc.wantResult, exists)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduces a mechanism to verify whether the k8s server supports a given GVK.

Uses v1 API implementations if they exist for Ingress, StorageClass and CustomResourceDefinition, and current behaviour (v1beta1) if they don't.  This avoids deprecation warnings such as:

```
W0923 10:18:09.628640  493696 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

Fixes #426