### PR TITLE
chore(ci): fix sbom assets for krew

### DIFF
--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -58,7 +58,9 @@ archives:
       - README*
       - changelog*
       - CHANGELOG*
-      - sbom/assets/*
+      - src: 'sbom/assets/*'
+        dst: .
+        strip_parent: true  # this is needed to make up for the way unzips work in krew v0.4.1
   - id: support-bundle
     builds:
       - support-bundle
@@ -76,6 +78,9 @@ archives:
       - README*
       - changelog*
       - CHANGELOG*
+      - src: 'sbom/assets/*'
+        dst: .
+        strip_parent: true # this is needed to make up for the way unzips work in krew v0.4.1
 dockers:
   - dockerfile: ./deploy/Dockerfile.troubleshoot
     image_templates:


### PR DESCRIPTION
Fixing issues related to moving around files during krew install.

Failed Krew PR: https://github.com/kubernetes-sigs/krew-index/pull/1575/checks

Place where it's breaking in Krew: https://github.com/kubernetes-sigs/krew/blob/a28e95123e693b0444e6a6f4a3b2826a1096ddd5/internal/download/downloader.go#L78-L82