### PR TITLE
Add support for k8s 1.24+

### DIFF
--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -73,6 +73,9 @@ func ParseNodesForProviders(nodes []corev1.Node) (providers, string) {
 			if k == "node-role.kubernetes.io/master" {
 				foundMaster = true
 			}
+			if k == "node-role.kubernetes.io/control-plane" {
+				foundMaster = true
+			}
 			if k == "kubernetes.azure.com/role" {
 				foundProviders.aks = true
 				stringProvider = "aks"

--- a/pkg/collect/copy_from_host.go
+++ b/pkg/collect/copy_from_host.go
@@ -137,6 +137,11 @@ func copyFromHostCreateDaemonSet(ctx context.Context, client kubernetes.Interfac
 							Operator: "Exists",
 							Effect:   "NoSchedule",
 						},
+						{
+							Key:      "node-role.kubernetes.io/control-plane",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
 					},
 					Volumes: []corev1.Volume{
 						{

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -69,6 +69,11 @@ func RunPodsReadyNodes(ctx context.Context, client v1.CoreV1Interface, opts RunP
 							Operator: "Exists",
 							Effect:   "NoSchedule",
 						},
+						{
+							Key:      "node-role.kubernetes.io/control-plane",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
 					},
 				},
 			}


### PR DESCRIPTION
https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24

[The master label is no longer present on kubeadm control plane nodes](https://github.com/kubernetes/kubernetes/pull/107533). For new clusters, the label 'node-role.kubernetes.io/master' will no longer be added to control plane nodes, only the label 'node-role.kubernetes.io/control-plane' will be added. For more information, refer to [KEP-2067: Rename the kubeadm "master" label and taint](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint).