### PR TITLE
fix panic: return nil result when no files to check deployment status analyzer

### DIFF
--- a/pkg/analyze/deployment_status.go
+++ b/pkg/analyze/deployment_status.go
@@ -55,6 +55,10 @@ func analyzeOneDeploymentStatus(analyzer *troubleshootv1beta2.DeploymentStatus, 
 		}
 	}
 
+	if result == nil {
+		return nil, nil
+	}
+
 	return []*AnalyzeResult{result}, nil
 }
 


### PR DESCRIPTION
When there is no deployment found for the specified analyzer, 
`[]*analyzeResults` will contain: `[]*analyzerResult{nil}` which causes panic in multiple places.

the deployment file may not exist due to two reasons:
- namespace for the deployment doesn't exist
- clusterResources collector is excluded

So, when the analyzerResult is not available, 
return result=nil and err nil

preflight eg:
```
apiVersion: troubleshoot.sh/v1beta2
kind: Preflight
metadata:
  name: api-deployment-running
spec:
  analyzers:
    - deploymentStatus:
        name: api
        namespace: test
        outcomes:
          - fail:
              when: "< 1"
              message: The API deployment does not have any ready replicas.
          - warn:
              when: "= 1"
              message: The API deployment has only a single ready replica.
          - pass:
              message: There are multiple replicas of the API deployment ready.
```