### PR TITLE
Disable client-go logging

### DIFF
--- a/cmd/analyze/cli/root.go
+++ b/cmd/analyze/cli/root.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/klog/v2"
 )
 
 func RootCmd() *cobra.Command {
@@ -18,7 +20,12 @@ func RootCmd() *cobra.Command {
 		Long:         `Run a series of analyzers on a support bundle archive`,
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlags(cmd.Flags())
+			v := viper.GetViper()
+			v.BindPFlags(cmd.Flags())
+
+			if !v.GetBool("debug") {
+				klog.SetLogger(logr.Discard())
+			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
@@ -32,6 +39,7 @@ func RootCmd() *cobra.Command {
 	cobra.OnInitialize(initConfig)
 
 	cmd.Flags().String("analyzers", "", "filename or url of the analyzers to use")
+	cmd.Flags().Bool("debug", false, "enable debug logging")
 
 	viper.BindPFlags(cmd.Flags())
 

--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -4,9 +4,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/klog/v2"
 )
 
 func RootCmd() *cobra.Command {
@@ -18,7 +20,12 @@ func RootCmd() *cobra.Command {
 that a cluster meets the requirements to run an application.`,
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlags(cmd.Flags())
+			v := viper.GetViper()
+			v.BindPFlags(cmd.Flags())
+
+			if !v.GetBool("debug") {
+				klog.SetLogger(logr.Discard())
+			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
@@ -39,6 +46,7 @@ that a cluster meets the requirements to run an application.`,
 	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 	cmd.Flags().StringP("output", "o", "", "specify the output file path for the preflight checks")
+	cmd.Flags().Bool("debug", false, "enable debug logging")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/logr"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/klog/v2"
 )
 
 func RootCmd() *cobra.Command {
@@ -21,7 +23,12 @@ func RootCmd() *cobra.Command {
 from a server that can be used to assist when troubleshooting a Kubernetes cluster.`,
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlags(cmd.Flags())
+			v := viper.GetViper()
+			v.BindPFlags(cmd.Flags())
+
+			if !v.GetBool("debug") {
+				klog.SetLogger(logr.Discard())
+			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
@@ -43,6 +50,7 @@ from a server that can be used to assist when troubleshooting a Kubernetes clust
 	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 	cmd.Flags().StringP("output", "o", "", "specify the output file path for the support bundle")
+	cmd.Flags().Bool("debug", false, "enable debug logging")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")


### PR DESCRIPTION
When you run a support bundle we see a lot of logs from client-go. This isn't useful to the end user.

```
$ ./bin/support-bundle https://kots.io --debug

 Collecting support bundle ⠇ cluster-resourcesW0610 15:35:17.811103  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.814310  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.817095  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.819604  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.822711  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.825399  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.827627  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.829691  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
 Collecting support bundle ⠏ cluster-resourcesW0610 15:35:17.832705  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W0610 15:35:17.835899  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
 Collecting support bundle ⠋ cluster-resourcesW0610 15:35:18.011776  523309 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
 Collecting support bundle ⠼ cluster-resources
```