### PR TITLE
do not return that a strict analyzer is present in an application if …

### DIFF
--- a/pkg/preflight/util.go
+++ b/pkg/preflight/util.go
@@ -64,6 +64,9 @@ func hasStrictAnalyzer(analyzerMap map[string]interface{}) (bool, error) {
 		if err != nil {
 			return false, errors.Wrap(err, "error while un-marshalling marshalledAnalyzers")
 		}
+		if analyzeMeta.Exclude.BoolOrDefaultFalse() {
+			continue
+		}
 		if analyzeMeta.Strict.BoolOrDefaultFalse() {
 			return true, nil
 		}

--- a/pkg/preflight/util_test.go
+++ b/pkg/preflight/util_test.go
@@ -46,6 +46,16 @@ var (
 			StrVal: "1",
 		},
 	}
+	analyzeMetaStrictTrueExcludeTrue = troubleshootv1beta2.AnalyzeMeta{
+		Exclude: &multitype.BoolOrString{
+			Type:    multitype.Bool,
+			BoolVal: true,
+		},
+		Strict: &multitype.BoolOrString{
+			Type:    multitype.Bool,
+			BoolVal: true,
+		},
+	}
 )
 
 func TestHasStrictAnalyzers(t *testing.T) {
@@ -229,6 +239,36 @@ func TestHasStrictAnalyzers(t *testing.T) {
 					Analyzers: []*troubleshootv1beta2.Analyze{
 						{
 							ClusterVersion: &troubleshootv1beta2.ClusterVersion{AnalyzeMeta: analyzeMetaStrictFalseInt},
+							StorageClass:   &troubleshootv1beta2.StorageClass{AnalyzeMeta: analyzeMetaStrictFalseInt},
+							Secret:         &troubleshootv1beta2.AnalyzeSecret{AnalyzeMeta: analyzeMetaStrictTrueBool},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "expect false when preflight spec's analyzer has analyzer with strict true and exclude true",
+			preflight: &troubleshootv1beta2.Preflight{
+				Spec: troubleshootv1beta2.PreflightSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							ClusterVersion: &troubleshootv1beta2.ClusterVersion{AnalyzeMeta: analyzeMetaStrictTrueExcludeTrue},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "expect true when preflight spec's analyzer has analyzer with strict true in one of multiple analyzers, but one analyzer with strict true is exclude true",
+			preflight: &troubleshootv1beta2.Preflight{
+				Spec: troubleshootv1beta2.PreflightSpec{
+					Analyzers: []*troubleshootv1beta2.Analyze{
+						{
+							ClusterVersion: &troubleshootv1beta2.ClusterVersion{AnalyzeMeta: analyzeMetaStrictTrueExcludeTrue},
 							StorageClass:   &troubleshootv1beta2.StorageClass{AnalyzeMeta: analyzeMetaStrictFalseInt},
 							Secret:         &troubleshootv1beta2.AnalyzeSecret{AnalyzeMeta: analyzeMetaStrictTrueBool},
 						},


### PR DESCRIPTION
…a strict analyzer is excluded

If we have an application with a preflight like the following 

<details>
  <summary>Preflight Spec</summary>

```
apiVersion: troubleshoot.sh/v1beta2
kind: Preflight
metadata:
  name: supported-mysql-version
spec:
  collectors:
    - mysql:
        exclude: true
        collectorName: mysql
        uri: '{{repl ConfigOption "db_username"}}:{{repl ConfigOption "db_password"}}@tcp({{repl "db_hostname"}}:{{repl ConfigOption "db_port"}})/{{repl ConfigOption "db_name"}}'
  analyzers:
    - mysql:
        exclude: true
        strict: true
        checkName: Must be MySQL 8.x or later
        collectorName: mysql
        outcomes:
          - fail:
              when: connected == false
              message: Cannot connect to the MariaDB server
          - pass:
              message: The MariaDB server is ready
```
</details>

We are unable to deploy the application because the check still thinks that there is a strict analyzer, even though it is excluded. This PR adds a simple check to not include the analyzer if it is excluded. 

Screenshots of the behavior during deploy vv
<img width="1767" alt="Screen Shot 2022-06-14 at 11 18 43 AM" src="https://user-images.githubusercontent.com/1361223/173639322-8f3763a1-a250-42a2-87cb-a123a20c195f.png">
<img width="1304" alt="Screen Shot 2022-05-30 at 1 22 12 PM" src="https://user-images.githubusercontent.com/1361223/173639328-16c88247-b5f6-4216-8cb8-048ed20c4e45.png">
