### PR TITLE
Host Run Collector

### DIFF
--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -150,6 +150,12 @@ type HostServices struct {
 	HostCollectorMeta `json:",inline" yaml:",inline"`
 }
 
+type RunHost struct {
+	HostCollectorMeta `json:",inline" yaml:",inline"`
+	Command           string   `json:"command"`
+	Args              []string `json:"args"`
+}
+
 type HostCollect struct {
 	CPU                   *CPU                   `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	Memory                *Memory                `json:"memory,omitempty" yaml:"memory,omitempty"`
@@ -169,6 +175,7 @@ type HostCollect struct {
 	Certificate           *Certificate           `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	HostServices          *HostServices          `json:"hostServices,omitempty" yaml:"hostServices,omitempty"`
 	HostOS                *HostOS                `json:"hostOS,omitempty" yaml:"hostOS,omitempty"`
+	RunHost               *RunHost               `json:"run,omitempty" yaml:"run,omitempty"`
 }
 
 func (c *HostCollect) GetName() string {

--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -150,7 +150,7 @@ type HostServices struct {
 	HostCollectorMeta `json:",inline" yaml:",inline"`
 }
 
-type RunHost struct {
+type HostRun struct {
 	HostCollectorMeta `json:",inline" yaml:",inline"`
 	Command           string   `json:"command"`
 	Args              []string `json:"args"`
@@ -175,7 +175,7 @@ type HostCollect struct {
 	Certificate           *Certificate           `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	HostServices          *HostServices          `json:"hostServices,omitempty" yaml:"hostServices,omitempty"`
 	HostOS                *HostOS                `json:"hostOS,omitempty" yaml:"hostOS,omitempty"`
-	RunHost               *RunHost               `json:"run,omitempty" yaml:"run,omitempty"`
+	HostRun               *HostRun               `json:"run,omitempty" yaml:"run,omitempty"`
 }
 
 func (c *HostCollect) GetName() string {

--- a/pkg/collect/host_collector.go
+++ b/pkg/collect/host_collector.go
@@ -51,8 +51,8 @@ func GetHostCollector(collector *troubleshootv1beta2.HostCollect, bundlePath str
 		return &CollectHostServices{collector.HostServices, bundlePath}, true
 	case collector.HostOS != nil:
 		return &CollectHostOS{collector.HostOS, bundlePath}, true
-	case collector.RunHost != nil:
-		return &CollectRunHost{collector.RunHost, bundlePath}, true
+	case collector.HostRun != nil:
+		return &CollectHostRun{collector.HostRun, bundlePath}, true
 	default:
 		return nil, false
 	}

--- a/pkg/collect/host_collector.go
+++ b/pkg/collect/host_collector.go
@@ -51,6 +51,8 @@ func GetHostCollector(collector *troubleshootv1beta2.HostCollect, bundlePath str
 		return &CollectHostServices{collector.HostServices, bundlePath}, true
 	case collector.HostOS != nil:
 		return &CollectHostOS{collector.HostOS, bundlePath}, true
+	case collector.RunHost != nil:
+		return &CollectRunHost{collector.RunHost, bundlePath}, true
 	default:
 		return nil, false
 	}

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -11,26 +11,26 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
-type RunHostResults struct {
+type HostRunResults struct {
 	Command  string `json:"result"`
 	ExitCode string `json:"exitCode"`
 	Error    string `json:"error"`
 }
 
-type CollectRunHost struct {
-	hostCollector *troubleshootv1beta2.RunHost
+type CollectHostRun struct {
+	hostCollector *troubleshootv1beta2.HostRun
 	BundlePath    string
 }
 
-func (c *CollectRunHost) Title() string {
+func (c *CollectHostRun) Title() string {
 	return hostCollectorTitleOrDefault(c.hostCollector.HostCollectorMeta, "Run Host")
 }
 
-func (c *CollectRunHost) IsExcluded() (bool, error) {
+func (c *CollectHostRun) IsExcluded() (bool, error) {
 	return isExcluded(c.hostCollector.Exclude)
 }
 
-func (c *CollectRunHost) Collect(progressChan chan<- interface{}) (map[string][]byte, error) {
+func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]byte, error) {
 	runHostCollector := c.hostCollector
 
 	cmd := exec.Command(runHostCollector.Command, runHostCollector.Args...)
@@ -39,7 +39,7 @@ func (c *CollectRunHost) Collect(progressChan chan<- interface{}) (map[string][]
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	runResult := RunHostResults{
+	runResult := HostRunResults{
 		Command:  cmd.String(),
 		ExitCode: "0",
 	}

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -1,0 +1,80 @@
+package collect
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+)
+
+type RunHostResults struct {
+	Command  string `json:"result"`
+	ExitCode string `json:"exitCode"`
+	Error    string `json:"error"`
+}
+
+type CollectRunHost struct {
+	hostCollector *troubleshootv1beta2.RunHost
+	BundlePath    string
+}
+
+func (c *CollectRunHost) Title() string {
+	return hostCollectorTitleOrDefault(c.hostCollector.HostCollectorMeta, "Run Host")
+}
+
+func (c *CollectRunHost) IsExcluded() (bool, error) {
+	return isExcluded(c.hostCollector.Exclude)
+}
+
+func (c *CollectRunHost) Collect(progressChan chan<- interface{}) (map[string][]byte, error) {
+	runHostCollector := c.hostCollector
+
+	cmd := exec.Command(runHostCollector.Command, runHostCollector.Args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runResult := RunHostResults{
+		Command:  cmd.String(),
+		ExitCode: "0",
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		if werr, ok := err.(*exec.ExitError); ok {
+			runResult.ExitCode = strings.TrimPrefix(werr.Error(), "exit status ")
+		} else {
+			return nil, errors.Wrap(err, "failed to run")
+		}
+	}
+
+	runResult.Error = stderr.String()
+
+	collectorName := c.hostCollector.CollectorName
+	if collectorName == "" {
+		collectorName = "run-host"
+	}
+	resultDetails := filepath.Join("host-collectors/run-host", collectorName+"-info.json")
+	result := filepath.Join("host-collectors/run-host", collectorName+".txt")
+
+	b, err := json.Marshal(runResult)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal run host result")
+	}
+
+	output := NewResult()
+	output.SaveResult(c.BundlePath, resultDetails, bytes.NewBuffer(b))
+	output.SaveResult(c.BundlePath, result, bytes.NewBuffer(stdout.Bytes()))
+
+	runHostOutput := map[string][]byte{
+		resultDetails: b,
+		result:        stdout.Bytes(),
+	}
+
+	return runHostOutput, nil
+}

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -48,18 +48,17 @@ func (c *CollectRunHost) Collect(progressChan chan<- interface{}) (map[string][]
 	if err != nil {
 		if werr, ok := err.(*exec.ExitError); ok {
 			runResult.ExitCode = strings.TrimPrefix(werr.Error(), "exit status ")
+			runResult.Error = stderr.String()
 		} else {
 			return nil, errors.Wrap(err, "failed to run")
 		}
 	}
 
-	runResult.Error = stderr.String()
-
 	collectorName := c.hostCollector.CollectorName
 	if collectorName == "" {
 		collectorName = "run-host"
 	}
-	resultDetails := filepath.Join("host-collectors/run-host", collectorName+"-info.json")
+	resultInfo := filepath.Join("host-collectors/run-host", collectorName+"-info.json")
 	result := filepath.Join("host-collectors/run-host", collectorName+".txt")
 
 	b, err := json.Marshal(runResult)
@@ -68,12 +67,12 @@ func (c *CollectRunHost) Collect(progressChan chan<- interface{}) (map[string][]
 	}
 
 	output := NewResult()
-	output.SaveResult(c.BundlePath, resultDetails, bytes.NewBuffer(b))
+	output.SaveResult(c.BundlePath, resultInfo, bytes.NewBuffer(b))
 	output.SaveResult(c.BundlePath, result, bytes.NewBuffer(stdout.Bytes()))
 
 	runHostOutput := map[string][]byte{
-		resultDetails: b,
-		result:        stdout.Bytes(),
+		resultInfo: b,
+		result:     stdout.Bytes(),
 	}
 
 	return runHostOutput, nil

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -11,7 +11,7 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
-type HostRunResults struct {
+type HostRunInfo struct {
 	Command  string `json:"result"`
 	ExitCode string `json:"exitCode"`
 	Error    string `json:"error"`
@@ -39,7 +39,7 @@ func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	runResult := HostRunResults{
+	runResult := HostRunInfo{
 		Command:  cmd.String(),
 		ExitCode: "0",
 	}

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -12,7 +12,7 @@ import (
 )
 
 type HostRunInfo struct {
-	Command  string `json:"result"`
+	Command  string `json:"command"`
 	ExitCode string `json:"exitCode"`
 	Error    string `json:"error"`
 }
@@ -39,7 +39,7 @@ func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	runResult := HostRunInfo{
+	runInfo := HostRunInfo{
 		Command:  cmd.String(),
 		ExitCode: "0",
 	}
@@ -47,8 +47,8 @@ func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]
 	err := cmd.Run()
 	if err != nil {
 		if werr, ok := err.(*exec.ExitError); ok {
-			runResult.ExitCode = strings.TrimPrefix(werr.Error(), "exit status ")
-			runResult.Error = stderr.String()
+			runInfo.ExitCode = strings.TrimPrefix(werr.Error(), "exit status ")
+			runInfo.Error = stderr.String()
 		} else {
 			return nil, errors.Wrap(err, "failed to run")
 		}
@@ -61,7 +61,7 @@ func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]
 	resultInfo := filepath.Join("host-collectors/run-host", collectorName+"-info.json")
 	result := filepath.Join("host-collectors/run-host", collectorName+".txt")
 
-	b, err := json.Marshal(runResult)
+	b, err := json.Marshal(runInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal run host result")
 	}


### PR DESCRIPTION
[SC-50881](https://app.shortcut.com/replicated/story/50881/run-hostcollector)

https://troubleshoot.sh/docs/collect/run-pod/ but at the host level

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: ping-google
spec:
  hostCollectors:
    - run:
        collectorName: "ping-google"
        command: "ping"
        args: ["-c", "5", "google.com"]
  ```
  
  ```
 # ping-google-info.json

{"result":"/sbin/ping -c 5 google.com","exitCode":"0","error":""}
  ```
  
  ```
  # ping-google.txt
PING google.com (142.250.217.238): 56 data bytes
64 bytes from 142.250.217.238: icmp_seq=0 ttl=120 time=36.565 ms
64 bytes from 142.250.217.238: icmp_seq=1 ttl=120 time=34.608 ms
64 bytes from 142.250.217.238: icmp_seq=2 ttl=120 time=35.004 ms
64 bytes from 142.250.217.238: icmp_seq=3 ttl=120 time=35.774 ms
64 bytes from 142.250.217.238: icmp_seq=4 ttl=120 time=34.922 ms

--- google.com ping statistics ---
5 packets transmitted, 5 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 34.608/35.375/36.565/0.708 ms
  ```