### PR TITLE
fix: use `storedVersions` to determine specific CR version

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -797,6 +797,9 @@ func crsV1(ctx context.Context, client dynamic.Interface, config *rest.Config, n
 		if len(crd.Spec.Versions) > 0 {
 			version = crd.Spec.Versions[0].Name
 		}
+		if len(crd.Status.StoredVersions) > 0 {
+			version = crd.Status.StoredVersions[0]
+		}
 		gvr := schema.GroupVersionResource{
 			Group:    crd.Spec.Group,
 			Version:  version,


### PR DESCRIPTION
Fixes #608 

Right now, it could be possible that we are not saving a CR fully because we look for `spec.versions` instead of `status.storedVersions` when deciding to collect CR at a specific version. This could create data loss in the collected bundle as the storedVersion might have a more correct/complete representation of the state as compared the the version listed in the spec. This is not always the case, but is definitely possible - consider this scenario:

```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
spec:
  versions:
  - name: v1beta1
    ...
  - name: v1beta2
    ...
status:
  ...
  storedVersions:
  - v1beta2
```

In above example, v1beta2 might have have rich information state compared to v1beta1 and thus we should refer to storedVersions in this case.