### PR TITLE
Add Ceph auth redactors

### DIFF
--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -304,6 +304,11 @@ func getRedactors(path string) ([]Redactor, error) {
 			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:  "Redact usernames in multiline JSON",
 		},
+		{
+			line1: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
+			line2: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
+			name:  "Redact 'key' values found in Ceph auth lists",
+		},
 	}
 
 	for _, l := range doubleLines {

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -816,6 +816,53 @@ func Test_Redactors(t *testing.T) {
 		  "status": {
 			"loadBalancer": {}
 		  }
+		},
+		{
+			"auth_dump": [
+				{
+					"entity": "osd.0",
+					"key": "ABCxyzABCxyz/foo/bar123xyz/BAZAABBCCDD==",
+					"caps": {
+						"mgr": "allow profile osd",
+						"mon": "allow profile osd",
+						"osd": "allow *"
+					}
+				},
+				{
+					"entity": "client.admin",
+					"key": "ABCxyzABCxyz/foo/bar123xyz/BAZAABBCCDD==",
+					"caps": {
+						"mds": "allow *",
+						"mgr": "allow *",
+						"mon": "allow *",
+						"osd": "allow *"
+					}
+				},
+				{
+					"entity": "client.bootstrap-mds",
+					"key": "ABCxyzABCxyz/foo/bar123xyz/BAZAABBCCDD==",
+					"caps": {
+						"mon": "allow profile bootstrap-mds"
+					}
+				},
+				{
+					"entity": "client.rgw.rook.ceph.store.a",
+					"key": "ABCxyzABCxyz/foo/bar123xyz/BAZAABBCCDD==",
+					"caps": {
+						"mon": "allow rw",
+						"osd": "allow rwx"
+					}
+				},
+				{
+					"entity": "mgr.a",
+					"key": "ABCxyzABCxyz/foo/bar123xyz/BAZAABBCCDD==",
+					"caps": {
+						"mds": "allow *",
+						"mon": "allow profile mgr",
+						"osd": "allow *"
+					}
+				}
+			]
 		}
 	  ]`
 
@@ -1624,11 +1671,58 @@ func Test_Redactors(t *testing.T) {
 		  "status": {
 			"loadBalancer": {}
 		  }
+		},
+		{
+			"auth_dump": [
+				{
+					"entity": "osd.0",
+					"key": "***HIDDEN***",
+					"caps": {
+						"mgr": "allow profile osd",
+						"mon": "allow profile osd",
+						"osd": "allow *"
+					}
+				},
+				{
+					"entity": "client.admin",
+					"key": "***HIDDEN***",
+					"caps": {
+						"mds": "allow *",
+						"mgr": "allow *",
+						"mon": "allow *",
+						"osd": "allow *"
+					}
+				},
+				{
+					"entity": "client.bootstrap-mds",
+					"key": "***HIDDEN***",
+					"caps": {
+						"mon": "allow profile bootstrap-mds"
+					}
+				},
+				{
+					"entity": "client.rgw.rook.ceph.store.a",
+					"key": "***HIDDEN***",
+					"caps": {
+						"mon": "allow rw",
+						"osd": "allow rwx"
+					}
+				},
+				{
+					"entity": "mgr.a",
+					"key": "***HIDDEN***",
+					"caps": {
+						"mds": "allow *",
+						"mon": "allow profile mgr",
+						"osd": "allow *"
+					}
+				}
+			]
 		}
 	  ]`
 
-	wantRedactionsLen := 39
-	wantRedactionsCount := 25
+	wantRedactionsLen := 44
+	wantRedactionsCount := 26
 
 	t.Run("test default redactors", func(t *testing.T) {
 		req := require.New(t)


### PR DESCRIPTION
[SC-37299](https://app.shortcut.com/replicated/story/37229/mask-ceph-secrets-in-support-bundles)

Add automatic redactors for Ceph auth_dump json which includes auth keys.