### PR TITLE
include the db connection error message with the outcome

### DIFF
--- a/pkg/analyze/postgres.go
+++ b/pkg/analyze/postgres.go
@@ -39,12 +39,6 @@ func analyzePostgres(analyzer *troubleshootv1beta2.DatabaseAnalyze, getCollected
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/postgres-analyze.svg",
 	}
 
-	if databaseConnection.Error != "" {
-		result.IsFail = true
-		result.Message = databaseConnection.Error
-		return result, nil
-	}
-
 	for _, outcome := range analyzer.Outcomes {
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -61,8 +55,14 @@ func analyzePostgres(analyzer *troubleshootv1beta2.DatabaseAnalyze, getCollected
 			}
 
 			if isMatch {
+
+				if databaseConnection.Error != "" {
+					result.Message = outcome.Fail.Message + " " + databaseConnection.Error
+				} else {
+					result.Message = outcome.Fail.Message
+				}
+
 				result.IsFail = true
-				result.Message = outcome.Fail.Message
 				result.URI = outcome.Fail.URI
 
 				return result, nil


### PR DESCRIPTION
make sure to return `outcome.Message` even if the database connection fails, and include the connection error message with the outcome