### PR TITLE
Add HostAnalyzers to Support Bundles

### DIFF
--- a/pkg/analyze/download.go
+++ b/pkg/analyze/download.go
@@ -22,7 +22,7 @@ type fileContentProvider struct {
 }
 
 // Analyze local will analyze a locally available (already downloaded) bundle
-func AnalyzeLocal(localBundlePath string, analyzers []*troubleshootv1beta2.Analyze) ([]*AnalyzeResult, error) {
+func AnalyzeLocal(localBundlePath string, analyzers []*troubleshootv1beta2.Analyze, hostAnalyzers []*troubleshootv1beta2.HostAnalyze) ([]*AnalyzeResult, error) {
 	rootDir, err := FindBundleRootDir(localBundlePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find root dir")
@@ -44,6 +44,11 @@ func AnalyzeLocal(localBundlePath string, analyzers []*troubleshootv1beta2.Analy
 				analyzeResults = append(analyzeResults, r)
 			}
 		}
+	}
+
+	for _, hostAnalyzer := range hostAnalyzers {
+		analyzeResult := HostAnalyze(hostAnalyzer, fcp.getFileContents, fcp.getChildFileContents)
+		analyzeResults = append(analyzeResults, analyzeResult...)
 	}
 
 	return analyzeResults, nil
@@ -71,22 +76,24 @@ func DownloadAndAnalyze(bundleURL string, analyzersSpec string) ([]*AnalyzeResul
 	}
 
 	analyzers := []*troubleshootv1beta2.Analyze{}
+	hostAnalyzers := []*troubleshootv1beta2.HostAnalyze{}
 
 	if analyzersSpec == "" {
-		defaultAnalyzers, err := getDefaultAnalyzers()
+		defaultAnalyzers, _, err := getDefaultAnalyzers()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get default analyzers")
 		}
 		analyzers = defaultAnalyzers
 	} else {
-		parsedAnalyzers, err := parseAnalyzers(analyzersSpec)
+		parsedAnalyzers, parsedHostAnalyzers, err := parseAnalyzers(analyzersSpec)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse analyzers")
 		}
 		analyzers = parsedAnalyzers
+		hostAnalyzers = parsedHostAnalyzers
 	}
 
-	return AnalyzeLocal(rootDir, analyzers)
+	return AnalyzeLocal(rootDir, analyzers, hostAnalyzers)
 }
 
 func downloadTroubleshootBundle(bundleURL string, destDir string) error {
@@ -174,33 +181,33 @@ func ExtractTroubleshootBundle(reader io.Reader, destDir string) error {
 	return nil
 }
 
-func parseAnalyzers(spec string) ([]*troubleshootv1beta2.Analyze, error) {
+func parseAnalyzers(spec string) ([]*troubleshootv1beta2.Analyze, []*troubleshootv1beta2.HostAnalyze, error) {
 	troubleshootscheme.AddToScheme(scheme.Scheme)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
 	convertedSpec, err := docrewrite.ConvertToV1Beta2([]byte(spec))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert to v1beta2")
+		return nil, nil, errors.Wrap(err, "failed to convert to v1beta2")
 	}
 
 	obj, gvk, err := decode(convertedSpec, nil, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode analyzers")
+		return nil, nil, errors.Wrap(err, "failed to decode analyzers")
 	}
 
 	// SupportBundle overwrites Analyzer if defined
 	if gvk.Group == "troubleshoot.sh" && gvk.Version == "v1beta2" && gvk.Kind == "SupportBundle" {
 		supportBundle := obj.(*troubleshootv1beta2.SupportBundle)
-		return supportBundle.Spec.Analyzers, nil
+		return supportBundle.Spec.Analyzers, supportBundle.Spec.HostAnalyzers, nil
 	} else if gvk.Group == "troubleshoot.sh" && gvk.Version == "v1beta2" && gvk.Kind == "Analyzer" {
 		analyzer := obj.(*troubleshootv1beta2.Analyzer)
-		return analyzer.Spec.Analyzers, nil
+		return analyzer.Spec.Analyzers, analyzer.Spec.HostAnalyzers, nil
 	}
 
-	return nil, errors.Errorf("invalid gvk %q", gvk)
+	return nil, nil, errors.Errorf("invalid gvk %q", gvk)
 }
 
-func getDefaultAnalyzers() ([]*troubleshootv1beta2.Analyze, error) {
+func getDefaultAnalyzers() ([]*troubleshootv1beta2.Analyze, []*troubleshootv1beta2.HostAnalyze, error) {
 	spec := `apiVersion: troubleshoot.sh/v1beta2
 kind: Analyzer
 metadata:

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_types.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_types.go
@@ -22,7 +22,8 @@ import (
 
 // AnalyzerSpec defines the desired state of Analyzer
 type AnalyzerSpec struct {
-	Analyzers []*Analyze `json:"analyzers,omitempty"`
+	Analyzers     []*Analyze     `json:"analyzers,omitempty"`
+	HostAnalyzers []*HostAnalyze `json:"hostAnalyzers,omitempty" yaml:"hostAnalyzers,omitempty"`
 }
 
 // AnalyzerStatus defines the observed state of Analyzer

--- a/pkg/apis/troubleshoot/v1beta2/supportbundle_types.go
+++ b/pkg/apis/troubleshoot/v1beta2/supportbundle_types.go
@@ -26,6 +26,7 @@ type SupportBundleSpec struct {
 	Collectors      []*Collect         `json:"collectors,omitempty" yaml:"collectors,omitempty"`
 	HostCollectors  []*HostCollect     `json:"hostCollectors,omitempty" yaml:"hostCollectors,omitempty"`
 	Analyzers       []*Analyze         `json:"analyzers,omitempty" yaml:"analyzers,omitempty"`
+	HostAnalyzers   []*HostAnalyze     `json:"hostAnalyzers,omitempty" yaml:"hostAnalyzers,omitempty"`
 }
 
 // SupportBundleStatus defines the observed state of SupportBundle

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -201,10 +201,10 @@ func ProcessSupportBundleAfterCollection(spec *troubleshootv1beta2.SupportBundle
 // AnalyzeSupportBundle performs analysis on a support bundle using the support bundle spec and an already unpacked support
 // bundle on disk
 func AnalyzeSupportBundle(spec *troubleshootv1beta2.SupportBundleSpec, tmpDir string) ([]*analyzer.AnalyzeResult, error) {
-	if len(spec.Analyzers) == 0 {
+	if len(spec.Analyzers) == 0 && len(spec.HostAnalyzers) == 0 {
 		return nil, nil
 	}
-	analyzeResults, err := analyzer.AnalyzeLocal(tmpDir, spec.Analyzers)
+	analyzeResults, err := analyzer.AnalyzeLocal(tmpDir, spec.Analyzers, spec.HostAnalyzers)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to analyze support bundle")
 	}


### PR DESCRIPTION
[SC-48402](https://app.shortcut.com/replicated/story/48402/add-hostanalyzers-to-support-bundles)

Example:

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: modules
spec:
  hostCollectors:
    - cpu: {}
  hostAnalyzers:
    - cpu:
        outcomes:
          - fail:
              when: "physical < 8"
              message: System requires at least 8 physical cores
  ```