### PR TITLE
fix: use kube-aware version selector for crs collector

### DIFF
--- a/pkg/collect/cluster_resources_test.go
+++ b/pkg/collect/cluster_resources_test.go
@@ -1,0 +1,14 @@
+package collect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SelectCRDVersionByPriority(t *testing.T) {
+	assert.Equal(t, "v1alpha3", selectCRDVersionByPriority([]string{"v1alpha2", "v1alpha3"}))
+	assert.Equal(t, "v1alpha3", selectCRDVersionByPriority([]string{"v1alpha3", "v1alpha2"}))
+	assert.Equal(t, "v1", selectCRDVersionByPriority([]string{"v1alpha2", "v1alpha3", "v1"}))
+	assert.Equal(t, "v1", selectCRDVersionByPriority([]string{"v1", "v1alpha2", "v1alpha3"}))
+}


### PR DESCRIPTION
Fix the way of selecting the API version of CRDs when a CRD contains multiple versions. This will ensure that the "latest" version is stored in the bundle.