### PR TITLE
Always attempt to generate a Support Bundle when Host Collectors exist

### DIFF
--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -42,10 +42,10 @@ func runHostCollectors(hostCollectors []*troubleshootv1beta2.HostCollect, additi
 			continue
 		}
 
-		opts.ProgressChan <- fmt.Sprintf("[%s] Running collector...", collector.Title())
+		opts.ProgressChan <- fmt.Sprintf("[%s] Running host collector...", collector.Title())
 		result, err := collector.Collect(opts.ProgressChan)
 		if err != nil {
-			opts.ProgressChan <- errors.Errorf("failed to run collector: %s: %v", collector.Title(), err)
+			opts.ProgressChan <- errors.Errorf("failed to run host collector: %s: %v", collector.Title(), err)
 		}
 		for k, v := range result {
 			allCollectedData[k] = v


### PR DESCRIPTION
Host Collectors have been added to Support Bundles, so that a method of debugging cluster down scenarioes as well as other use cases would be possible. Right now support bundle generation will always fail if the K8s cluster cannot be reached