### PR TITLE
Allow custom messages to be passed if a deployment/statefulset is absent

### DIFF
--- a/pkg/analyze/common_status.go
+++ b/pkg/analyze/common_status.go
@@ -59,7 +59,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 
 			if exists == false  && outcome.Warn.When != "absent" {
 				result.IsFail = true
-				result.Message = fmt.Sprintf("The %s %s was not found", resourceType, name)
+				result.Message = fmt.Sprintf("The %s %q was not found", resourceType, name)
 				result.URI = outcome.Fail.URI
 				return result, nil
 			}
@@ -95,7 +95,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 
 			if exists == false  && outcome.Pass.When != "absent" {
 				result.IsFail = true
-				result.Message = fmt.Sprintf("The %s %s was not found", resourceType, name)
+				result.Message = fmt.Sprintf("The %s %q was not found", resourceType, name)
 				result.URI = outcome.Fail.URI
 				return result, nil
 			}

--- a/pkg/analyze/common_status.go
+++ b/pkg/analyze/common_status.go
@@ -21,7 +21,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 		if outcome.Fail != nil {
 
 			// if we're not checking that something is absent but it is, we should throw a default but meaningful error.
-			if exists == false  && outcome.Fail.When != "absent" {
+			if exists == false && outcome.Fail.When != "absent" {
 				result.IsFail = true
 				result.Message = fmt.Sprintf("The %s %q was not found", resourceType, name)
 				result.URI = outcome.Fail.URI
@@ -36,11 +36,15 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 				return result, nil
 			}
 
-			if outcome.Fail.When == "absent" && exists == false {
-				result.IsFail = true
-				result.Message = outcome.Fail.Message
-				result.URI = outcome.Fail.URI
-				return result, nil
+			if  outcome.Fail.When == "absent"  {
+				if exists == false {
+					result.IsFail = true
+					result.Message = outcome.Fail.Message
+					result.URI = outcome.Fail.URI
+					return result, nil
+				} else {
+					continue
+				}
 			}
 
 			match, err := compareActualToWhen(outcome.Fail.When, readyReplicas, exists)
@@ -57,7 +61,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 			}
 		} else if outcome.Warn != nil {
 
-			if exists == false  && outcome.Warn.When != "absent" {
+			if exists == false && outcome.Warn.When != "absent" {
 				result.IsFail = true
 				result.Message = fmt.Sprintf("The %s %q was not found", resourceType, name)
 				result.URI = outcome.Fail.URI
@@ -72,11 +76,15 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 				return result, nil
 			}
 
-			if outcome.Warn.When == "absent" && exists == false {
-				result.IsWarn = true
-				result.Message = outcome.Warn.Message
-				result.URI = outcome.Warn.URI
-				return result, nil
+			if outcome.Warn.When == "absent" {
+				if exists == false {
+					result.IsWarn = true
+					result.Message = outcome.Warn.Message
+					result.URI = outcome.Warn.URI
+					return result, nil
+				} else {
+					continue
+				}
 			}
 
 			match, err := compareActualToWhen(outcome.Warn.When, readyReplicas, exists)
@@ -93,7 +101,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 			}
 		} else if outcome.Pass != nil {
 
-			if exists == false  && outcome.Pass.When != "absent" {
+			if exists == false && outcome.Pass.When != "absent" {
 				result.IsFail = true
 				result.Message = fmt.Sprintf("The %s %q was not found", resourceType, name)
 				result.URI = outcome.Fail.URI
@@ -108,11 +116,15 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 				return result, nil
 			}
 
-			if outcome.Pass.When == "absent" && exists == false {
-				result.IsPass = true
-				result.Message = outcome.Pass.Message
-				result.URI = outcome.Pass.URI
-				return result, nil
+			if outcome.Pass.When == "absent" {
+				if exists == false {
+					result.IsPass = true
+					result.Message = outcome.Pass.Message
+					result.URI = outcome.Pass.URI
+					return result, nil
+				} else {
+					continue
+				}
 			}
 
 			match, err := compareActualToWhen(outcome.Pass.When, readyReplicas, exists)

--- a/pkg/analyze/common_status.go
+++ b/pkg/analyze/common_status.go
@@ -23,7 +23,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey 
 			// if we're not checking that something is absent but it is, we should throw a default but meaningful error.
 			if exists == false  && outcome.Fail.When != "absent" {
 				result.IsFail = true
-				result.Message = fmt.Sprintf("The %s %s was not found", resourceType, name)
+				result.Message = fmt.Sprintf("The %s %q was not found", resourceType, name)
 				result.URI = outcome.Fail.URI
 				return result, nil
 			}

--- a/pkg/analyze/common_status.go
+++ b/pkg/analyze/common_status.go
@@ -3,21 +3,31 @@ package analyzer
 import (
 	"strconv"
 	"strings"
-
+	"fmt"
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
-func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string, iconURI string, readyReplicas int) (*AnalyzeResult, error) {
+func commonStatus(outcomes []*troubleshootv1beta2.Outcome, name string, iconKey string, iconURI string, readyReplicas int, exists bool, resourceType string) (*AnalyzeResult, error) {
 	result := &AnalyzeResult{
-		Title:   title,
+		Title:   fmt.Sprintf("%s Status", name),
 		IconKey: iconKey,
 		IconURI: iconURI,
 	}
 
 	// ordering from the spec is important, the first one that matches returns
 	for _, outcome := range outcomes {
+
 		if outcome.Fail != nil {
+
+			// if we're not checking that something is absent but it is, we should throw a default but meaningful error.
+			if exists == false  && outcome.Fail.When != "absent" {
+				result.IsFail = true
+				result.Message = fmt.Sprintf("The %s %s was not found", resourceType, name)
+				result.URI = outcome.Fail.URI
+				return result, nil
+			}
+
 			if outcome.Fail.When == "" {
 				result.IsFail = true
 				result.Message = outcome.Fail.Message
@@ -26,7 +36,14 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string
 				return result, nil
 			}
 
-			match, err := compareActualToWhen(outcome.Fail.When, readyReplicas)
+			if outcome.Fail.When == "absent" && exists == false {
+				result.IsFail = true
+				result.Message = outcome.Fail.Message
+				result.URI = outcome.Fail.URI
+				return result, nil
+			}
+
+			match, err := compareActualToWhen(outcome.Fail.When, readyReplicas, exists)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse fail range")
 			}
@@ -39,6 +56,14 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string
 				return result, nil
 			}
 		} else if outcome.Warn != nil {
+
+			if exists == false  && outcome.Warn.When != "absent" {
+				result.IsFail = true
+				result.Message = fmt.Sprintf("The %s %s was not found", resourceType, name)
+				result.URI = outcome.Fail.URI
+				return result, nil
+			}
+
 			if outcome.Warn.When == "" {
 				result.IsWarn = true
 				result.Message = outcome.Warn.Message
@@ -47,7 +72,14 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string
 				return result, nil
 			}
 
-			match, err := compareActualToWhen(outcome.Warn.When, readyReplicas)
+			if outcome.Warn.When == "absent" && exists == false {
+				result.IsWarn = true
+				result.Message = outcome.Warn.Message
+				result.URI = outcome.Warn.URI
+				return result, nil
+			}
+
+			match, err := compareActualToWhen(outcome.Warn.When, readyReplicas, exists)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse warn range")
 			}
@@ -60,6 +92,14 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string
 				return result, nil
 			}
 		} else if outcome.Pass != nil {
+
+			if exists == false  && outcome.Pass.When != "absent" {
+				result.IsFail = true
+				result.Message = fmt.Sprintf("The %s %s was not found", resourceType, name)
+				result.URI = outcome.Fail.URI
+				return result, nil
+			}
+
 			if outcome.Pass.When == "" {
 				result.IsPass = true
 				result.Message = outcome.Pass.Message
@@ -68,7 +108,14 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string
 				return result, nil
 			}
 
-			match, err := compareActualToWhen(outcome.Pass.When, readyReplicas)
+			if outcome.Pass.When == "absent" && exists == false {
+				result.IsPass = true
+				result.Message = outcome.Pass.Message
+				result.URI = outcome.Pass.URI
+				return result, nil
+			}
+
+			match, err := compareActualToWhen(outcome.Pass.When, readyReplicas, exists)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to parse pass range")
 			}
@@ -86,7 +133,7 @@ func commonStatus(outcomes []*troubleshootv1beta2.Outcome, title, iconKey string
 	return result, nil
 }
 
-func compareActualToWhen(when string, actual int) (bool, error) {
+func compareActualToWhen(when string, actual int, exists bool) (bool, error) {
 	parts := strings.Split(strings.TrimSpace(when), " ")
 
 	// we can make this a lot more flexible

--- a/pkg/analyze/deployment_status.go
+++ b/pkg/analyze/deployment_status.go
@@ -26,6 +26,9 @@ func analyzeOneDeploymentStatus(analyzer *troubleshootv1beta2.DeploymentStatus, 
 
 	var result *AnalyzeResult
 	for _, collected := range files { // only 1 file here
+		var exists bool = true
+		var readyReplicas int
+
 		var deployments appsv1.DeploymentList
 		if err := json.Unmarshal(collected, &deployments); err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal deployment list")
@@ -39,19 +42,15 @@ func analyzeOneDeploymentStatus(analyzer *troubleshootv1beta2.DeploymentStatus, 
 		}
 
 		if status == nil {
-			// there's not an error, but maybe the requested deployment is not even deployed
-			result = &AnalyzeResult{
-				Title:   fmt.Sprintf("%s Deployment Status", analyzer.Name),
-				IconKey: "kubernetes_deployment_status",
-				IconURI: "https://troubleshoot.sh/images/analyzer-icons/deployment-status.svg?w=17&h=17",
-				IsFail:  true,
-				Message: fmt.Sprintf("The deployment %q was not found", analyzer.Name),
-			}
+			exists = false
+			readyReplicas = 0
 		} else {
-			result, err = commonStatus(analyzer.Outcomes, fmt.Sprintf("%s Status", analyzer.Name), "kubernetes_deployment_status", "https://troubleshoot.sh/images/analyzer-icons/deployment-status.svg?w=17&h=17", int(status.ReadyReplicas))
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to process status")
-			}
+			readyReplicas = int(status.ReadyReplicas)
+		}
+
+		result, err = commonStatus(analyzer.Outcomes, analyzer.Name, "kubernetes_deployment_status", "https://troubleshoot.sh/images/analyzer-icons/deployment-status.svg?w=17&h=17", readyReplicas, exists, "deployment")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to process status")
 		}
 	}
 

--- a/pkg/analyze/deployment_status_test.go
+++ b/pkg/analyze/deployment_status_test.go
@@ -16,6 +16,37 @@ func Test_deploymentStatus(t *testing.T) {
 		files        map[string][]byte
 	}{
 		{
+			name: "1/1, fail when absent",
+			analyzer: troubleshootv1beta2.DeploymentStatus{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When: "absent",
+							Message: "fail",
+						},
+					},
+				},
+				Namespace: "default",
+				Name: "nonexistant-deployment",
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass: false,
+					IsWarn: false,
+					IsFail: true,
+					Title: "nonexistant-deployment Status",
+					Message: "fail",
+					IconKey: "kubernetes_deployment_status",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/deployment-status.svg?w=17&h=17",
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/deployments/default.json":     []byte(defaultDeployments),
+				"cluster-resources/deployments/monitoring.json":  []byte(monitoringDeployments),
+				"cluster-resources/deployments/kube-system.json": []byte(kubeSystemDeployments),
+			},
+		},
+		{
 			name: "1/1, pass when = 1",
 			analyzer: troubleshootv1beta2.DeploymentStatus{
 				Outcomes: []*troubleshootv1beta2.Outcome{

--- a/pkg/analyze/deployment_status_test.go
+++ b/pkg/analyze/deployment_status_test.go
@@ -25,6 +25,12 @@ func Test_deploymentStatus(t *testing.T) {
 							Message: "fail",
 						},
 					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "= 1",
+							Message: "pass",
+						},
+					},
 				},
 				Namespace: "default",
 				Name: "nonexistant-deployment",
@@ -50,6 +56,12 @@ func Test_deploymentStatus(t *testing.T) {
 			name: "1/1, pass when = 1",
 			analyzer: troubleshootv1beta2.DeploymentStatus{
 				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When: "absent",
+							Message: "fail",
+						},
+					},
 					{
 						Pass: &troubleshootv1beta2.SingleOutcome{
 							When:    "= 1",
@@ -87,6 +99,12 @@ func Test_deploymentStatus(t *testing.T) {
 			analyzer: troubleshootv1beta2.DeploymentStatus{
 				Outcomes: []*troubleshootv1beta2.Outcome{
 					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When: "absent",
+							Message: "fail",
+						},
+					},
+					{
 						Pass: &troubleshootv1beta2.SingleOutcome{
 							When:    "= 2",
 							Message: "pass",
@@ -122,6 +140,12 @@ func Test_deploymentStatus(t *testing.T) {
 			name: "1/1, pass when >= 2, warn when = 1, fail when 0",
 			analyzer: troubleshootv1beta2.DeploymentStatus{
 				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When: "absent",
+							Message: "fail",
+						},
+					},
 					{
 						Pass: &troubleshootv1beta2.SingleOutcome{
 							When:    ">= 2",

--- a/pkg/analyze/statefulset_status_test.go
+++ b/pkg/analyze/statefulset_status_test.go
@@ -25,6 +25,12 @@ func Test_analyzeStatefulsetStatus(t *testing.T) {
 							Message: "fail",
 						},
 					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "= 1",
+							Message: "pass",
+						},
+					},
 				},
 				Namespace: "default",
 				Name: "nonexistant",

--- a/pkg/analyze/statefulset_status_test.go
+++ b/pkg/analyze/statefulset_status_test.go
@@ -16,6 +16,35 @@ func Test_analyzeStatefulsetStatus(t *testing.T) {
 		files        map[string][]byte
 	}{
 		{
+			name: "fail when absent",
+			analyzer: troubleshootv1beta2.StatefulsetStatus{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When: "absent",
+							Message: "fail",
+						},
+					},
+				},
+				Namespace: "default",
+				Name: "nonexistant",
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass: false,
+					IsWarn: false,
+					IsFail: true,
+					Title: "nonexistant Status",
+					Message: "fail",
+					IconKey: "kubernetes_statefulset_status",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/statefulset-status.svg?w=23&h=14",
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/statefulsets/default.json":    []byte(defaultStatefulSets),
+			},
+		},
+		{
 			name:     "analyze all statefulsets",
 			analyzer: troubleshootv1beta2.StatefulsetStatus{},
 			expectResult: []*AnalyzeResult{


### PR DESCRIPTION
This is an attempt to address internal shortcut 49195. 

We would like to be able to add custom messages when a deployment (e.g EKCO) is absent from the cluster to better explain how to resolve it's absence.

This change introduces a new special keyword "absent" that can be used in the "When" statement in a deploymentStatus or statefulSetStatus analyzer to allow absent deployments and statefulsets to be handled with custom messages.

for example:
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: example
spec:
  analyzers:
    - deploymentStatus:
        name: ekc-operator
        namespace: kurl
        outcomes:
          - fail:
              when: "absent"
              message: "The ekc-operator deployment is not instaled. Without it, this cluster may not behave as intended"
```

While the change acheives this objective, I do have some reservations that I'd like to discuss:

- currently the `when: "absent"` statement would need to be the first outcome for an analyzer due to how I'm catching it. comments on how I can improve this would be greatly appreciated.
- I'm currently having to repeat a block to allow for the default `the <resource> <name> does not exist` for each warn|pass|fail outcome when we aren't specifically looking for the absence of a deployment. I'd like to reduce this repitition if possible.