### PR TITLE
Collect networkPolicies

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -151,9 +151,9 @@ func ClusterResources(c *Collector, clusterResourcesCollector *troubleshootv1bet
 	// network policy
 	networkPolicy, networkPolicyErrors := networkPolicy(ctx, client, namespaceNames)
 	for k, v := range networkPolicy {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/networkPolicy", k), bytes.NewBuffer(v))
+		output.SaveResult(c.BundlePath, path.Join("cluster-resources/network-policy", k), bytes.NewBuffer(v))
 	}
-	output.SaveResult(c.BundlePath, "cluster-resources/networkPolicy-errors.json", marshalErrors(networkPolicyErrors))
+	output.SaveResult(c.BundlePath, "cluster-resources/network-policy-errors.json", marshalErrors(networkPolicyErrors))
 
 
 	// storage classes


### PR DESCRIPTION
This addresses internal shortcut 53924, and gives us some visibility to networkPolicies deployed in clusters.

The usefullness of this may be improved upon further with the addition of some kind of ip address mapping rather than opaque obfuscation.

Signed-off-by: Dan Jones <danj@replicated.com>