### PR TITLE
EL 20220901 - Implement new type  for #682

### DIFF
--- a/config/samples/troubleshoot_v1beta2_collector.yaml
+++ b/config/samples/troubleshoot_v1beta2_collector.yaml
@@ -3,6 +3,7 @@ kind: Collector
 metadata:
   name: collector-sample
 spec:
+  uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml
   collectors:
     - clusterInfo: {}
     - clusterResources: {}

--- a/pkg/apis/troubleshoot/v1beta2/supportbundle_types.go
+++ b/pkg/apis/troubleshoot/v1beta2/supportbundle_types.go
@@ -27,6 +27,13 @@ type SupportBundleSpec struct {
 	HostCollectors  []*HostCollect     `json:"hostCollectors,omitempty" yaml:"hostCollectors,omitempty"`
 	Analyzers       []*Analyze         `json:"analyzers,omitempty" yaml:"analyzers,omitempty"`
 	HostAnalyzers   []*HostAnalyze     `json:"hostAnalyzers,omitempty" yaml:"hostAnalyzers,omitempty"`
+	// Uri defines the location of the spec file that needs to be used. This is optional and can be
+	// either a secret, url or spec yaml file.
+	// When presented with a spec document that contains a URI, if that spec is one of the specs provided
+	// on the command line or initial call to Troubleshoot, attempt to collect a replacement spec from that URI.
+	// If successful, it will replace the entire spec with the one downloaded.
+	// If unsuccessful, log the error and use the spec provided.
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 }
 
 // SupportBundleStatus defines the observed state of SupportBundle

--- a/pkg/apis/troubleshoot/v1beta2/supportbundle_types.go
+++ b/pkg/apis/troubleshoot/v1beta2/supportbundle_types.go
@@ -27,12 +27,7 @@ type SupportBundleSpec struct {
 	HostCollectors  []*HostCollect     `json:"hostCollectors,omitempty" yaml:"hostCollectors,omitempty"`
 	Analyzers       []*Analyze         `json:"analyzers,omitempty" yaml:"analyzers,omitempty"`
 	HostAnalyzers   []*HostAnalyze     `json:"hostAnalyzers,omitempty" yaml:"hostAnalyzers,omitempty"`
-	// Uri defines the location of the spec file that needs to be used. This is optional and can be
-	// either a secret, url or spec yaml file.
-	// When presented with a spec document that contains a URI, if that spec is one of the specs provided
-	// on the command line or initial call to Troubleshoot, attempt to collect a replacement spec from that URI.
-	// If successful, it will replace the entire spec with the one downloaded.
-	// If unsuccessful, log the error and use the spec provided.
+	// URI optionally defines a location which is the source of this spec to allow updating of the spec at runtime
 	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 }
 


### PR DESCRIPTION
This PR implements a new type for Troubleshoot as per issue #682 

Added are:

- A new type: `uri` to specify a spec located on web, a secret in a cluster or a spec yaml file
- An updated sample spec containing the new uri field

Actual functionality will be built into Troubleshoot with #694 

! to implement in a new build, run `make schemas` before running `make support-bundle`.

While automated test options are not yet built into to check spec validity et al, I have manually tested this new version/PR with the following current and older versions of Troubleshoot:

v0.34.0 (May 2022 - arm64 & amd64) 
v0.28.1 (January 2022 - arm64 & amd64)
v0.13.14 (September 2021 - amd64) 

And a 'new' spec to test with:

```
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: default
spec:
  uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml
  collectors:
    - clusterInfo: {}
    - clusterResources: {}
  analyzers:
    - cephStatus: {}
    - longhorn: {}
```

