### PR TITLE
`uri:` implementation

### DIFF
--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -173,7 +173,7 @@ func CollectSupportBundleFromSpec(spec *troubleshootv1beta2.SupportBundleSpec, a
 // collectors, analyzers and after collection steps. Input arguments are the URIs of the support bundle and redactor specs.
 // The support bundle is archived in the OS temp folder (os.TempDir()).
 func CollectSupportBundleFromURI(specURI string, redactorURIs []string, opts SupportBundleCreateOpts) (*SupportBundleResponse, error) {
-	supportbundle, err := GetSupportBundleFromURI(specURI)
+	supportBundle, err := GetSupportBundleFromURI(specURI)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not bundle from URI")
 	}
@@ -190,7 +190,7 @@ func CollectSupportBundleFromURI(specURI string, redactorURIs []string, opts Sup
 		}
 	}
 
-	return CollectSupportBundleFromSpec(&supportbundle.Spec, additionalRedactors, opts)
+	return CollectSupportBundleFromSpec(&supportBundle.Spec, additionalRedactors, opts)
 }
 
 // ProcessSupportBundleAfterCollection performs the after collection actions, like Callbacks and sending the archive to a remote server.

--- a/pkg/supportbundle/test/bad-upstream-uri-spec.yaml
+++ b/pkg/supportbundle/test/bad-upstream-uri-spec.yaml
@@ -1,0 +1,12 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: default
+spec:
+  uri: https://raw.githubusercontent.com/adamancini/troubleshoot-specs/main/host/bad-spec.yaml
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+  analyzers:
+    - cephStatus: {}
+    - longhorn: {}

--- a/pkg/supportbundle/test/bad-uri-spec.yaml
+++ b/pkg/supportbundle/test/bad-uri-spec.yaml
@@ -1,0 +1,12 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: default
+spec:
+  uri: https://githubusercontent.com/adamancini/troubleshoot-specs/main/host/cluster-down
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+  analyzers:
+    - cephStatus: {}
+    - longhorn: {}

--- a/pkg/supportbundle/test/uri-spec.yaml
+++ b/pkg/supportbundle/test/uri-spec.yaml
@@ -1,0 +1,12 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: default
+spec:
+  uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/host/cluster-down.yaml
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+  analyzers:
+    - cephStatus: {}
+    - longhorn: {}


### PR DESCRIPTION
if a spec is provided that specifies a `uri:` field, get the referenced spec from upstream and use it.  if getting the upstream spec fails, fall back to what is provided.

avoid a recursion loop by adding a `recurse` argument to `GetSupportBundleFromURI()` and `ParseSupportBundleFromDoc()` so that it only performs this operation once.