### PR TITLE
use push-only token

### DIFF
--- a/.github/workflows/pr-license-scan.yaml
+++ b/.github/workflows/pr-license-scan.yaml
@@ -6,15 +6,14 @@ on:
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v3
       - name: "Run FOSSA Analyze" 
         uses: fossas/fossa-action@main
         with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
+          api-key: cf2d0196f5b5bb2fd245c559af8766d8 # push-only token, safe to expose
       - name: "Run FOSSA Test"
         uses: fossas/fossa-action@main
         with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
+          api-key: cf2d0196f5b5bb2fd245c559af8766d8 # push-only token, safe to expose
           run-tests: true


### PR DESCRIPTION
Change the PR integration to use a push-only token on recommendation from FOSSA team. This token can be safely exposed and does not need to be kept in a secret, simplifying the pipeline logic.