### PR TITLE
Wrap more information url in the analyser message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 bin
+.DS_Store
 
 # Test binary, build with `go test -c`
 *.test
@@ -34,3 +35,6 @@ workspace.*
 
 cosign.key
 sbom/
+
+# Ignore local pre-commit config
+.pre-commit-config.yaml

--- a/cmd/troubleshoot/cli/interactive_results.go
+++ b/cmd/troubleshoot/cli/interactive_results.go
@@ -204,10 +204,11 @@ func drawDetails(analysisResult *analyzerunner.AnalyzeResult) {
 		uri := widgets.NewParagraph()
 		uri.Text = fmt.Sprintf("For more information: %s", analysisResult.URI)
 		uri.Border = false
-		height = estimateNumberOfLines(uri.Text, termWidth/2)
+		// For long urls that lead to wrapping text, make the rectangle bigger by
+		// increasing the calculated height by 2
+		height = estimateNumberOfLines(uri.Text, termWidth/2) + 2
 		uri.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
 		ui.Render(uri)
-		currentTop = currentTop + height + 1
 	}
 }
 

--- a/examples/support-bundle/sample-supportbundle.yaml
+++ b/examples/support-bundle/sample-supportbundle.yaml
@@ -30,6 +30,7 @@ spec:
         outcomes:
           - fail:
               message: The Rook CRD was not found in the cluster.
+              uri: https://kurl.sh/docs/add-ons/rook/some/path/that/does/not/exist/for/the/sake/of/having/a/very/long/url.md
           - pass:
               message: Rook is installed and available.
     - containerRuntime:


### PR DESCRIPTION
The height of the rectangle where we draw the text needs to be large enough to accommodate the wrapped text. See illustration below

With height = 2
<img width="1912" alt="Screenshot 2022-10-05 at 11 57 18" src="https://user-images.githubusercontent.com/681087/194044931-7f3679b3-21ee-4a12-bb64-020950d3a8f1.png">

With height = 4
<img width="1912" alt="Screenshot 2022-10-05 at 11 58 21" src="https://user-images.githubusercontent.com/681087/194045100-cff473c5-379c-402e-9c74-c512ab98647f.png">

PS: The changes in the PR does not have the text drawn within a border. I added that for testing purposes.
