### PR TITLE
Supports the Kubernetes distribution analyzer identifying VMware Tanzu

### DIFF
--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -59,7 +59,7 @@ func CheckOpenShift(foundProviders *providers, apiResources []*metav1.APIResourc
 
 func CheckTanzu(foundProviders *providers, apiResources []*metav1.APIResourceList, provider string) string {
 	for _, resource := range apiResources {
-		if strings.HasPrefix(resource.GroupVersion, "packaging.carvel.dev/") {
+		if strings.HasPrefix(resource.GroupVersion, "run.tanzu.vmware.com/") {
 			foundProviders.tanzu = true
 			return "tanzu"
 		}

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -46,19 +46,12 @@ const (
 	k3s           Provider = iota
 )
 
-func CheckOpenShift(foundProviders *providers, apiResources []*metav1.APIResourceList, provider string) string {
+func CheckApiResourcesForProviders(foundProviders *providers, apiResources []*metav1.APIResourceList, provider string) string {
 	for _, resource := range apiResources {
 		if strings.HasPrefix(resource.GroupVersion, "apps.openshift.io/") {
 			foundProviders.openShift = true
 			return "openShift"
 		}
-	}
-
-	return provider
-}
-
-func CheckTanzu(foundProviders *providers, apiResources []*metav1.APIResourceList, provider string) string {
-	for _, resource := range apiResources {
 		if strings.HasPrefix(resource.GroupVersion, "run.tanzu.vmware.com/") {
 			foundProviders.tanzu = true
 			return "tanzu"
@@ -170,8 +163,7 @@ func analyzeDistribution(analyzer *troubleshootv1beta2.Distribution, getCollecte
 		if err := json.Unmarshal(apiResourcesBytes, &apiResources); err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal api resource list")
 		}
-		_ = CheckOpenShift(&foundProviders, apiResources, "")
-		_ = CheckTanzu(&foundProviders, apiResources, "")
+		_ = CheckApiResourcesForProvider(&foundProviders, apiResources, "")
 	}
 
 	title := analyzer.CheckName

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -163,7 +163,7 @@ func analyzeDistribution(analyzer *troubleshootv1beta2.Distribution, getCollecte
 		if err := json.Unmarshal(apiResourcesBytes, &apiResources); err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal api resource list")
 		}
-		_ = CheckApiResourcesForProvider(&foundProviders, apiResources, "")
+		_ = CheckApiResourcesForProviders(&foundProviders, apiResources, "")
 	}
 
 	title := analyzer.CheckName


### PR DESCRIPTION
Adds a check to the Kubernetes distribution analyzer to identify VMware Tanzu using the same approach as identifying OpenShift. I started down the road of trying to identify Tanzu via the node after a discussion with @jdewinne, but there was nothing unique to a Tanzu cluster vs. any other cluster created by Cluster API. 

After seeing how OpenShift was identified, I was able to use a similar approach to identify Tanzu. There is an API service `run.tanzu.vmware.com` and a capabilities resource that will be found in a Tanzu cluster. I looked for the group `run.tanzu.vmware.com` in the same way the OpenShift check looks for `apps.openshift.io`.

Originally I implemented it as a separate check (so we had `CheckOpenShift` and `CheckTanzu`) but I generated it into one function `CheckApiResourcesForProviders` for readability.