### PR TITLE
Ensure clusterResources is added prior to other collectors

### DIFF
--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/spf13/cobra"
@@ -80,19 +79,6 @@ func InitAndExecute() {
 func initConfig() {
 	viper.SetEnvPrefix("TROUBLESHOOT")
 	viper.AutomaticEnv()
-}
-
-func ensureCollectorInList(list []*troubleshootv1beta2.Collect, collector troubleshootv1beta2.Collect) []*troubleshootv1beta2.Collect {
-	for _, inList := range list {
-		if collector.ClusterResources != nil && inList.ClusterResources != nil {
-			return list
-		}
-		if collector.ClusterInfo != nil && inList.ClusterInfo != nil {
-			return list
-		}
-	}
-
-	return append(list, &collector)
 }
 
 func writeFile(filename string, contents []byte) error {

--- a/pkg/collect/collect.go
+++ b/pkg/collect/collect.go
@@ -190,3 +190,31 @@ func CollectRemote(c *troubleshootv1beta2.RemoteCollector, additionalRedactors *
 	collectResult.AllCollectedData = allCollectedData
 	return collectResult, nil
 }
+
+// Ensure that the specified collector is in the list of collectors
+func EnsureCollectorInList(list []*troubleshootv1beta2.Collect, collector troubleshootv1beta2.Collect) []*troubleshootv1beta2.Collect {
+	for _, inList := range list {
+		if collector.ClusterResources != nil && inList.ClusterResources != nil {
+			return list
+		}
+		if collector.ClusterInfo != nil && inList.ClusterInfo != nil {
+			return list
+		}
+	}
+
+	return append(list, &collector)
+}
+
+// collect ClusterResources earliest in the list so the pod list does not include pods started by collectors
+func EnsureClusterResourcesFirst(list []*troubleshootv1beta2.Collect) []*troubleshootv1beta2.Collect {
+	sliceOfClusterResources := []*troubleshootv1beta2.Collect{}
+	sliceOfOtherCollectors := []*troubleshootv1beta2.Collect{}
+	for _, collector := range list {
+		if collector.ClusterResources != nil {
+			sliceOfClusterResources = append(sliceOfClusterResources, []*troubleshootv1beta2.Collect{collector}...)
+		} else {
+			sliceOfOtherCollectors = append(sliceOfOtherCollectors, []*troubleshootv1beta2.Collect{collector}...)
+		}
+	}
+	return append(sliceOfClusterResources, sliceOfOtherCollectors...)
+}

--- a/pkg/collect/collect_test.go
+++ b/pkg/collect/collect_test.go
@@ -1,0 +1,43 @@
+package collect
+
+import (
+	"testing"
+
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ensureClusterResourcesFirst(t *testing.T) {
+
+	testCases := []struct {
+		name string
+		want []*troubleshootv1beta2.Collect
+		list []*troubleshootv1beta2.Collect
+	}{
+		{
+			name: "Reorg OK",
+			want: []*troubleshootv1beta2.Collect{
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{},
+				},
+				{
+					Data: &troubleshootv1beta2.Data{},
+				},
+			},
+			list: []*troubleshootv1beta2.Collect{
+				{
+					Data: &troubleshootv1beta2.Data{},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EnsureClusterResourcesFirst(tc.list)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -123,8 +123,9 @@ func CollectHost(opts CollectOpts, p *troubleshootv1beta2.HostPreflight) (Collec
 func Collect(opts CollectOpts, p *troubleshootv1beta2.Preflight) (CollectResult, error) {
 	collectSpecs := make([]*troubleshootv1beta2.Collect, 0, 0)
 	collectSpecs = append(collectSpecs, p.Spec.Collectors...)
-	collectSpecs = ensureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
-	collectSpecs = ensureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
+	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
+	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
+	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
 
 	var allCollectors []collect.Collector
 
@@ -359,30 +360,4 @@ func CollectRemote(opts CollectOpts, p *troubleshootv1beta2.HostPreflight) (Coll
 
 	collectResult.AllCollectedData = allCollectedData
 	return collectResult, nil
-}
-
-func ensureCollectorInList(list []*troubleshootv1beta2.Collect, collector troubleshootv1beta2.Collect) []*troubleshootv1beta2.Collect {
-	for _, inList := range list {
-		if collector.ClusterResources != nil && inList.ClusterResources != nil {
-			return list
-		}
-		if collector.ClusterInfo != nil && inList.ClusterInfo != nil {
-			return list
-		}
-	}
-
-	return append(list, &collector)
-}
-
-func ensureHostCollectorInList(list []*troubleshootv1beta2.HostCollect, collector troubleshootv1beta2.HostCollect) []*troubleshootv1beta2.HostCollect {
-	for _, inList := range list {
-		if collector.CPU != nil && inList.CPU != nil {
-			return list
-		}
-		if collector.Memory != nil && inList.Memory != nil {
-			return list
-		}
-	}
-
-	return append(list, &collector)
 }

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -32,8 +32,6 @@ func runHostCollectors(hostCollectors []*troubleshootv1beta2.HostCollect, additi
 		}
 	}
 
-	collectResult := collect.NewResult()
-
 	for _, collector := range collectors {
 		isExcluded, _ := collector.IsExcluded()
 		if isExcluded {
@@ -50,7 +48,7 @@ func runHostCollectors(hostCollectors []*troubleshootv1beta2.HostCollect, additi
 		}
 	}
 
-	collectResult = allCollectedData
+	collectResult := allCollectedData
 
 	globalRedactors := []*troubleshootv1beta2.Redact{}
 	if additionalRedactors != nil {
@@ -71,8 +69,9 @@ func runHostCollectors(hostCollectors []*troubleshootv1beta2.HostCollect, additi
 func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactors *troubleshootv1beta2.Redactor, bundlePath string, opts SupportBundleCreateOpts) (collect.CollectorResult, error) {
 	collectSpecs := make([]*troubleshootv1beta2.Collect, 0)
 	collectSpecs = append(collectSpecs, collectors...)
-	collectSpecs = ensureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
-	collectSpecs = ensureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
+	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
+	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
+	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
 
 	var allCollectors []collect.Collector
 
@@ -173,19 +172,6 @@ func findFileName(basename, extension string) (string, error) {
 		name = fmt.Sprintf("%s (%d)", basename, n)
 		n = n + 1
 	}
-}
-
-func ensureCollectorInList(list []*troubleshootv1beta2.Collect, collector troubleshootv1beta2.Collect) []*troubleshootv1beta2.Collect {
-	for _, inList := range list {
-		if collector.ClusterResources != nil && inList.ClusterResources != nil {
-			return list
-		}
-		if collector.ClusterInfo != nil && inList.ClusterInfo != nil {
-			return list
-		}
-	}
-
-	return append(list, &collector)
 }
 
 const VersionFilename = "version.yaml"


### PR DESCRIPTION
If Troubleshoot adds the clusterResources or ClusterInfo collector, ensure that this is added at the first element of the collectors array.

Fixes: #767