### PR TITLE
make runPreflight and preflight cli flags public

### DIFF
--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
+	"github.com/replicatedhq/troubleshoot/pkg/preflight"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
@@ -29,24 +30,14 @@ that a cluster meets the requirements to run an application.`,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
-			return runPreflights(v, args[0])
+			return preflight.RunPreflights(v.GetBool("interactive"), v.GetString("output"), v.GetString("format"), args[0])
 		},
 	}
 
 	cobra.OnInitialize(initConfig)
 
 	cmd.AddCommand(VersionCmd())
-
-	cmd.Flags().Bool("interactive", true, "interactive preflights")
-	cmd.Flags().String("format", "human", "output format, one of human, json, yaml. only used when interactive is set to false")
-	cmd.Flags().String("collector-image", "", "the full name of the collector image to use")
-	cmd.Flags().String("collector-pullpolicy", "", "the pull policy of the collector image")
-	cmd.Flags().Bool("collect-without-permissions", true, "always run preflight checks even if some require permissions that preflight does not have")
-	cmd.Flags().String("selector", "", "selector (label query) to filter remote collection nodes on.")
-	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
-	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
-	cmd.Flags().StringP("output", "o", "", "specify the output file path for the preflight checks")
-	cmd.Flags().Bool("debug", false, "enable debug logging")
+	preflight.AddFlags(cmd.PersistentFlags())
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/pkg/preflight/flags.go
+++ b/pkg/preflight/flags.go
@@ -1,0 +1,96 @@
+package preflight
+
+import (
+	flag "github.com/spf13/pflag"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	flagInteractive               = "interactive"
+	flagFormat                    = "format"
+	flagCollectorImage            = "collector-image"
+	flagCollectorPullPolicy       = "collector-pullpolicy"
+	flagCollectWithoutPermissions = "collect-without-permissions"
+	flagSelector                  = "selector"
+	flagSinceTime                 = "since-time"
+	flagSince                     = "since"
+	flagOutput                    = "output"
+	flagDebug                     = "debug"
+)
+
+type PreflightFlags struct {
+	Interactive               *bool
+	Format                    *string
+	CollectorImage            *string
+	CollectorPullPolicy       *string
+	CollectWithoutPermissions *bool
+	Selector                  *string
+	SinceTime                 *string
+	Since                     *string
+	Output                    *string
+	Debug                     *bool
+}
+
+var preflightFlags *PreflightFlags
+
+func NewPreflightFlags() *PreflightFlags {
+	return &PreflightFlags{
+		Interactive:               utilpointer.Bool(true),
+		Format:                    utilpointer.String("human"),
+		CollectorImage:            utilpointer.String(""),
+		CollectorPullPolicy:       utilpointer.String(""),
+		CollectWithoutPermissions: utilpointer.Bool(true),
+		Selector:                  utilpointer.String(""),
+		SinceTime:                 utilpointer.String(""),
+		Since:                     utilpointer.String(""),
+		Output:                    utilpointer.String("o"),
+		Debug:                     utilpointer.Bool(false),
+	}
+}
+
+func AddFlags(flags *flag.FlagSet) {
+	if preflightFlags == nil {
+		preflightFlags = NewPreflightFlags()
+	}
+
+	preflightFlags.addFlags(flags)
+}
+
+// AddFlags binds client configuration flags to a given flagset
+func (f *PreflightFlags) addFlags(flags *flag.FlagSet) {
+	if preflightFlags == nil {
+		preflightFlags = NewPreflightFlags()
+	}
+
+	if f.Interactive != nil {
+		flags.BoolVar(f.Interactive, flagInteractive, *f.Interactive, "interactive preflights")
+	}
+	if f.Format != nil {
+		flags.StringVar(f.Format, flagFormat, *f.Format, "output format, one of human, json, yaml. only used when interactive is set to false")
+	}
+
+	if f.CollectorImage != nil {
+		flags.StringVar(f.CollectorImage, flagCollectorImage, *f.CollectorImage, "the full name of the collector image to use")
+	}
+	if f.CollectorPullPolicy != nil {
+		flags.StringVar(f.CollectorPullPolicy, flagCollectorPullPolicy, *f.CollectorPullPolicy, "the pull policy of the collector image")
+	}
+	if f.CollectWithoutPermissions != nil {
+		flags.BoolVar(f.CollectWithoutPermissions, flagCollectWithoutPermissions, *f.CollectWithoutPermissions, "always run preflight checks even if some require permissions that preflight does not have")
+	}
+	if f.Selector != nil {
+		flags.StringVar(f.Selector, flagSelector, *f.Selector, "selector (label query) to filter remote collection nodes on.")
+	}
+	if f.SinceTime != nil {
+		flags.StringVar(f.SinceTime, flagSinceTime, *f.SinceTime, "force pod logs collectors to return logs after a specific date (RFC3339)")
+	}
+	if f.Since != nil {
+		flags.StringVar(f.Since, flagSince, *f.Since, "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
+	}
+	if f.Output != nil {
+		flags.StringVar(f.Output, flagOutput, *f.Output, "specify the output file path for the preflight checks")
+	}
+	if f.Debug != nil {
+		flags.BoolVar(f.Debug, flagDebug, *f.Debug, "enable debug logging")
+	}
+}

--- a/pkg/preflight/interactive_results.go
+++ b/pkg/preflight/interactive_results.go
@@ -1,4 +1,4 @@
-package cli
+package preflight
 
 import (
 	"fmt"

--- a/pkg/preflight/stdout_results.go
+++ b/pkg/preflight/stdout_results.go
@@ -1,4 +1,4 @@
-package cli
+package preflight
 
 import (
 	"encoding/json"

--- a/pkg/preflight/upload_results.go
+++ b/pkg/preflight/upload_results.go
@@ -1,4 +1,4 @@
-package cli
+package preflight
 
 import (
 	"bytes"
@@ -8,15 +8,14 @@ import (
 	"github.com/pkg/errors"
 	analyzerunner "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
-	"github.com/replicatedhq/troubleshoot/pkg/preflight"
 )
 
 func uploadResults(uri string, analyzeResults []*analyzerunner.AnalyzeResult) error {
-	uploadPreflightResults := &preflight.UploadPreflightResults{
-		Results: []*preflight.UploadPreflightResult{},
+	uploadPreflightResults := &UploadPreflightResults{
+		Results: []*UploadPreflightResult{},
 	}
 	for _, analyzeResult := range analyzeResults {
-		uploadPreflightResult := &preflight.UploadPreflightResult{
+		uploadPreflightResult := &UploadPreflightResult{
 			Strict:  analyzeResult.Strict,
 			IsFail:  analyzeResult.IsFail,
 			IsWarn:  analyzeResult.IsWarn,
@@ -33,23 +32,23 @@ func uploadResults(uri string, analyzeResults []*analyzerunner.AnalyzeResult) er
 }
 
 func uploadErrors(uri string, collectors []collect.Collector) error {
-	errors := []*preflight.UploadPreflightError{}
+	errors := []*UploadPreflightError{}
 	for _, collector := range collectors {
 		for _, e := range collector.GetRBACErrors() {
-			errors = append(errors, &preflight.UploadPreflightError{
+			errors = append(errors, &UploadPreflightError{
 				Error: e.Error(),
 			})
 		}
 	}
 
-	results := &preflight.UploadPreflightResults{
+	results := &UploadPreflightResults{
 		Errors: errors,
 	}
 
 	return upload(uri, results)
 }
 
-func upload(uri string, payload *preflight.UploadPreflightResults) error {
+func upload(uri string, payload *UploadPreflightResults) error {
 	b, err := json.Marshal(payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal payload")


### PR DESCRIPTION
This PR makes the `runPreflights` function publicly accessible and also includes an `AddFlags` implementation for `preflight` so we can easily utilize the same CLI flags in our helm plugin.