### PR TITLE
Update logs.go

### DIFF
--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"time"
+	"os"
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -184,10 +184,10 @@ func savePodLogs(ctx context.Context, bundlePath string, client *kubernetes.Clie
 	}
 	
 	// EL - Temporarily moved defer to this location for further testing
-	defer podLogs.Close()
-	defer result.CloseWriter(bundlePath, fileKey+".log", logWriter)
-	defer podLogs.Close()
-	defer result.CloseWriter(bundlePath, fileKey+"-previous.log", logWriter)
+	podLogs.Close()
+	result.CloseWriter(bundlePath, fileKey+".log", logWriter)
+	podLogs.Close()
+	result.CloseWriter(bundlePath, fileKey+"-previous.log", logWriter)
 
 	// EL - Create a SymLink for SBCTL log reference
 	err = os.Symlink(fileKey, symFileKey)

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -150,13 +150,13 @@ func savePodLogs(ctx context.Context, bundlePath string, client *kubernetes.Clie
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get log stream")
 	}
-	defer podLogs.Close()
+	//defer podLogs.Close()
 
 	logWriter, err := result.GetWriter(bundlePath, fileKey+".log")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get log writer")
 	}
-	defer result.CloseWriter(bundlePath, fileKey+".log", logWriter)
+	//defer result.CloseWriter(bundlePath, fileKey+".log", logWriter)
 
 	_, err = io.Copy(logWriter, podLogs)
 	if err != nil {
@@ -170,18 +170,24 @@ func savePodLogs(ctx context.Context, bundlePath string, client *kubernetes.Clie
 		// maybe fail on !kuberneteserrors.IsNotFound(err)?
 		return result, nil
 	}
-	defer podLogs.Close()
+	//defer podLogs.Close()
 
 	prevLogWriter, err := result.GetWriter(bundlePath, fileKey+"-previous.log")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get previous log writer")
 	}
-	defer result.CloseWriter(bundlePath, fileKey+"-previous.log", logWriter)
+	//defer result.CloseWriter(bundlePath, fileKey+"-previous.log", logWriter)
 
 	_, err = io.Copy(prevLogWriter, podLogs)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to copy previous log")
 	}
+	
+	// EL - Temporarily moved defer to this location for further testing
+	defer podLogs.Close()
+	defer result.CloseWriter(bundlePath, fileKey+".log", logWriter)
+	defer podLogs.Close()
+	defer result.CloseWriter(bundlePath, fileKey+"-previous.log", logWriter)
 
 	// EL - Create a SymLink for SBCTL log reference
 	err = os.Symlink(fileKey, symFileKey)

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -138,6 +138,9 @@ func savePodLogs(ctx context.Context, bundlePath string, client *kubernetes.Clie
 	if container != "" {
 		fileKey = fmt.Sprintf("%s/%s/%s", name, pod.Name, container)
 	}
+	
+	// EL - Define fileKey for the SymLink
+	symFileKey := fmt.Sprintf("%s/%s/%s/%s", "bundlePath/cluster-resources/pods/logs", pod.Namespace, pod.Name, container)
 
 	result := NewResult()
 
@@ -179,6 +182,12 @@ func savePodLogs(ctx context.Context, bundlePath string, client *kubernetes.Clie
 		return nil, errors.Wrap(err, "failed to copy previous log")
 	}
 
+	// EL - Create a SymLink for SBCTL log reference
+	err = os.Symlink(fileKey, symFileKey)
+	if err != nil {
+		fmt.Println(err)
+	}
+	
 	return result, nil
 }
 


### PR DESCRIPTION
Patch logs.go to use a symbolic link in order to let SBCTL access logs via `kubectl logs <pod-name> ...`

While this is not yet as simple as it may seem, this draft PR will allow us to further discuss/look at how to implement this.