### PR TITLE
Add omitempty to StorageClassName in schema

### DIFF
--- a/config/crds/troubleshoot.replicated.com_analyzers.yaml
+++ b/config/crds/troubleshoot.replicated.com_analyzers.yaml
@@ -687,7 +687,6 @@ spec:
                           type: string
                       required:
                       - outcomes
-                      - storageClassName
                       type: object
                     textAnalyze:
                       properties:

--- a/config/crds/troubleshoot.replicated.com_preflights.yaml
+++ b/config/crds/troubleshoot.replicated.com_preflights.yaml
@@ -687,7 +687,6 @@ spec:
                           type: string
                       required:
                       - outcomes
-                      - storageClassName
                       type: object
                     textAnalyze:
                       properties:

--- a/config/crds/troubleshoot.replicated.com_supportbundles.yaml
+++ b/config/crds/troubleshoot.replicated.com_supportbundles.yaml
@@ -718,7 +718,6 @@ spec:
                           type: string
                       required:
                       - outcomes
-                      - storageClassName
                       type: object
                     textAnalyze:
                       properties:

--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -41,6 +41,10 @@ spec:
                   properties:
                     cephStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -89,6 +93,10 @@ spec:
                       type: object
                     clusterPodStatuses:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -136,6 +144,10 @@ spec:
                       type: object
                     clusterVersion:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -179,6 +191,10 @@ spec:
                       type: object
                     configMap:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         configMapName:
@@ -230,6 +246,10 @@ spec:
                       type: object
                     containerRuntime:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -273,6 +293,10 @@ spec:
                       type: object
                     customResourceDefinition:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         customResourceDefinitionName:
@@ -319,6 +343,10 @@ spec:
                       type: object
                     deploymentStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -371,6 +399,10 @@ spec:
                       type: object
                     distribution:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -414,6 +446,10 @@ spec:
                       type: object
                     imagePullSecret:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -460,6 +496,10 @@ spec:
                       type: object
                     ingress:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -509,6 +549,10 @@ spec:
                       type: object
                     jobStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -559,8 +603,67 @@ spec:
                       - name
                       - outcomes
                       type: object
+                    jsonCompare:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        fileName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        strict:
+                          type: BoolString
+                        value:
+                          type: string
+                      required:
+                      - outcomes
+                      type: object
                     longhorn:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -609,6 +712,10 @@ spec:
                       type: object
                     mysql:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -657,6 +764,10 @@ spec:
                       type: object
                     nodeResources:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -726,6 +837,10 @@ spec:
                       type: object
                     postgres:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -774,6 +889,10 @@ spec:
                       type: object
                     redis:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -822,6 +941,10 @@ spec:
                       type: object
                     registryImages:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -868,6 +991,10 @@ spec:
                       type: object
                     replicasetStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -925,6 +1052,10 @@ spec:
                       type: object
                     secret:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -976,6 +1107,10 @@ spec:
                       type: object
                     statefulsetStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1028,6 +1163,10 @@ spec:
                       type: object
                     storageClass:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1070,10 +1209,13 @@ spec:
                           type: BoolString
                       required:
                       - outcomes
-                      - storageClassName
                       type: object
                     sysctl:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1117,6 +1259,10 @@ spec:
                       type: object
                     textAnalyze:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -1170,6 +1316,10 @@ spec:
                       type: object
                     weaveReport:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1180,6 +1330,906 @@ spec:
                           type: BoolString
                       required:
                       - reportFileGlob
+                      type: object
+                    yamlCompare:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        fileName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        strict:
+                          type: BoolString
+                        value:
+                          type: string
+                      required:
+                      - outcomes
+                      type: object
+                  type: object
+                type: array
+              hostAnalyzers:
+                items:
+                  properties:
+                    blockDevices:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        includeUnmountedPartitions:
+                          type: boolean
+                        minimumAcceptableSize:
+                          format: int64
+                          type: integer
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - includeUnmountedPartitions
+                      - minimumAcceptableSize
+                      - outcomes
+                      type: object
+                    certificate:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    cpu:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    diskUsage:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    filesystemPerformance:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    hostOS:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    hostServices:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    http:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    httpLoadBalancer:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    ipv4Interfaces:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    kernelModules:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    memory:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    systemPackages:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    tcpConnect:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    tcpLoadBalancer:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    tcpPortStatus:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    time:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
                       type: object
                   type: object
                 type: array

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -2114,14 +2114,14 @@ spec:
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -2933,9 +2933,6 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is beta-level and available on clusters
-                                that haven't disabled the EphemeralContainers feature
-                                gate.
                               items:
                                 description: "An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
@@ -2947,9 +2944,7 @@ spec:
                                   the Pod to exceed its resource allocation. \n To
                                   add an ephemeral container, use the ephemeralcontainers
                                   subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted. \n This is a beta
-                                  feature available on clusters that haven't disabled
-                                  the EphemeralContainers feature gate."
+                                  may not be removed or restarted."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
@@ -4354,6 +4349,20 @@ spec:
                               description: 'Use the host''s pid namespace. Optional:
                                 Default to false.'
                               type: boolean
+                            hostUsers:
+                              description: 'Use the host''s user namespace. Optional:
+                                Default to true. If set to true or not present, the
+                                pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to
+                                the host user namespace, such as loading a kernel
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod. Setting false is useful
+                                for mitigating container breakout vulnerabilities
+                                even allowing users to run their containers as root
+                                without actually having root privileges on the host.
+                                This field is alpha-level and is only honored by servers
+                                that enable the UserNamespacesSupport feature.'
+                              type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
                                 specified, the pod's hostname will be set to a system-defined
@@ -5022,14 +5031,14 @@ spec:
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -5800,20 +5809,19 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
-                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                                - spec.containers[*].securityContext.seLinuxOptions
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                                - spec.securityContext.sysctls - spec.shareProcessNamespace
+                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
                                 - spec.containers[*].securityContext.seccompProfile
                                 - spec.containers[*].securityContext.capabilities
                                 - spec.containers[*].securityContext.readOnlyRootFilesystem
                                 - spec.containers[*].securityContext.privileged -
                                 spec.containers[*].securityContext.allowPrivilegeEscalation
                                 - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup This
-                                is a beta field and requires the IdentifyPodOS feature"
+                                - spec.containers[*].securityContext.runAsGroup"
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
@@ -6258,6 +6266,21 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select the pods over which spreading
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored. A null or empty list means
+                                      only match against labelSelector.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   maxSkew:
                                     description: 'MaxSkew describes the degree to
                                       which pods may be unevenly distributed. When
@@ -6308,11 +6331,37 @@ spec:
                                       with the same labelSelector cannot be scheduled,
                                       because computed skew will be 3(3 - 0) if new
                                       Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is an alpha
-                                      field and requires enabling MinDomainsInPodTopologySpread
-                                      feature gate."
+                                      it will violate MaxSkew. \n This is a beta field
+                                      and requires the MinDomainsInPodTopologySpread
+                                      feature gate to be enabled (enabled by default)."
                                     format: int32
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options
+                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                                      are included in the calculations. - Ignore:
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy. This is a alpha-level feature
+                                      enabled by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: "NodeTaintsPolicy indicates how we
+                                      will treat node taints when calculating pod
+                                      topology spread skew. Options are: - Honor:
+                                      nodes without taints, along with tainted nodes
+                                      for which the incoming pod has a toleration,
+                                      are included. - Ignore: node taints are ignored.
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy. This is a alpha-level feature enabled
+                                      by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
                                       Nodes that have a label with this key and identical
@@ -6321,8 +6370,9 @@ spec:
                                       and try to put balanced number of pods into
                                       each bucket. We define a domain as a particular
                                       instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes match the node
-                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      domain as a domain whose nodes meet the requirements
+                                      of nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname",
                                       each Node is a domain of that topology. And,
                                       if TopologyKey is "topology.kubernetes.io/zone",
                                       each zone is a domain of that topology. It's

--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -41,6 +41,10 @@ spec:
                   properties:
                     blockDevices:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -93,6 +97,10 @@ spec:
                       type: object
                     certificate:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -138,6 +146,10 @@ spec:
                       type: object
                     cpu:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -183,6 +195,10 @@ spec:
                       type: object
                     diskUsage:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -228,6 +244,10 @@ spec:
                       type: object
                     filesystemPerformance:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -273,6 +293,10 @@ spec:
                       type: object
                     hostOS:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -318,6 +342,10 @@ spec:
                       type: object
                     hostServices:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -363,6 +391,10 @@ spec:
                       type: object
                     http:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -408,6 +440,10 @@ spec:
                       type: object
                     httpLoadBalancer:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -453,6 +489,10 @@ spec:
                       type: object
                     ipv4Interfaces:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -498,6 +538,10 @@ spec:
                       type: object
                     kernelModules:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -543,6 +587,10 @@ spec:
                       type: object
                     memory:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -588,6 +636,10 @@ spec:
                       type: object
                     systemPackages:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -633,6 +685,10 @@ spec:
                       type: object
                     tcpConnect:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -678,6 +734,10 @@ spec:
                       type: object
                     tcpLoadBalancer:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -723,6 +783,10 @@ spec:
                       type: object
                     tcpPortStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -768,6 +832,10 @@ spec:
                       type: object
                     time:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -1043,6 +1111,22 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                      type: object
+                    run:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        collectorName:
+                          type: string
+                        command:
+                          type: string
+                        exclude:
+                          type: BoolString
+                      required:
+                      - args
+                      - command
                       type: object
                     systemPackages:
                       properties:

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -41,6 +41,10 @@ spec:
                   properties:
                     blockDevices:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -93,6 +97,10 @@ spec:
                       type: object
                     certificate:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -138,6 +146,10 @@ spec:
                       type: object
                     cpu:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -183,6 +195,10 @@ spec:
                       type: object
                     diskUsage:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -228,6 +244,10 @@ spec:
                       type: object
                     filesystemPerformance:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -273,6 +293,10 @@ spec:
                       type: object
                     hostOS:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -318,6 +342,10 @@ spec:
                       type: object
                     hostServices:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -363,6 +391,10 @@ spec:
                       type: object
                     http:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -408,6 +440,10 @@ spec:
                       type: object
                     httpLoadBalancer:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -453,6 +489,10 @@ spec:
                       type: object
                     ipv4Interfaces:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -498,6 +538,10 @@ spec:
                       type: object
                     kernelModules:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -543,6 +587,10 @@ spec:
                       type: object
                     memory:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -588,6 +636,10 @@ spec:
                       type: object
                     systemPackages:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -633,6 +685,10 @@ spec:
                       type: object
                     tcpConnect:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -678,6 +734,10 @@ spec:
                       type: object
                     tcpLoadBalancer:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -723,6 +783,10 @@ spec:
                       type: object
                     tcpPortStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -768,6 +832,10 @@ spec:
                       type: object
                     time:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -1043,6 +1111,22 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                      type: object
+                    run:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        collectorName:
+                          type: string
+                        command:
+                          type: string
+                        exclude:
+                          type: BoolString
+                      required:
+                      - args
+                      - command
                       type: object
                     systemPackages:
                       properties:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -41,6 +41,10 @@ spec:
                   properties:
                     cephStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -89,6 +93,10 @@ spec:
                       type: object
                     clusterPodStatuses:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -136,6 +144,10 @@ spec:
                       type: object
                     clusterVersion:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -179,6 +191,10 @@ spec:
                       type: object
                     configMap:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         configMapName:
@@ -230,6 +246,10 @@ spec:
                       type: object
                     containerRuntime:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -273,6 +293,10 @@ spec:
                       type: object
                     customResourceDefinition:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         customResourceDefinitionName:
@@ -319,6 +343,10 @@ spec:
                       type: object
                     deploymentStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -371,6 +399,10 @@ spec:
                       type: object
                     distribution:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -414,6 +446,10 @@ spec:
                       type: object
                     imagePullSecret:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -460,6 +496,10 @@ spec:
                       type: object
                     ingress:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -509,6 +549,10 @@ spec:
                       type: object
                     jobStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -559,8 +603,67 @@ spec:
                       - name
                       - outcomes
                       type: object
+                    jsonCompare:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        fileName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        strict:
+                          type: BoolString
+                        value:
+                          type: string
+                      required:
+                      - outcomes
+                      type: object
                     longhorn:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -609,6 +712,10 @@ spec:
                       type: object
                     mysql:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -657,6 +764,10 @@ spec:
                       type: object
                     nodeResources:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -726,6 +837,10 @@ spec:
                       type: object
                     postgres:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -774,6 +889,10 @@ spec:
                       type: object
                     redis:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -822,6 +941,10 @@ spec:
                       type: object
                     registryImages:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -868,6 +991,10 @@ spec:
                       type: object
                     replicasetStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -925,6 +1052,10 @@ spec:
                       type: object
                     secret:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -976,6 +1107,10 @@ spec:
                       type: object
                     statefulsetStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1028,6 +1163,10 @@ spec:
                       type: object
                     storageClass:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1070,10 +1209,13 @@ spec:
                           type: BoolString
                       required:
                       - outcomes
-                      - storageClassName
                       type: object
                     sysctl:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1117,6 +1259,10 @@ spec:
                       type: object
                     textAnalyze:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -1170,6 +1316,10 @@ spec:
                       type: object
                     weaveReport:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1180,6 +1330,61 @@ spec:
                           type: BoolString
                       required:
                       - reportFileGlob
+                      type: object
+                    yamlCompare:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        fileName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        strict:
+                          type: BoolString
+                        value:
+                          type: string
+                      required:
+                      - outcomes
                       type: object
                   type: object
                 type: array
@@ -3230,14 +3435,14 @@ spec:
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4049,9 +4254,6 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is beta-level and available on clusters
-                                that haven't disabled the EphemeralContainers feature
-                                gate.
                               items:
                                 description: "An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
@@ -4063,9 +4265,7 @@ spec:
                                   the Pod to exceed its resource allocation. \n To
                                   add an ephemeral container, use the ephemeralcontainers
                                   subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted. \n This is a beta
-                                  feature available on clusters that haven't disabled
-                                  the EphemeralContainers feature gate."
+                                  may not be removed or restarted."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
@@ -5470,6 +5670,20 @@ spec:
                               description: 'Use the host''s pid namespace. Optional:
                                 Default to false.'
                               type: boolean
+                            hostUsers:
+                              description: 'Use the host''s user namespace. Optional:
+                                Default to true. If set to true or not present, the
+                                pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to
+                                the host user namespace, such as loading a kernel
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod. Setting false is useful
+                                for mitigating container breakout vulnerabilities
+                                even allowing users to run their containers as root
+                                without actually having root privileges on the host.
+                                This field is alpha-level and is only honored by servers
+                                that enable the UserNamespacesSupport feature.'
+                              type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
                                 specified, the pod's hostname will be set to a system-defined
@@ -6138,14 +6352,14 @@ spec:
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -6916,20 +7130,19 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
-                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                                - spec.containers[*].securityContext.seLinuxOptions
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                                - spec.securityContext.sysctls - spec.shareProcessNamespace
+                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
                                 - spec.containers[*].securityContext.seccompProfile
                                 - spec.containers[*].securityContext.capabilities
                                 - spec.containers[*].securityContext.readOnlyRootFilesystem
                                 - spec.containers[*].securityContext.privileged -
                                 spec.containers[*].securityContext.allowPrivilegeEscalation
                                 - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup This
-                                is a beta field and requires the IdentifyPodOS feature"
+                                - spec.containers[*].securityContext.runAsGroup"
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
@@ -7374,6 +7587,21 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select the pods over which spreading
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored. A null or empty list means
+                                      only match against labelSelector.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   maxSkew:
                                     description: 'MaxSkew describes the degree to
                                       which pods may be unevenly distributed. When
@@ -7424,11 +7652,37 @@ spec:
                                       with the same labelSelector cannot be scheduled,
                                       because computed skew will be 3(3 - 0) if new
                                       Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is an alpha
-                                      field and requires enabling MinDomainsInPodTopologySpread
-                                      feature gate."
+                                      it will violate MaxSkew. \n This is a beta field
+                                      and requires the MinDomainsInPodTopologySpread
+                                      feature gate to be enabled (enabled by default)."
                                     format: int32
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options
+                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                                      are included in the calculations. - Ignore:
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy. This is a alpha-level feature
+                                      enabled by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: "NodeTaintsPolicy indicates how we
+                                      will treat node taints when calculating pod
+                                      topology spread skew. Options are: - Honor:
+                                      nodes without taints, along with tainted nodes
+                                      for which the incoming pod has a toleration,
+                                      are included. - Ignore: node taints are ignored.
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy. This is a alpha-level feature enabled
+                                      by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
                                       Nodes that have a label with this key and identical
@@ -7437,8 +7691,9 @@ spec:
                                       and try to put balanced number of pods into
                                       each bucket. We define a domain as a particular
                                       instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes match the node
-                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      domain as a domain whose nodes meet the requirements
+                                      of nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname",
                                       each Node is a domain of that topology. And,
                                       if TopologyKey is "topology.kubernetes.io/zone",
                                       each zone is a domain of that topology. It's

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -72,6 +72,10 @@ spec:
                   properties:
                     cephStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -120,6 +124,10 @@ spec:
                       type: object
                     clusterPodStatuses:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -167,6 +175,10 @@ spec:
                       type: object
                     clusterVersion:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -210,6 +222,10 @@ spec:
                       type: object
                     configMap:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         configMapName:
@@ -261,6 +277,10 @@ spec:
                       type: object
                     containerRuntime:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -304,6 +324,10 @@ spec:
                       type: object
                     customResourceDefinition:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         customResourceDefinitionName:
@@ -350,6 +374,10 @@ spec:
                       type: object
                     deploymentStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -402,6 +430,10 @@ spec:
                       type: object
                     distribution:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -445,6 +477,10 @@ spec:
                       type: object
                     imagePullSecret:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -491,6 +527,10 @@ spec:
                       type: object
                     ingress:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -540,6 +580,10 @@ spec:
                       type: object
                     jobStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -590,8 +634,67 @@ spec:
                       - name
                       - outcomes
                       type: object
+                    jsonCompare:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        fileName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        strict:
+                          type: BoolString
+                        value:
+                          type: string
+                      required:
+                      - outcomes
+                      type: object
                     longhorn:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -640,6 +743,10 @@ spec:
                       type: object
                     mysql:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -688,6 +795,10 @@ spec:
                       type: object
                     nodeResources:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -757,6 +868,10 @@ spec:
                       type: object
                     postgres:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -805,6 +920,10 @@ spec:
                       type: object
                     redis:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -853,6 +972,10 @@ spec:
                       type: object
                     registryImages:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -899,6 +1022,10 @@ spec:
                       type: object
                     replicasetStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -956,6 +1083,10 @@ spec:
                       type: object
                     secret:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1007,6 +1138,10 @@ spec:
                       type: object
                     statefulsetStatus:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1059,6 +1194,10 @@ spec:
                       type: object
                     storageClass:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1101,10 +1240,13 @@ spec:
                           type: BoolString
                       required:
                       - outcomes
-                      - storageClassName
                       type: object
                     sysctl:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1148,6 +1290,10 @@ spec:
                       type: object
                     textAnalyze:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         collectorName:
@@ -1201,6 +1347,10 @@ spec:
                       type: object
                     weaveReport:
                       properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
                         checkName:
                           type: string
                         exclude:
@@ -1211,6 +1361,61 @@ spec:
                           type: BoolString
                       required:
                       - reportFileGlob
+                      type: object
+                    yamlCompare:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        fileName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        path:
+                          type: string
+                        strict:
+                          type: BoolString
+                        value:
+                          type: string
+                      required:
+                      - outcomes
                       type: object
                   type: object
                 type: array
@@ -3261,14 +3466,14 @@ spec:
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4080,9 +4285,6 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is beta-level and available on clusters
-                                that haven't disabled the EphemeralContainers feature
-                                gate.
                               items:
                                 description: "An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
@@ -4094,9 +4296,7 @@ spec:
                                   the Pod to exceed its resource allocation. \n To
                                   add an ephemeral container, use the ephemeralcontainers
                                   subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted. \n This is a beta
-                                  feature available on clusters that haven't disabled
-                                  the EphemeralContainers feature gate."
+                                  may not be removed or restarted."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
@@ -5501,6 +5701,20 @@ spec:
                               description: 'Use the host''s pid namespace. Optional:
                                 Default to false.'
                               type: boolean
+                            hostUsers:
+                              description: 'Use the host''s user namespace. Optional:
+                                Default to true. If set to true or not present, the
+                                pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to
+                                the host user namespace, such as loading a kernel
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod. Setting false is useful
+                                for mitigating container breakout vulnerabilities
+                                even allowing users to run their containers as root
+                                without actually having root privileges on the host.
+                                This field is alpha-level and is only honored by servers
+                                that enable the UserNamespacesSupport feature.'
+                              type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
                                 specified, the pod's hostname will be set to a system-defined
@@ -6169,14 +6383,14 @@ spec:
                                     type: string
                                   ports:
                                     description: List of ports to expose from the
-                                      container. Exposing a port here gives the system
-                                      additional information about the network connections
-                                      a container uses, but is primarily informational.
-                                      Not specifying a port here DOES NOT prevent
-                                      that port from being exposed. Any port which
-                                      is listening on the default "0.0.0.0" address
-                                      inside a container will be accessible from the
-                                      network. Cannot be updated.
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -6947,20 +7161,19 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
-                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
-                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
-                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
-                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
-                                - spec.containers[*].securityContext.seLinuxOptions
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                                - spec.securityContext.sysctls - spec.shareProcessNamespace
+                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
                                 - spec.containers[*].securityContext.seccompProfile
                                 - spec.containers[*].securityContext.capabilities
                                 - spec.containers[*].securityContext.readOnlyRootFilesystem
                                 - spec.containers[*].securityContext.privileged -
                                 spec.containers[*].securityContext.allowPrivilegeEscalation
                                 - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup This
-                                is a beta field and requires the IdentifyPodOS feature"
+                                - spec.containers[*].securityContext.runAsGroup"
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
@@ -7405,6 +7618,21 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select the pods over which spreading
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored. A null or empty list means
+                                      only match against labelSelector.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   maxSkew:
                                     description: 'MaxSkew describes the degree to
                                       which pods may be unevenly distributed. When
@@ -7455,11 +7683,37 @@ spec:
                                       with the same labelSelector cannot be scheduled,
                                       because computed skew will be 3(3 - 0) if new
                                       Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is an alpha
-                                      field and requires enabling MinDomainsInPodTopologySpread
-                                      feature gate."
+                                      it will violate MaxSkew. \n This is a beta field
+                                      and requires the MinDomainsInPodTopologySpread
+                                      feature gate to be enabled (enabled by default)."
                                     format: int32
                                     type: integer
+                                  nodeAffinityPolicy:
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options
+                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                                      are included in the calculations. - Ignore:
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy. This is a alpha-level feature
+                                      enabled by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: "NodeTaintsPolicy indicates how we
+                                      will treat node taints when calculating pod
+                                      topology spread skew. Options are: - Honor:
+                                      nodes without taints, along with tainted nodes
+                                      for which the incoming pod has a toleration,
+                                      are included. - Ignore: node taints are ignored.
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy. This is a alpha-level feature enabled
+                                      by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
                                       Nodes that have a label with this key and identical
@@ -7468,8 +7722,9 @@ spec:
                                       and try to put balanced number of pods into
                                       each bucket. We define a domain as a particular
                                       instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes match the node
-                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      domain as a domain whose nodes meet the requirements
+                                      of nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname",
                                       each Node is a domain of that topology. And,
                                       if TopologyKey is "topology.kubernetes.io/zone",
                                       each zone is a domain of that topology. It's
@@ -9317,6 +9572,851 @@ spec:
                       type: object
                   type: object
                 type: array
+              hostAnalyzers:
+                items:
+                  properties:
+                    blockDevices:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        includeUnmountedPartitions:
+                          type: boolean
+                        minimumAcceptableSize:
+                          format: int64
+                          type: integer
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - includeUnmountedPartitions
+                      - minimumAcceptableSize
+                      - outcomes
+                      type: object
+                    certificate:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    cpu:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    diskUsage:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    filesystemPerformance:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    hostOS:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    hostServices:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    http:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    httpLoadBalancer:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    ipv4Interfaces:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    kernelModules:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    memory:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    systemPackages:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    tcpConnect:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    tcpLoadBalancer:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    tcpPortStatus:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                    time:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
+                  type: object
+                type: array
               hostCollectors:
                 items:
                   properties:
@@ -9548,6 +10648,22 @@ spec:
                         exclude:
                           type: BoolString
                       type: object
+                    run:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        collectorName:
+                          type: string
+                        command:
+                          type: string
+                        exclude:
+                          type: BoolString
+                      required:
+                      - args
+                      - command
+                      type: object
                     systemPackages:
                       properties:
                         amzn:
@@ -9666,6 +10782,10 @@ spec:
                       type: object
                   type: object
                 type: array
+              uri:
+                description: URI optionally defines a location which is the source
+                  of this spec to allow updating of the spec at runtime
+                type: string
             type: object
           status:
             description: SupportBundleStatus defines the observed state of SupportBundle

--- a/pkg/apis/troubleshoot/v1beta1/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta1/analyzer_shared.go
@@ -24,7 +24,7 @@ type ClusterVersion struct {
 type StorageClass struct {
 	AnalyzeMeta      `json:",inline" yaml:",inline"`
 	Outcomes         []*Outcome `json:"outcomes" yaml:"outcomes"`
-	StorageClassName string     `json:"storageClassName" yaml:"storageClassName"`
+	StorageClassName string     `json:"storageClassName,omitempty" yaml:"storageClassName,omitempty"`
 }
 
 type CustomResourceDefinition struct {

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -12,7 +12,7 @@ type ClusterVersion struct {
 type StorageClass struct {
 	AnalyzeMeta      `json:",inline" yaml:",inline"`
 	Outcomes         []*Outcome `json:"outcomes" yaml:"outcomes"`
-	StorageClassName string     `json:"storageClassName" yaml:"storageClassName"`
+	StorageClassName string     `json:"storageClassName,omitempty" yaml:"storageClassName,omitempty"`
 }
 
 type CustomResourceDefinition struct {

--- a/schemas/analyzer-troubleshoot-v1beta1.json
+++ b/schemas/analyzer-troubleshoot-v1beta1.json
@@ -961,8 +961,7 @@
               "storageClass": {
                 "type": "object",
                 "required": [
-                  "outcomes",
-                  "storageClassName"
+                  "outcomes"
                 ],
                 "properties": {
                   "checkName": {

--- a/schemas/analyzer-troubleshoot-v1beta2.json
+++ b/schemas/analyzer-troubleshoot-v1beta2.json
@@ -29,6 +29,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -102,6 +108,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -175,6 +187,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -244,6 +262,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -320,6 +344,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -388,6 +418,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -459,6 +495,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -538,6 +580,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -606,6 +654,12 @@
                   "registryName"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -678,6 +732,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -752,6 +812,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -825,6 +891,91 @@
                   }
                 }
               },
+              "jsonCompare": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
               "longhorn": {
                 "type": "object",
                 "required": [
@@ -832,6 +983,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -906,6 +1063,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -979,6 +1142,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1087,6 +1256,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1161,6 +1336,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1235,6 +1416,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1307,6 +1494,12 @@
                   "selector"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1394,6 +1587,12 @@
                   "secretName"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1471,6 +1670,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1547,10 +1752,15 @@
               "storageClass": {
                 "type": "object",
                 "required": [
-                  "outcomes",
-                  "storageClassName"
+                  "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1621,6 +1831,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1688,6 +1904,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1770,6 +1992,12 @@
                   "reportFileGlob"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1778,6 +2006,1400 @@
                   },
                   "reportFileGlob": {
                     "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "yamlCompare": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hostAnalyzers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "blockDevices": {
+                "type": "object",
+                "required": [
+                  "includeUnmountedPartitions",
+                  "minimumAcceptableSize",
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "includeUnmountedPartitions": {
+                    "type": "boolean"
+                  },
+                  "minimumAcceptableSize": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "certificate": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "cpu": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "diskUsage": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "filesystemPerformance": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "hostOS": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "hostServices": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "http": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "httpLoadBalancer": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "ipv4Interfaces": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "kernelModules": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "memory": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "systemPackages": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "tcpConnect": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "tcpLoadBalancer": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "tcpPortStatus": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "time": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
                   },
                   "strict": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -1918,7 +1918,7 @@
                               "type": "string"
                             },
                             "ports": {
-                              "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                               "type": "array",
                               "items": {
                                 "description": "ContainerPort represents a network port in a single container.",
@@ -2542,10 +2542,10 @@
                         "type": "boolean"
                       },
                       "ephemeralContainers": {
-                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.",
+                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
                         "type": "array",
                         "items": {
-                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate.",
+                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
                           "type": "object",
                           "required": [
                             "name"
@@ -3702,6 +3702,10 @@
                         "description": "Use the host's pid namespace. Optional: Default to false.",
                         "type": "boolean"
                       },
+                      "hostUsers": {
+                        "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                        "type": "boolean"
+                      },
                       "hostname": {
                         "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
                         "type": "string"
@@ -4266,7 +4270,7 @@
                               "type": "string"
                             },
                             "ports": {
-                              "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                               "type": "array",
                               "items": {
                                 "description": "ContainerPort represents a network port in a single container.",
@@ -4857,7 +4861,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature",
+                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
                         "type": "object",
                         "required": [
                           "name"
@@ -5157,18 +5161,34 @@
                                 }
                               }
                             },
+                            "matchLabelKeys": {
+                              "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
                             "maxSkew": {
                               "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
                               "type": "integer",
                               "format": "int32"
                             },
                             "minDomains": {
-                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate.",
+                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
                               "type": "integer",
                               "format": "int32"
                             },
+                            "nodeAffinityPolicy": {
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "type": "string"
+                            },
                             "topologyKey": {
-                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
                               "type": "string"
                             },
                             "whenUnsatisfiable": {

--- a/schemas/preflight-troubleshoot-v1beta1.json
+++ b/schemas/preflight-troubleshoot-v1beta1.json
@@ -961,8 +961,7 @@
               "storageClass": {
                 "type": "object",
                 "required": [
-                  "outcomes",
-                  "storageClassName"
+                  "outcomes"
                 ],
                 "properties": {
                   "checkName": {

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -29,6 +29,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -102,6 +108,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -175,6 +187,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -244,6 +262,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -320,6 +344,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -388,6 +418,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -459,6 +495,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -538,6 +580,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -606,6 +654,12 @@
                   "registryName"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -678,6 +732,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -752,6 +812,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -825,6 +891,91 @@
                   }
                 }
               },
+              "jsonCompare": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
               "longhorn": {
                 "type": "object",
                 "required": [
@@ -832,6 +983,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -906,6 +1063,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -979,6 +1142,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1087,6 +1256,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1161,6 +1336,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1235,6 +1416,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1307,6 +1494,12 @@
                   "selector"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1394,6 +1587,12 @@
                   "secretName"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1471,6 +1670,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1547,10 +1752,15 @@
               "storageClass": {
                 "type": "object",
                 "required": [
-                  "outcomes",
-                  "storageClassName"
+                  "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1621,6 +1831,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1688,6 +1904,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1770,6 +1992,12 @@
                   "reportFileGlob"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1781,6 +2009,91 @@
                   },
                   "strict": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "yamlCompare": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "value": {
+                    "type": "string"
                   }
                 }
               }
@@ -3642,7 +3955,7 @@
                               "type": "string"
                             },
                             "ports": {
-                              "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                               "type": "array",
                               "items": {
                                 "description": "ContainerPort represents a network port in a single container.",
@@ -4266,10 +4579,10 @@
                         "type": "boolean"
                       },
                       "ephemeralContainers": {
-                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.",
+                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
                         "type": "array",
                         "items": {
-                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate.",
+                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
                           "type": "object",
                           "required": [
                             "name"
@@ -5426,6 +5739,10 @@
                         "description": "Use the host's pid namespace. Optional: Default to false.",
                         "type": "boolean"
                       },
+                      "hostUsers": {
+                        "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                        "type": "boolean"
+                      },
                       "hostname": {
                         "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
                         "type": "string"
@@ -5990,7 +6307,7 @@
                               "type": "string"
                             },
                             "ports": {
-                              "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                               "type": "array",
                               "items": {
                                 "description": "ContainerPort represents a network port in a single container.",
@@ -6581,7 +6898,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature",
+                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
                         "type": "object",
                         "required": [
                           "name"
@@ -6881,18 +7198,34 @@
                                 }
                               }
                             },
+                            "matchLabelKeys": {
+                              "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
                             "maxSkew": {
                               "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
                               "type": "integer",
                               "format": "int32"
                             },
                             "minDomains": {
-                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate.",
+                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
                               "type": "integer",
                               "format": "int32"
                             },
+                            "nodeAffinityPolicy": {
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "type": "string"
+                            },
                             "topologyKey": {
-                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
                               "type": "string"
                             },
                             "whenUnsatisfiable": {

--- a/schemas/supportbundle-troubleshoot-v1beta1.json
+++ b/schemas/supportbundle-troubleshoot-v1beta1.json
@@ -1007,8 +1007,7 @@
               "storageClass": {
                 "type": "object",
                 "required": [
-                  "outcomes",
-                  "storageClassName"
+                  "outcomes"
                 ],
                 "properties": {
                   "checkName": {

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -75,6 +75,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -148,6 +154,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -221,6 +233,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -290,6 +308,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -366,6 +390,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -434,6 +464,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -505,6 +541,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -584,6 +626,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -652,6 +700,12 @@
                   "registryName"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -724,6 +778,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -798,6 +858,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -871,6 +937,91 @@
                   }
                 }
               },
+              "jsonCompare": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
               "longhorn": {
                 "type": "object",
                 "required": [
@@ -878,6 +1029,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -952,6 +1109,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1025,6 +1188,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1133,6 +1302,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1207,6 +1382,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1281,6 +1462,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1353,6 +1540,12 @@
                   "selector"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1440,6 +1633,12 @@
                   "secretName"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1517,6 +1716,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1593,10 +1798,15 @@
               "storageClass": {
                 "type": "object",
                 "required": [
-                  "outcomes",
-                  "storageClassName"
+                  "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1667,6 +1877,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1734,6 +1950,12 @@
                   "outcomes"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1816,6 +2038,12 @@
                   "reportFileGlob"
                 ],
                 "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
                   "checkName": {
                     "type": "string"
                   },
@@ -1827,6 +2055,91 @@
                   },
                   "strict": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "yamlCompare": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "fileName": {
+                    "type": "string"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "value": {
+                    "type": "string"
                   }
                 }
               }
@@ -3688,7 +4001,7 @@
                               "type": "string"
                             },
                             "ports": {
-                              "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                               "type": "array",
                               "items": {
                                 "description": "ContainerPort represents a network port in a single container.",
@@ -4312,10 +4625,10 @@
                         "type": "boolean"
                       },
                       "ephemeralContainers": {
-                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.",
+                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
                         "type": "array",
                         "items": {
-                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate.",
+                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
                           "type": "object",
                           "required": [
                             "name"
@@ -5472,6 +5785,10 @@
                         "description": "Use the host's pid namespace. Optional: Default to false.",
                         "type": "boolean"
                       },
+                      "hostUsers": {
+                        "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                        "type": "boolean"
+                      },
                       "hostname": {
                         "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
                         "type": "string"
@@ -6036,7 +6353,7 @@
                               "type": "string"
                             },
                             "ports": {
-                              "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
                               "type": "array",
                               "items": {
                                 "description": "ContainerPort represents a network port in a single container.",
@@ -6627,7 +6944,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature",
+                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
                         "type": "object",
                         "required": [
                           "name"
@@ -6927,18 +7244,34 @@
                                 }
                               }
                             },
+                            "matchLabelKeys": {
+                              "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
                             "maxSkew": {
                               "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
                               "type": "integer",
                               "format": "int32"
                             },
                             "minDomains": {
-                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate.",
+                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
                               "type": "integer",
                               "format": "int32"
                             },
+                            "nodeAffinityPolicy": {
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "type": "string"
+                            },
                             "topologyKey": {
-                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each \u003ckey, value\u003e as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
                               "type": "string"
                             },
                             "whenUnsatisfiable": {
@@ -8324,6 +8657,1315 @@
             }
           }
         },
+        "hostAnalyzers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "blockDevices": {
+                "type": "object",
+                "required": [
+                  "includeUnmountedPartitions",
+                  "minimumAcceptableSize",
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "includeUnmountedPartitions": {
+                    "type": "boolean"
+                  },
+                  "minimumAcceptableSize": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "certificate": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "cpu": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "diskUsage": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "filesystemPerformance": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "hostOS": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "hostServices": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "http": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "httpLoadBalancer": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "ipv4Interfaces": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "kernelModules": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "memory": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "systemPackages": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "tcpConnect": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "tcpLoadBalancer": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "tcpPortStatus": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
+              "time": {
+                "type": "object",
+                "required": [
+                  "outcomes"
+                ],
+                "properties": {
+                  "annotations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "checkName": {
+                    "type": "string"
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  },
+                  "outcomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fail": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "pass": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "warn": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "uri": {
+                              "type": "string"
+                            },
+                            "when": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "strict": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              }
+            }
+          }
+        },
         "hostCollectors": {
           "type": "array",
           "items": {
@@ -8629,6 +10271,30 @@
                   }
                 }
               },
+              "run": {
+                "type": "object",
+                "required": [
+                  "args",
+                  "command"
+                ],
+                "properties": {
+                  "args": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "collectorName": {
+                    "type": "string"
+                  },
+                  "command": {
+                    "type": "string"
+                  },
+                  "exclude": {
+                    "oneOf": [{"type": "string"},{"type": "boolean"}]
+                  }
+                }
+              },
               "systemPackages": {
                 "type": "object",
                 "properties": {
@@ -8807,6 +10473,10 @@
               }
             }
           }
+        },
+        "uri": {
+          "description": "URI optionally defines a location which is the source of this spec to allow updating of the spec at runtime",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
Allow a StorageClass spec to not require specify storageClassName.

Includes the associated schema update, which pulls in a number of other updates.

Fixes: #813