### PR TITLE
chore: Add vscode launch configurations to allow debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,9 @@ vendor
 dist
 try.sh
 
-.vscode/
+__debug_bin
 workspace.*
+*.tar.gz
 
 cosign.key
 sbom/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    // NOTE: These configurations assumes VS Code's workspace is the root of your repo
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch supportbundle",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/troubleshoot/main.go",
+            "args": [
+                "${workspaceFolder}/examples/support-bundle/sample-supportbundle.yaml",
+                "--interactive=false",
+                "--debug"
+            ]
+        },
+        {
+            "name": "Launch analyze",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/analyze/main.go",
+            "args": [
+                "${workspaceFolder}/examples/support-bundle/sample-analyzers.yaml",
+                "--debug"
+            ]
+        },
+        {
+            "name": "Launch preflight",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/preflight/main.go",
+            "args": [
+                "${workspaceFolder}/examples/preflight/sample-preflight.yaml",
+                "--debug"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
With these launch configurations, you should be able to run or debug applications (supportbundle, analyze or preflight) from within vscode. The configurations assume vsode's workspace is the root of your repo so you need to launch vscode from your repo.

More on vscode debugging: https://code.visualstudio.com/docs/editor/debugging

Fixes: #817