### PR TITLE
Update fossa

### DIFF
--- a/.github/workflows/pr-license-scan.yaml
+++ b/.github/workflows/pr-license-scan.yaml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - name: "Install FOSSA" 
         uses: replicatedhq/action-fossa/install@main
       - name: "Run FOSSA Scan"

--- a/.github/workflows/pr-license-scan.yaml
+++ b/.github/workflows/pr-license-scan.yaml
@@ -1,19 +1,16 @@
 name: PR license scan
 
 on:
-  pull_request:
+  pull_request_target: # this is safe as these scans do not execute provided code
 
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: "Run FOSSA Analyze" 
-        uses: fossas/fossa-action@main
+      - name: "Install FOSSA" 
+        uses: replicatedhq/action-fossa/install@main
+      - name: "Run FOSSA Scan"
+        uses: replicatedhq/action-fossa/scan@main
         with:
-          api-key: 1d5511d63d5a4ccda6d3cef2a7ef08c1 # push-only token, safe to expose
-      - name: "Run FOSSA Test"
-        uses: fossas/fossa-action@main
-        with:
-          api-key: 1d5511d63d5a4ccda6d3cef2a7ef08c1 # push-only token, safe to expose
-          run-tests: true
+          api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Centralize the FOSSA runner to make troubleshooting easier. Uses the pull_request_target event which is generally considered safe since we are not executing the provided code.