### PR TITLE
Deduplication for Cluster Resources Collector

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -72,10 +72,9 @@ func (c *CollectClusterResources) Merge(allCollectors []Collector) ([]Collector,
 					uniqueNamespaces[namespace] = true
 				}
 			}
-		} else {
-			result = append(result, collectorInterface)
 		}
 	}
+	fmt.Println(uniqueNamespaces)
 
 	clusterResourcesCollector := c
 
@@ -98,7 +97,7 @@ func (c *CollectClusterResources) Merge(allCollectors []Collector) ([]Collector,
 
 	// As opposed to the spec originally having multiple collector definitions specified, the merge function now collapses them into one with
 	//     a longer string slice of all the unqiue namespaces that were provided
-	result = append(allCollectors, clusterResourcesCollector)
+	result = append(result, clusterResourcesCollector)
 
 	return result, nil
 }

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -88,6 +88,9 @@ EMPTY_NAMESPACE_FOUND:
 			allNamespaces = append(allNamespaces, k)
 		}
 	}
+
+	sort.Strings(allNamespaces)
+
 	clusterResourcesCollector.Collector.Namespaces = allNamespaces
 
 	result = append(result, clusterResourcesCollector)

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -74,7 +74,6 @@ func (c *CollectClusterResources) Merge(allCollectors []Collector) ([]Collector,
 			}
 		}
 	}
-	fmt.Println(uniqueNamespaces)
 
 	clusterResourcesCollector := c
 

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -55,6 +55,7 @@ func (c *CollectClusterResources) Merge(allCollectors []Collector) ([]Collector,
 	uniqueNamespaces := make(map[string]bool)
 	hasEmptyNameSpaceCollector := false
 
+EMPTY_NAMESPACE_FOUND:
 	for _, collectorInterface := range allCollectors {
 		if collector, ok := collectorInterface.(*CollectClusterResources); ok {
 			if collector.Collector.Namespaces == nil {
@@ -62,7 +63,12 @@ func (c *CollectClusterResources) Merge(allCollectors []Collector) ([]Collector,
 				break
 			} else {
 				for _, namespace := range collector.Collector.Namespaces {
-					uniqueNamespaces[namespace] = true
+					if namespace == "" {
+						hasEmptyNameSpaceCollector = true
+						break EMPTY_NAMESPACE_FOUND
+					} else {
+						uniqueNamespaces[namespace] = true
+					}
 				}
 			}
 		}

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -51,7 +51,55 @@ func (c *CollectClusterResources) IsExcluded() (bool, error) {
 }
 
 func (c *CollectClusterResources) Merge(allCollectors []Collector) ([]Collector, error) {
-	result := append(allCollectors, c)
+	// Right now this merge function assumes it has been provided the entire list of collectors to be run and will
+	//       return the entire "spec" but modifying the pieces it needs to
+	var result []Collector
+	uniqueNamespaces := make(map[string]bool)
+	hasEmptyNameSpaceCollector := false
+
+	// 1. search all collectors for Cluster Resources Collectors
+	// 2. If we come across one with namespaces not set, set hasEmptyNameSpaceCollector true and continue
+	// 3. However if we exclusively come across collectors with a specific namespace set, start building a map to use later
+	// 4. If its not a cluster resources collector just append the current collector to the result
+	// 5. Else just add the collector to the list as its not a Cluster Resources collector so we don't need to do anything
+	for _, collectorInterface := range allCollectors {
+		if collector, ok := collectorInterface.(*CollectClusterResources); ok {
+			if collector.Collector.Namespaces == nil {
+				hasEmptyNameSpaceCollector = true
+				break
+			} else {
+				for _, namespace := range collector.Collector.Namespaces {
+					uniqueNamespaces[namespace] = true
+				}
+			}
+		} else {
+			result = append(result, collectorInterface)
+		}
+	}
+
+	clusterResourcesCollector := c
+
+	// If we found a cluster resources collector earlier, return a single cluster resources collector with namespace set to nil
+	if hasEmptyNameSpaceCollector {
+		clusterResourcesCollector.Collector.Namespaces = nil
+		result = append(result, clusterResourcesCollector)
+		return result, nil
+	}
+
+	// Build a string slice of all the namespaces we found ealier in the cluster resource collectors
+	var allNamespaces []string
+	for k, v := range uniqueNamespaces {
+		if v {
+			allNamespaces = append(allNamespaces, k)
+		}
+	}
+	// Set the cluster resources collector object we created to use the slice of string we built
+	clusterResourcesCollector.Collector.Namespaces = allNamespaces
+
+	// As opposed to the spec originally having multiple collector definitions specified, the merge function now collapses them into one with
+	//     a longer string slice of all the unqiue namespaces that were provided
+	result = append(allCollectors, clusterResourcesCollector)
+
 	return result, nil
 }
 

--- a/pkg/collect/cluster_resources_test.go
+++ b/pkg/collect/cluster_resources_test.go
@@ -110,6 +110,43 @@ func TestClusterResources_Merge(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple cluster resource collectors with a empty string namespace provided",
+			Collectors: []troubleshootv1beta2.Collect{
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello2"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{""},
+					},
+				},
+			},
+			want: &CollectClusterResources{
+				Collector: &troubleshootv1beta2.ClusterResources{
+					CollectorMeta: troubleshootv1beta2.CollectorMeta{
+						CollectorName: "collectorname",
+					},
+					Namespaces: nil,
+				},
+			},
+		},
+		{
 			name: "multiple cluster resource collectors with a nil namespace provided",
 			Collectors: []troubleshootv1beta2.Collect{
 				{

--- a/pkg/collect/cluster_resources_test.go
+++ b/pkg/collect/cluster_resources_test.go
@@ -1,9 +1,12 @@
 package collect
 
 import (
+	"reflect"
 	"testing"
 
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_SelectCRDVersionByPriority(t *testing.T) {
@@ -11,4 +14,163 @@ func Test_SelectCRDVersionByPriority(t *testing.T) {
 	assert.Equal(t, "v1alpha3", selectCRDVersionByPriority([]string{"v1alpha3", "v1alpha2"}))
 	assert.Equal(t, "v1", selectCRDVersionByPriority([]string{"v1alpha2", "v1alpha3", "v1"}))
 	assert.Equal(t, "v1", selectCRDVersionByPriority([]string{"v1", "v1alpha2", "v1alpha3"}))
+}
+
+func TestClusterResources_Merge(t *testing.T) {
+	tests := []struct {
+		name       string
+		Collectors []troubleshootv1beta2.Collect
+		want       *CollectClusterResources
+	}{
+		{
+			name: "single cluster resources collector with multiple unique namespaces",
+			Collectors: []troubleshootv1beta2.Collect{
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello", "hello2"},
+					},
+				},
+			},
+			want: &CollectClusterResources{
+				Collector: &troubleshootv1beta2.ClusterResources{
+					CollectorMeta: troubleshootv1beta2.CollectorMeta{
+						CollectorName: "collectorname",
+					},
+					Namespaces: []string{"hello", "hello2"},
+				},
+			},
+		},
+		{
+			name: "multiple cluster resources collectors with unique namespaces",
+			Collectors: []troubleshootv1beta2.Collect{
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello2"},
+					},
+				},
+			},
+			want: &CollectClusterResources{
+				Collector: &troubleshootv1beta2.ClusterResources{
+					CollectorMeta: troubleshootv1beta2.CollectorMeta{
+						CollectorName: "collectorname",
+					},
+					Namespaces: []string{"hello", "hello2"},
+				},
+			},
+		},
+		{
+			name: "multiple cluster resources collectors with duplicate namespaces",
+			Collectors: []troubleshootv1beta2.Collect{
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello2"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello"},
+					},
+				},
+			},
+			want: &CollectClusterResources{
+				Collector: &troubleshootv1beta2.ClusterResources{
+					CollectorMeta: troubleshootv1beta2.CollectorMeta{
+						CollectorName: "collectorname",
+					},
+					Namespaces: []string{"hello", "hello2"},
+				},
+			},
+		},
+		{
+			name: "multiple cluster resource collectors with a nil namespace provided",
+			Collectors: []troubleshootv1beta2.Collect{
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: []string{"hello2"},
+					},
+				},
+				{
+					ClusterResources: &troubleshootv1beta2.ClusterResources{
+						CollectorMeta: troubleshootv1beta2.CollectorMeta{
+							CollectorName: "collectorname",
+						},
+						Namespaces: nil,
+					},
+				},
+			},
+			want: &CollectClusterResources{
+				Collector: &troubleshootv1beta2.ClusterResources{
+					CollectorMeta: troubleshootv1beta2.CollectorMeta{
+						CollectorName: "collectorname",
+					},
+					Namespaces: nil,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			var mergedCollectors []Collector
+			allCollectors := make(map[reflect.Type][]Collector)
+			collectorType := reflect.TypeOf(CollectClusterResources{})
+
+			for _, v := range tt.Collectors {
+				collectorInterface, _ := GetCollector(&v, "", "", nil, nil, nil)
+				if collector, ok := collectorInterface.(MergeableCollector); ok {
+					allCollectors[collectorType] = append(allCollectors[collectorType], collector)
+				}
+			}
+
+			for _, collectors := range allCollectors {
+				if mergeCollector, ok := collectors[0].(MergeableCollector); ok {
+					mergedCollectors, _ = mergeCollector.Merge(collectors)
+				}
+			}
+
+			clusterResourceCollector, _ := mergedCollectors[0].(*CollectClusterResources)
+
+			req.EqualValues(tt.want, clusterResourceCollector)
+		})
+	}
 }

--- a/pkg/collect/cluster_resources_test.go
+++ b/pkg/collect/cluster_resources_test.go
@@ -155,10 +155,10 @@ func TestClusterResources_Merge(t *testing.T) {
 			allCollectors := make(map[reflect.Type][]Collector)
 			collectorType := reflect.TypeOf(CollectClusterResources{})
 
-			for _, v := range tt.Collectors {
-				collectorInterface, _ := GetCollector(&v, "", "", nil, nil, nil)
-				if collector, ok := collectorInterface.(MergeableCollector); ok {
-					allCollectors[collectorType] = append(allCollectors[collectorType], collector)
+			for _, collector := range tt.Collectors {
+				collectorInterface, _ := GetCollector(&collector, "", "", nil, nil, nil)
+				if mergeCollector, ok := collectorInterface.(MergeableCollector); ok {
+					allCollectors[collectorType] = append(allCollectors[collectorType], mergeCollector)
 				}
 			}
 

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -3,6 +3,7 @@ package collect
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -51,18 +52,20 @@ func isExcluded(excludeVal *multitype.BoolOrString) (bool, error) {
 	return parsed, nil
 }
 
-func GetCollector(collector *troubleshootv1beta2.Collect, bundlePath string, namespace string, clientConfig *rest.Config, client kubernetes.Interface, sinceTime *time.Time) (interface{}, bool) {
+func GetCollector(collector *troubleshootv1beta2.Collect, bundlePath string, namespace string, clientConfig *rest.Config, client kubernetes.Interface, sinceTime *time.Time) (interface{}, interface{}, bool) {
 
-	ctx := context.TODO()
+	//ctx := context.TODO()
 
 	var RBACErrors []error
 
 	switch {
 	case collector.ClusterInfo != nil:
-		return &CollectClusterInfo{collector.ClusterInfo, bundlePath, namespace, clientConfig, RBACErrors}, true
+		return &CollectClusterInfo{collector.ClusterInfo, bundlePath, namespace, clientConfig, RBACErrors}, &CollectClusterInfo{}, true
 	case collector.ClusterResources != nil:
-		return &CollectClusterResources{collector.ClusterResources, bundlePath, namespace, clientConfig, RBACErrors}, true
-	case collector.Secret != nil:
+		obj := &CollectClusterResources{collector.ClusterResources, bundlePath, namespace, clientConfig, RBACErrors}
+		typeOf := reflect.TypeOf(obj)
+		return obj, typeOf, true
+	/*case collector.Secret != nil:
 		return &CollectSecret{collector.Secret, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
 	case collector.ConfigMap != nil:
 		return &CollectConfigMap{collector.ConfigMap, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
@@ -97,9 +100,9 @@ func GetCollector(collector *troubleshootv1beta2.Collect, bundlePath string, nam
 	case collector.RegistryImages != nil:
 		return &CollectRegistry{collector.RegistryImages, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
 	case collector.Sysctl != nil:
-		return &CollectSysctl{collector.Sysctl, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
+		return &CollectSysctl{collector.Sysctl, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true*/
 	default:
-		return nil, false
+		return nil, nil, false
 	}
 }
 

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -3,7 +3,6 @@ package collect
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -52,20 +51,18 @@ func isExcluded(excludeVal *multitype.BoolOrString) (bool, error) {
 	return parsed, nil
 }
 
-func GetCollector(collector *troubleshootv1beta2.Collect, bundlePath string, namespace string, clientConfig *rest.Config, client kubernetes.Interface, sinceTime *time.Time) (interface{}, interface{}, bool) {
+func GetCollector(collector *troubleshootv1beta2.Collect, bundlePath string, namespace string, clientConfig *rest.Config, client kubernetes.Interface, sinceTime *time.Time) (interface{}, bool) {
 
-	//ctx := context.TODO()
+	ctx := context.TODO()
 
 	var RBACErrors []error
 
 	switch {
 	case collector.ClusterInfo != nil:
-		return &CollectClusterInfo{collector.ClusterInfo, bundlePath, namespace, clientConfig, RBACErrors}, &CollectClusterInfo{}, true
+		return &CollectClusterInfo{collector.ClusterInfo, bundlePath, namespace, clientConfig, RBACErrors}, true
 	case collector.ClusterResources != nil:
-		obj := &CollectClusterResources{collector.ClusterResources, bundlePath, namespace, clientConfig, RBACErrors}
-		typeOf := reflect.TypeOf(obj)
-		return obj, typeOf, true
-	/*case collector.Secret != nil:
+		return &CollectClusterResources{collector.ClusterResources, bundlePath, namespace, clientConfig, RBACErrors}, true
+	case collector.Secret != nil:
 		return &CollectSecret{collector.Secret, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
 	case collector.ConfigMap != nil:
 		return &CollectConfigMap{collector.ConfigMap, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
@@ -100,9 +97,9 @@ func GetCollector(collector *troubleshootv1beta2.Collect, bundlePath string, nam
 	case collector.RegistryImages != nil:
 		return &CollectRegistry{collector.RegistryImages, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
 	case collector.Sysctl != nil:
-		return &CollectSysctl{collector.Sysctl, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true*/
+		return &CollectSysctl{collector.Sysctl, bundlePath, namespace, clientConfig, client, ctx, RBACErrors}, true
 	default:
-		return nil, nil, false
+		return nil, false
 	}
 }
 

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -89,8 +89,8 @@ func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactor
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to check RBAC for collectors")
 				}
-
-				if mergeCollector, ok := collectorInterface.(collect.MergeableCollector); ok {
+				allCollectors = append(allCollectors, collector)
+				/*if mergeCollector, ok := collectorInterface.(collect.MergeableCollector); ok {
 					allCollectors, err = mergeCollector.Merge(allCollectors)
 					if err != nil {
 						msg := fmt.Sprintf("failed to merge collector: %s: %s", collector.Title(), err)
@@ -98,7 +98,16 @@ func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactor
 					}
 				} else {
 					allCollectors = append(allCollectors, collector)
-				}
+				}*/
+			}
+		}
+	}
+	for _, collec := range allCollectors {
+		if mergeCollector, ok := collec.(collect.MergeableCollector); ok {
+			allCollectors, err = mergeCollector.Merge(allCollectors)
+			if err != nil {
+				msg := fmt.Sprintf("failed to merge collector: %s: %s", mergeCollector.Title(), err)
+				opts.CollectorProgressCallback(opts.ProgressChan, msg)
 			}
 		}
 	}


### PR DESCRIPTION
## Description, Motivation and Context

Add deduplication for Cluster Resources collector to prevent the same collector configuration from running twice and also to ensure if no namespace is provided on any one cluster resource definition, that all namespaces are collected by default

## Checklist

- [x] New and existing tests pass locally with the changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

