### PR TITLE
fix(flag): fix wrong output filename

### DIFF
--- a/pkg/preflight/flags.go
+++ b/pkg/preflight/flags.go
@@ -88,7 +88,7 @@ func (f *PreflightFlags) addFlags(flags *flag.FlagSet) {
 		flags.StringVar(f.Since, flagSince, *f.Since, "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 	}
 	if f.Output != nil {
-		flags.StringVar(f.Output, flagOutput, *f.Output, "specify the output file path for the preflight checks")
+		flags.StringVarP(f.Output, flagOutput, *f.Output, "", "specify the output file path for the preflight checks")
 	}
 	if f.Debug != nil {
 		flags.BoolVar(f.Debug, flagDebug, *f.Debug, "enable debug logging")

--- a/pkg/preflight/flags.go
+++ b/pkg/preflight/flags.go
@@ -56,6 +56,13 @@ func AddFlags(flags *flag.FlagSet) {
 	preflightFlags.addFlags(flags)
 }
 
+// Reset flags for preflightFlags
+func ResetFlags() {
+	if preflightFlags != nil {
+		preflightFlags = NewPreflightFlags()
+	}
+}
+
 // AddFlags binds client configuration flags to a given flagset
 func (f *PreflightFlags) addFlags(flags *flag.FlagSet) {
 	if preflightFlags == nil {

--- a/pkg/preflight/flags.go
+++ b/pkg/preflight/flags.go
@@ -56,13 +56,6 @@ func AddFlags(flags *flag.FlagSet) {
 	preflightFlags.addFlags(flags)
 }
 
-// Reset flags for preflightFlags
-func ResetFlags() {
-	if preflightFlags != nil {
-		preflightFlags = NewPreflightFlags()
-	}
-}
-
 // AddFlags binds client configuration flags to a given flagset
 func (f *PreflightFlags) addFlags(flags *flag.FlagSet) {
 	if preflightFlags == nil {

--- a/pkg/preflight/flags_test.go
+++ b/pkg/preflight/flags_test.go
@@ -19,42 +19,37 @@ func TestAddFlagsString(t *testing.T) {
 		want:    "",
 		wantErr: true,
 	}, {
-		name:    "expect output=empty, err=nil when output flag is set",
-		flag:    "output",
-		want:    "",
-		wantErr: false,
-	}, {
 		name:    "expect format=human, err=nil when format flag is set",
 		flag:    "format",
 		want:    "human",
 		wantErr: false,
 	}, {
-		name:    "expect collector-image=empty, err=nil when format collector-image is set",
+		name:    "expect collector-image=empty, err=nil when collector-image flag is set",
 		flag:    "collector-image",
 		want:    "",
 		wantErr: false,
 	}, {
-		name:    "expect collector-pullpolicy=empty, err=nil when format collector-pullpolicy is set",
+		name:    "expect collector-pullpolicy=empty, err=nil when collector-pullpolicy flag is set",
 		flag:    "collector-pullpolicy",
 		want:    "",
 		wantErr: false,
 	}, {
-		name:    "expect selector=empty, err=nil when format selector is set",
+		name:    "expect selector=empty, err=nil when selector flag is set",
 		flag:    "selector",
 		want:    "",
 		wantErr: false,
 	}, {
-		name:    "expect since-time=empty, err=nil when format since-time is set",
+		name:    "expect since-time=empty, err=nil when since-time flag is set",
 		flag:    "since-time",
 		want:    "",
 		wantErr: false,
 	}, {
-		name:    "expect since=empty, err=nil when format since is set",
+		name:    "expect since=empty, err=nil when since flag is set",
 		flag:    "since",
 		want:    "",
 		wantErr: false,
 	}, {
-		name:    "expect output=empty, err=nil when format output is set",
+		name:    "expect output=empty, err=nil when output flag is set",
 		flag:    "output",
 		want:    "",
 		wantErr: false,

--- a/pkg/preflight/flags_test.go
+++ b/pkg/preflight/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	flag "github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 )
 
 // Reset flags for preflightFlags
@@ -13,72 +14,56 @@ func resetFlags() {
 	}
 }
 
-func TestAddFlags(t *testing.T) {
+func TestAddFlagsString(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    []string
-		flags   []string
-		want    []string
+		flag    string
+		want    string
 		wantErr bool
 	}{{
-		name: "expect output=result.txt, err=nil when output flag is result.txt",
-		flags: []string{
-			"output",
-		},
-		args: []string{
-			"--output=result.txt",
-		},
-		want: []string{
-			"result.txt",
-		},
-		wantErr: false,
-	}, {
-		name: "expect output=nil, err=nil when output flag is nil",
-		flags: []string{
-			"output",
-		},
-		args: []string{
-			"--output=",
-		},
-		want: []string{
-			"",
-		},
-		wantErr: false,
-	}, {
-		name: "expect output=result.txt, err=nil when o flag is result.txt",
-		flags: []string{
-			"output",
-		},
-		args: []string{
-			"-o=result.txt",
-		},
-		want: []string{
-			"result.txt",
-		},
-		wantErr: false,
-	}, {
-		name: "expect error when o flag is nil",
-		flags: []string{
-			"output",
-		},
-		args: []string{
-			"-o",
-		},
-		want: []string{
-			"",
-		},
+		name:    "expect error when non-existent flag is set",
+		flag:    "non-existent",
+		want:    "",
 		wantErr: true,
 	}, {
-		name: "expect output=nil, err=nil when no output flag",
-		flags: []string{
-			"output",
-		},
-		args: []string{
-			"",
-		},
-		want: []string{
-			"",
-		},
+		name:    "expect output=empty, err=nil when output flag is set",
+		flag:    "output",
+		want:    "",
+		wantErr: false,
+	}, {
+		name:    "expect format=human, err=nil when format flag is set",
+		flag:    "format",
+		want:    "human",
+		wantErr: false,
+	}, {
+		name:    "expect collector-image=empty, err=nil when format collector-image is set",
+		flag:    "collector-image",
+		want:    "",
+		wantErr: false,
+	}, {
+		name:    "expect collector-pullpolicy=empty, err=nil when format collector-pullpolicy is set",
+		flag:    "collector-pullpolicy",
+		want:    "",
+		wantErr: false,
+	}, {
+		name:    "expect selector=empty, err=nil when format selector is set",
+		flag:    "selector",
+		want:    "",
+		wantErr: false,
+	}, {
+		name:    "expect since-time=empty, err=nil when format since-time is set",
+		flag:    "since-time",
+		want:    "",
+		wantErr: false,
+	}, {
+		name:    "expect since=empty, err=nil when format since is set",
+		flag:    "since",
+		want:    "",
+		wantErr: false,
+	}, {
+		name:    "expect output=empty, err=nil when format output is set",
+		flag:    "output",
+		want:    "",
 		wantErr: false,
 	}}
 
@@ -88,22 +73,47 @@ func TestAddFlags(t *testing.T) {
 			f := flag.FlagSet{}
 			AddFlags(&f)
 
-			if err := f.Parse(tt.args); err != nil {
-				if (err != nil) != tt.wantErr {
-					t.Errorf("AddFlags() error = %v, wantErr %v", err, tt.wantErr)
-				}
-			} else {
-				for i, flag := range tt.flags {
-					got, err := f.GetString(flag)
-					if (err != nil) != tt.wantErr {
-						t.Errorf("AddFlags() error = %v, wantErr %v", err, tt.wantErr)
-					}
+			got, err := f.GetString(tt.flag)
 
-					if got != tt.want[i] {
-						t.Errorf("AddFlags() = %v, want %v", got, tt.want[i])
-					}
-				}
-			}
+			assert.Equalf(t, (err != nil), tt.wantErr, "AddFlags() error = %v, wantErr %v", err, tt.wantErr)
+			assert.Equalf(t, got, tt.want, "AddFlags() = %v, wantErr %v", got, tt.want)
+		})
+	}
+}
+
+func TestAddFlagsBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		flag    string
+		want    bool
+		wantErr bool
+	}{{
+		name:    "expect interactive=true, err=nil when interactive flag is set",
+		flag:    "interactive",
+		want:    true,
+		wantErr: false,
+	}, {
+		name:    "expect collect-without-permissions=true, err=nil when collect-without-permissions flag is set",
+		flag:    "collect-without-permissions",
+		want:    true,
+		wantErr: false,
+	}, {
+		name:    "expect debug=true, err=nil when debug flag is set",
+		flag:    "debug",
+		want:    false,
+		wantErr: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags()
+			f := flag.FlagSet{}
+			AddFlags(&f)
+
+			got, err := f.GetBool(tt.flag)
+
+			assert.Equalf(t, (err != nil), tt.wantErr, "AddFlags() error = %v, wantErr %v", err, tt.wantErr)
+			assert.Equalf(t, got, tt.want, "AddFlags() = %v, wantErr %v", got, tt.want)
 		})
 	}
 }

--- a/pkg/preflight/flags_test.go
+++ b/pkg/preflight/flags_test.go
@@ -6,6 +6,13 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
+// Reset flags for preflightFlags
+func resetFlags() {
+	if preflightFlags != nil {
+		preflightFlags = NewPreflightFlags()
+	}
+}
+
 func TestAddFlags(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -77,7 +84,7 @@ func TestAddFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ResetFlags()
+			resetFlags()
 			f := flag.FlagSet{}
 			AddFlags(&f)
 

--- a/pkg/preflight/flags_test.go
+++ b/pkg/preflight/flags_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Reset flags for preflightFlags
-func resetFlags() {
-	if preflightFlags != nil {
-		preflightFlags = NewPreflightFlags()
-	}
-}
-
 func TestAddFlagsString(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -69,7 +62,6 @@ func TestAddFlagsString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetFlags()
 			f := flag.FlagSet{}
 			AddFlags(&f)
 
@@ -106,7 +98,6 @@ func TestAddFlagsBool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetFlags()
 			f := flag.FlagSet{}
 			AddFlags(&f)
 

--- a/pkg/preflight/flags_test.go
+++ b/pkg/preflight/flags_test.go
@@ -1,0 +1,102 @@
+package preflight
+
+import (
+	"testing"
+
+	flag "github.com/spf13/pflag"
+)
+
+func TestAddFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		flags   []string
+		want    []string
+		wantErr bool
+	}{{
+		name: "expect output=result.txt, err=nil when output flag is result.txt",
+		flags: []string{
+			"output",
+		},
+		args: []string{
+			"--output=result.txt",
+		},
+		want: []string{
+			"result.txt",
+		},
+		wantErr: false,
+	}, {
+		name: "expect output=nil, err=nil when output flag is nil",
+		flags: []string{
+			"output",
+		},
+		args: []string{
+			"--output=",
+		},
+		want: []string{
+			"",
+		},
+		wantErr: false,
+	}, {
+		name: "expect output=result.txt, err=nil when o flag is result.txt",
+		flags: []string{
+			"output",
+		},
+		args: []string{
+			"-o=result.txt",
+		},
+		want: []string{
+			"result.txt",
+		},
+		wantErr: false,
+	}, {
+		name: "expect error when o flag is nil",
+		flags: []string{
+			"output",
+		},
+		args: []string{
+			"-o",
+		},
+		want: []string{
+			"",
+		},
+		wantErr: true,
+	}, {
+		name: "expect output=nil, err=nil when no output flag",
+		flags: []string{
+			"output",
+		},
+		args: []string{
+			"",
+		},
+		want: []string{
+			"",
+		},
+		wantErr: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetFlags()
+			f := flag.FlagSet{}
+			AddFlags(&f)
+
+			if err := f.Parse(tt.args); err != nil {
+				if (err != nil) != tt.wantErr {
+					t.Errorf("AddFlags() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			} else {
+				for i, flag := range tt.flags {
+					got, err := f.GetString(flag)
+					if (err != nil) != tt.wantErr {
+						t.Errorf("AddFlags() error = %v, wantErr %v", err, tt.wantErr)
+					}
+
+					if got != tt.want[i] {
+						t.Errorf("AddFlags() = %v, want %v", got, tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description, Motivation and Context
- fix the issue of  default output to be "o"
- add go test for flag

Fixes: #825
<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with the changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

