### PR TITLE
Remove ingress check from https://preflight.replicated.com

### DIFF
--- a/examples/preflight/sample-preflight.yaml
+++ b/examples/preflight/sample-preflight.yaml
@@ -17,14 +17,6 @@ spec:
           - pass:
               when: ">= 1.22.0"
               message: Your cluster meets the recommended and required versions of Kubernetes.
-    - customResourceDefinition:
-        checkName: Ingress
-        customResourceDefinitionName: ingressroutes.contour.heptio.com
-        outcomes:
-          - fail:
-              message: Contour ingress not found!
-          - pass:
-              message: Contour ingress found!
     - containerRuntime:
         outcomes:
           - pass:


### PR DESCRIPTION
## Description, Motivation and Context

Currently, when we install an k8s with kURL and we run kubectl preflight https://preflight.replicated.com it will fail:

> ------------
> Check FAIL
> Title: Ingress
> Message: Contour ingress not found!

Therefore,  Contour ingress does not seems a pre-requirement to kURL. So, should we have this check in the default example/test?

Related to: https://github.com/replicatedhq/kURL/issues/3734