### PR TITLE
Remove nodes check from https://preflight.replicated.com

### DIFF
--- a/examples/preflight/sample-preflight.yaml
+++ b/examples/preflight/sample-preflight.yaml
@@ -75,19 +75,6 @@ spec:
           - warn:
               message: Unable to determine the distribution of Kubernetes
     - nodeResources:
-        checkName: Must have at least 3 nodes in the cluster, with 5 recommended
-        outcomes:
-        - fail:
-            when: "count() < 3"
-            message: This application requires at least 3 nodes.
-            uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
-        - warn:
-            when: "count() < 5"
-            message: This application recommends at last 5 nodes.
-            uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
-        - pass:
-            message: This cluster has enough nodes.
-    - nodeResources:
         checkName: Every node in the cluster must have at least 10 GB of memory, with 32 GB recommended
         outcomes:
         - fail:


### PR DESCRIPTION
## Description, Motivation and Context

Currently, when we install an k8s with kURL and we run kubectl preflight https://preflight.replicated.com/ it will fail:

```
Check FAIL
Title: Must have at least 3 nodes in the cluster, with 5 recommended
Message: This application requires at least 3 nodes.
```

For some specific App that seems OK. However, it does not seems a kURL requirement and also, would it really be a requirement and/or recommendation to any app?  

Related to: https://github.com/replicatedhq/kURL/issues/3734
