### PR TITLE
Minimal memory requirement for kURL is 8GI

### DIFF
--- a/examples/preflight/sample-preflight.yaml
+++ b/examples/preflight/sample-preflight.yaml
@@ -88,11 +88,11 @@ spec:
         - pass:
             message: This cluster has enough nodes.
     - nodeResources:
-        checkName: Every node in the cluster must have at least 10 GB of memory, with 32 GB recommended
+        checkName: Every node in the cluster must have at least 8 GB of memory, with 32 GB recommended
         outcomes:
         - fail:
-            when: "min(memoryCapacity) < 10Gi"
-            message: All nodes must have at least 10 GB of memory.
+            when: "min(memoryCapacity) < 8Gi"
+            message: All nodes must have at least 8 GB of memory.
             uri: https://kurl.sh/docs/install-with-kurl/system-requirements
         - warn:
             when: "min(memoryCapacity) < 32Gi"


### PR DESCRIPTION
## Description, Motivation and Context

Minimal requirement for kURL is 8GI and not 10GI.
See: https://kurl.sh/docs/install-with-kurl/system-requirements#minimum-system-requirements

Related to: https://github.com/replicatedhq/kURL/issues/3734
