### PR TITLE
doc/readme : make clear that the links are just examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ curl https://krew.sh/preflight | bash
  and run:
  
 ```
-# It is ONLY an example. Do **not** use to validate cluster state.
+# It is ONLY an example. Do **not** use to validate real scenarios.
 kubectl preflight https://preflight.replicated.com
 ```
 
@@ -33,7 +33,7 @@ curl https://krew.sh/support-bundle | bash
  and run:
  
 ```
-# It is ONLY an example. Do **not** use to validate applications.
+# It is ONLY an example. Do **not** use to validate real scenarios.
 kubectl support-bundle https://support-bundle.replicated.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ To run a sample preflight check from a sample application, install the preflight
 ```
 curl https://krew.sh/preflight | bash
 ```
- and run:
+ and run, where https://preflight.replicated.com provides an **example** preflight spec:
  
 ```
-# It is ONLY an example. Do **not** use to validate real scenarios.
 kubectl preflight https://preflight.replicated.com
 ```
+
+**NOTE** this is an example. Do **not** use to validate real scenarios. 
 
 For more details on creating the custom resource files that drive preflight checks, visit [creating preflight checks](https://troubleshoot.sh/docs/preflight/introduction/).
 
@@ -30,12 +31,13 @@ To collect a sample support bundle, install the troubleshoot kubectl plugin:
 ```
 curl https://krew.sh/support-bundle | bash
 ```
- and run:
+ and run, where https://support-bundle.replicated.com provides an **example** support bundle spec:
  
 ```
-# It is ONLY an example. Do **not** use to validate real scenarios.
 kubectl support-bundle https://support-bundle.replicated.com
 ```
+
+**NOTE** this is an example. Do **not** use to validate real scenarios. 
 
 For more details on creating the custom resource files that drive support-bundle collection, visit [creating collectors](https://troubleshoot.sh/docs/collect/) and [creating analyzers](https://troubleshoot.sh/docs/analyze/).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ curl https://krew.sh/preflight | bash
  and run:
  
 ```
-# It is ONLY an example. Do **not** use to validate cluster installs.
+# It is ONLY an example. Do **not** use to validate cluster state.
 kubectl preflight https://preflight.replicated.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ curl https://krew.sh/preflight | bash
  and run:
  
 ```
+# It is ONLY an example. Do **not** use to validate cluster installs.
 kubectl preflight https://preflight.replicated.com
 ```
 
@@ -32,8 +33,10 @@ curl https://krew.sh/support-bundle | bash
  and run:
  
 ```
+# It is ONLY an example. Do **not** use to validate applications.
 kubectl support-bundle https://support-bundle.replicated.com
 ```
+
 For more details on creating the custom resource files that drive support-bundle collection, visit [creating collectors](https://troubleshoot.sh/docs/collect/) and [creating analyzers](https://troubleshoot.sh/docs/analyze/).
 
 And see our other tool [sbctl](https://github.com/replicatedhq/sbctl) that makes it easier to interact with support bundles using `kubectl` commands you already know


### PR DESCRIPTION
## Description, Motivation and Context

Just ensure that users might not be misleading when they are trying to understand the replicated org solutions and does not know that those links are only preflight examples and has no relation with kURL or Kots. 

## Checklist

- [ ] New and existing tests pass locally with the changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

