### PR TITLE
Revert "Remove ingress check from https://preflight.replicated.com"

### DIFF
--- a/examples/preflight/sample-preflight.yaml
+++ b/examples/preflight/sample-preflight.yaml
@@ -17,6 +17,14 @@ spec:
           - pass:
               when: ">= 1.22.0"
               message: Your cluster meets the recommended and required versions of Kubernetes.
+    - customResourceDefinition:
+        checkName: Ingress
+        customResourceDefinitionName: ingressroutes.contour.heptio.com
+        outcomes:
+          - fail:
+              message: Contour ingress not found!
+          - pass:
+              message: Contour ingress found!
     - containerRuntime:
         outcomes:
           - pass:


### PR DESCRIPTION
Reverts replicatedhq/troubleshoot#840

We decide not remove the check and instead clarifies that is only for tests. So that end-users might have more options to get examples.