### PR TITLE
Add ghcr to package releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ endif
 .PHONY: release
 release: export GITHUB_TOKEN = $(shell echo ${GITHUB_TOKEN_TROUBLESHOOT})
 release:
-	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --config deploy/.goreleaser.yml
+	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --config deploy/.goreleaser.yaml
 
 .PHONY: snapshot-release
 snapshot-release:
-	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --snapshot --config deploy/.goreleaser.snapshot.yml
+	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --snapshot --config deploy/.goreleaser.snapshot.yaml
 	docker push replicated/troubleshoot:alpha
 	docker push replicated/preflight:alpha
 

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -125,20 +125,28 @@ archives:
 dockers:
   - dockerfile: ./deploy/Dockerfile.troubleshoot
     image_templates:
-      - "replicated/troubleshoot:latest"
-      - "replicated/troubleshoot:{{ .Major }}"
-      - "replicated/troubleshoot:{{ .Major }}.{{ .Minor }}"
-      - "replicated/troubleshoot:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "docker.io/replicated/troubleshoot:latest"
+      - "docker.io/replicated/troubleshoot:{{ .Major }}"
+      - "docker.io/replicated/troubleshoot:{{ .Major }}.{{ .Minor }}"
+      - "docker.io/replicated/troubleshoot:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "ghcr.io/replicatedhq/troubleshoot:latest"
+      - "ghcr.io/replicatedhq/troubleshoot:{{ .Major }}"
+      - "ghcr.io/replicatedhq/troubleshoot:{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/replicatedhq/troubleshoot:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     ids:
       - support-bundle
       - preflight
       - collect
   - dockerfile: ./deploy/Dockerfile.troubleshoot
     image_templates:
-      - "replicated/preflight:latest"
-      - "replicated/preflight:{{ .Major }}"
-      - "replicated/preflight:{{ .Major }}.{{ .Minor }}"
-      - "replicated/preflight:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "docker.io/replicated/preflight:latest"
+      - "docker.io/replicated/preflight:{{ .Major }}"
+      - "docker.io/replicated/preflight:{{ .Major }}.{{ .Minor }}"
+      - "docker.io/replicated/preflight:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "ghcr.io/replicatedhq/preflight:latest"
+      - "ghcr.io/replicatedhq/preflight:{{ .Major }}"
+      - "ghcr.io/replicatedhq/preflight:{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/replicatedhq/preflight:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     ids:
       - support-bundle
       - preflight


### PR DESCRIPTION
## Description, Motivation and Context

From #808 we've added images but they are being uploaded to dockerhub. This adds them to ghcr because dockerhub now has pull restrictions that ghcr doesn't.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
