### PR TITLE
chore: Add GH workflow to ensure schemas are generated in a PR

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -8,7 +8,7 @@ on:
     tags:
       - "v*.*.*"
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -29,6 +29,20 @@ jobs:
       - uses: actions/checkout@v3
 
       - run: make test
+
+  ensure-schemas-are-generated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+      - name: setup env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
+      - uses: actions/checkout@v3
+      - run: make check-schemas
 
   compile-preflight:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,13 @@ openapischema: controller-gen
 	controller-gen crd +output:dir=./config/crds  paths=./pkg/apis/troubleshoot/v1beta1
 	controller-gen crd +output:dir=./config/crds  paths=./pkg/apis/troubleshoot/v1beta2
 
+check-schemas: generate schemas
+	@if [ -n "$(shell git status --short)" ]; then \
+    	echo -e "\033[31mThe git repo is dirty :( Ensure all generated files are committed e.g CRD schema files\033[0;m"; \
+    	git status --short; \
+    	exit 1; \
+	fi
+
 .PHONY: schemas
 schemas: fmt vet openapischema
 	go build ${LDFLAGS} -o bin/schemagen github.com/replicatedhq/troubleshoot/cmd/schemagen

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -58,7 +58,7 @@ type Logs struct {
 	Selector       []string   `json:"selector" yaml:"selector"`
 	Namespace      string     `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	ContainerNames []string   `json:"containerNames,omitempty" yaml:"containerNames,omitempty"`
-	Limits         *LogLimits `json:"limits,omitempty" yaml:"omitempty"`
+	Limits         *LogLimits `json:"limits,omitempty" yaml:"limits,omitempty"`
 }
 
 type Data struct {


### PR DESCRIPTION
## Description, Motivation and Context

Often after making changes to a code base we forget to run `make schemas` which generates k8s schemas for troubleshoot CRDs. Some external projects such as [kots lint](https://github.com/replicatedhq/kots-lint) depend on these schemas being in sync with the code base.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with the changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

