### PR TITLE
patch cluster_resources.go

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -294,8 +294,8 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 
 	//Cluster Role Bindings
 	clusterRoleBindings, clusterRoleBindingsErrors := clusterRoleBindings(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/clusterRoleBindings.json", bytes.NewBuffer(clusterRoleBindings))
-	output.SaveResult(c.BundlePath, "cluster-resources/clusterRoleBindings-errors.json", marshalErrors(clusterRoleBindingsErrors))
+	output.SaveResult(c.BundlePath, "cluster-resources/clusterrolebindings.json", bytes.NewBuffer(clusterRoleBindings))
+	output.SaveResult(c.BundlePath, "cluster-resources/clusterrolebindings-errors.json", marshalErrors(clusterRoleBindingsErrors))
 
 	return output, nil
 }


### PR DESCRIPTION
Proposed change for the json filename output in the bundle for `clusterRoleBindings` to all lowercase to be similar to `roles`, `clusterroles` & `rolebindings`.

## Description, Motivation and Context

I'm proposing this change in order to clean up file naming and use one specific convention.

## Checklist

- [X] New and existing tests pass locally with introduced changes.
- [-] Tests for the changes have been added (for bug fixes / features)
- [X] The commit message(s) are informative and highlight any breaking changes
- [-] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X ] No

