### PR TITLE
Allow Preflight CLI to consume multiple specs as input 

### DIFF
--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -30,7 +30,7 @@ that a cluster meets the requirements to run an application.`,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
-			return preflight.RunPreflights(v.GetBool("interactive"), v.GetString("output"), v.GetString("format"), args[0])
+			return preflight.RunPreflights(v.GetBool("interactive"), v.GetString("output"), v.GetString("format"), args)
 		},
 	}
 

--- a/pkg/preflight/concat.go
+++ b/pkg/preflight/concat.go
@@ -8,7 +8,6 @@ func ConcatPreflightSpec(target *troubleshootv1beta2.Preflight, source *troubles
 	newSpec := target.DeepCopy()
 	newSpec.Spec.Collectors = append(target.Spec.Collectors, source.Spec.Collectors...)
 	newSpec.Spec.RemoteCollectors = append(target.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
-	//newSpec.Spec.UploadResultsTo = append(target.Spec.UploadResultsTo, source.Spec.UploadResultsTo...)
 	newSpec.Spec.Analyzers = append(target.Spec.Analyzers, source.Spec.Analyzers...)
 	return newSpec
 }

--- a/pkg/preflight/concat.go
+++ b/pkg/preflight/concat.go
@@ -1,0 +1,22 @@
+package preflight
+
+import (
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+)
+
+func ConcatPreflightSpec(target *troubleshootv1beta2.Preflight, source *troubleshootv1beta2.Preflight) *troubleshootv1beta2.Preflight {
+	newSpec := target.DeepCopy()
+	newSpec.Spec.Collectors = append(target.Spec.Collectors, source.Spec.Collectors...)
+	newSpec.Spec.RemoteCollectors = append(target.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
+	//newSpec.Spec.UploadResultsTo = append(target.Spec.UploadResultsTo, source.Spec.UploadResultsTo...)
+	newSpec.Spec.Analyzers = append(target.Spec.Analyzers, source.Spec.Analyzers...)
+	return newSpec
+}
+
+func ConcatHostPreflightSpec(target *troubleshootv1beta2.HostPreflight, source *troubleshootv1beta2.HostPreflight) *troubleshootv1beta2.HostPreflight {
+	newSpec := target.DeepCopy()
+	newSpec.Spec.Collectors = append(target.Spec.Collectors, source.Spec.Collectors...)
+	newSpec.Spec.RemoteCollectors = append(target.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
+	newSpec.Spec.Analyzers = append(target.Spec.Analyzers, source.Spec.Analyzers...)
+	return newSpec
+}

--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -48,7 +48,7 @@ func RunPreflights(interactive bool, output string, format string, args []string
 	var processedHostPreflightSpec *troubleshootv1beta2.HostPreflight
 	var err error
 
-	for k, v := range args {
+	for i, v := range args {
 		if strings.HasPrefix(v, "secret/") {
 			// format secret/namespace-name/secret-name
 			pathParts := strings.Split(v, "/")
@@ -124,13 +124,13 @@ func RunPreflights(interactive bool, output string, format string, args []string
 		}
 
 		if preflightSpec, ok := obj.(*troubleshootv1beta2.Preflight); ok {
-			if k == 0 {
+			if i == 0 {
 				processedPreflightSpec = preflightSpec
 			} else {
 				processedPreflightSpec = ConcatPreflightSpec(processedPreflightSpec, preflightSpec)
 			}
 		} else if hostPreflightSpec, ok := obj.(*troubleshootv1beta2.HostPreflight); ok {
-			if k == 0 {
+			if i == 0 {
 				processedHostPreflightSpec = hostPreflightSpec
 			} else {
 				processedHostPreflightSpec = ConcatHostPreflightSpec(processedHostPreflightSpec, hostPreflightSpec)


### PR DESCRIPTION
## Description, Motivation and Context

Updates the Preflight CLI to allow multiple specs via arguments. All specs will be concatenated into a single resultant spec which will be used for collection and analysis

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
