### PR TITLE
Xav/concurrent cluster resources

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil/discovery"
 )
 
@@ -289,9 +290,7 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	})
 
 	// run the collectors
-
-	maxNbConcurrentGoroutines := 5
-	concurrentGoroutines := make(chan struct{}, maxNbConcurrentGoroutines)
+	concurrentGoroutines := make(chan struct{}, constants.DEFAULT_MAX_NB_CONCURRENT_COLLECTORS)
 
 	for _, thisClusterResourceCollector := range clusterResourceCollectors {
 		wg.Add(1)

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
@@ -41,6 +42,14 @@ type CollectClusterResources struct {
 	ClientConfig *rest.Config
 	RBACErrors
 }
+
+type apiQueryFunc func(context.Context, *kubernetes.Clientset, []string) (map[string][]byte, map[string]string)
+type apiQuery struct {
+	queryFunction apiQueryFunc
+	saveLocation  string
+}
+
+type getClusterResource func()
 
 func (c *CollectClusterResources) Title() string {
 	return getCollectorName(c)
@@ -111,6 +120,7 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 
 	ctx := context.Background()
 	output := NewResult()
+	var wg sync.WaitGroup
 
 	// namespaces
 	nsListedFromCluster := false
@@ -156,185 +166,143 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 		}
 		namespaceNames = filteredNamespaces
 	}
+	var clusterResourceCollectors []getClusterResource
 
 	// pods
-	pods, podErrors, unhealthyPods := pods(ctx, client, namespaceNames)
-	for k, v := range pods {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/pods", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/pods-errors.json", marshalErrors(podErrors))
-
-	for _, pod := range unhealthyPods {
-		allContainers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
-		for _, container := range allContainers {
-			limits := &troubleshootv1beta2.LogLimits{
-				MaxLines: 500,
-			}
-			podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, "", container.Name, limits, false, false)
-			if err != nil {
-				errPath := filepath.Join("cluster-resources", "pods", "logs", pod.Namespace, pod.Name, fmt.Sprintf("%s-logs-errors.log", container.Name))
-				output.SaveResult(c.BundlePath, errPath, bytes.NewBuffer([]byte(err.Error())))
-			}
-			// Add logs collector results to the rest of the output
-			output.AddResult(podLogs)
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		pods, podErrors, unhealthyPods := pods(ctx, client, namespaceNames)
+		for k, v := range pods {
+			output.SaveResult(c.BundlePath, path.Join("cluster-resources/pods", k), bytes.NewBuffer(v))
 		}
+		output.SaveResult(c.BundlePath, "cluster-resources/pods-errors.json", marshalErrors(podErrors))
+
+		for _, pod := range unhealthyPods {
+			allContainers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+			for _, container := range allContainers {
+				logsRoot := ""
+				if c.BundlePath != "" {
+					logsRoot = path.Join(c.BundlePath, "cluster-resources", "pods", "logs", pod.Namespace)
+				}
+				limits := &troubleshootv1beta2.LogLimits{
+					MaxLines: 500,
+				}
+				podLogs, err := savePodLogs(ctx, logsRoot, client, &pod, "", container.Name, limits, false, false)
+				if err != nil {
+					errPath := filepath.Join("cluster-resources", "pods", "logs", pod.Namespace, pod.Name, fmt.Sprintf("%s-logs-errors.log", container.Name))
+					output.SaveResult(c.BundlePath, errPath, bytes.NewBuffer([]byte(err.Error())))
+				}
+				for k, v := range podLogs {
+					output[filepath.Join("cluster-resources", "pods", "logs", pod.Namespace, k)] = v
+				}
+			}
+		}
+	})
+
+	// these collect functions all have the exact same args and structure to run them
+	apiQueries := []apiQuery{
+		{getPodDisruptionBudgets, "pod-disruption-budgets"},
+		{services, "services"},
+		{deployments, "deployments"},
+		{statefulsets, "statefulsets"},
+		{replicasets, "replicasets"},
+		{jobs, "jobs"},
+		{cronJobs, "cronjobs"},
+		{ingress, "ingress"},
+		{networkPolicy, "network-policy"},
+		{resourceQuota, "resource-quotas"},
+		{imagePullSecrets, "image-pull-secrets"},
+		{limitRanges, "limitranges"},
+		{events, "events"},
+		{pvcs, "pvcs"},
+		{roles, "roles"},
+		{roleBindings, "rolebindings"},
 	}
 
-	// pod disruption budgets
-
-	PodDisruptionBudgets, pdbError := getPodDisruptionBudgets(ctx, client, namespaceNames)
-	for k, v := range PodDisruptionBudgets {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/pod-disruption-budgets", k), bytes.NewBuffer(v))
+	// add the above collect functions to the queue
+	for _, thisQuery := range apiQueries {
+		clusterResourceCollectors = append(clusterResourceCollectors, func() {
+			queryOutput, errors := thisQuery.queryFunction(ctx, client, namespaceNames)
+			for k, v := range queryOutput {
+				output.SaveResult(c.BundlePath, path.Join("cluster-resources", thisQuery.saveLocation, k), bytes.NewBuffer(v))
+			}
+			output.SaveResult(c.BundlePath, "cluster-resources/"+thisQuery.saveLocation+".json", marshalErrors(errors))
+		})
 	}
-	output.SaveResult(c.BundlePath, "cluster-resources/pod-disruption-budgets-info.json", marshalErrors(pdbError))
-
-	// services
-	services, servicesErrors := services(ctx, client, namespaceNames)
-	for k, v := range services {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/services", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/services-errors.json", marshalErrors(servicesErrors))
-
-	// deployments
-	deployments, deploymentsErrors := deployments(ctx, client, namespaceNames)
-	for k, v := range deployments {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/deployments", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/deployments-errors.json", marshalErrors(deploymentsErrors))
-
-	// statefulsets
-	statefulsets, statefulsetsErrors := statefulsets(ctx, client, namespaceNames)
-	for k, v := range statefulsets {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/statefulsets", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/statefulsets-errors.json", marshalErrors(statefulsetsErrors))
-
-	// replicasets
-	replicasets, replicasetsErrors := replicasets(ctx, client, namespaceNames)
-	for k, v := range replicasets {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/replicasets", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/replicasets-errors.json", marshalErrors(replicasetsErrors))
-
-	// jobs
-	jobs, jobsErrors := jobs(ctx, client, namespaceNames)
-	for k, v := range jobs {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/jobs", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/jobs-errors.json", marshalErrors(jobsErrors))
-
-	// cronJobs
-	cronJobs, cronJobsErrors := cronJobs(ctx, client, namespaceNames)
-	for k, v := range cronJobs {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/cronjobs", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/cronjobs-errors.json", marshalErrors(cronJobsErrors))
-
-	// ingress
-	ingress, ingressErrors := ingress(ctx, client, namespaceNames)
-	for k, v := range ingress {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/ingress", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/ingress-errors.json", marshalErrors(ingressErrors))
-
-	// network policy
-	networkPolicy, networkPolicyErrors := networkPolicy(ctx, client, namespaceNames)
-	for k, v := range networkPolicy {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/network-policy", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/network-policy-errors.json", marshalErrors(networkPolicyErrors))
-
-	// resource quotas
-	resourceQuota, resourceQuotaErrors := resourceQuota(ctx, client, namespaceNames)
-	for k, v := range resourceQuota {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/resource-quotas", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/resource-quota-errors.json", marshalErrors(resourceQuotaErrors))
 
 	// storage classes
-	storageClasses, storageErrors := storageClasses(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/storage-classes.json", bytes.NewBuffer(storageClasses))
-	output.SaveResult(c.BundlePath, "cluster-resources/storage-errors.json", marshalErrors(storageErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		storageClasses, storageErrors := storageClasses(ctx, client)
+		output.SaveResult(c.BundlePath, "cluster-resources/storage-classes.json", bytes.NewBuffer(storageClasses))
+		output.SaveResult(c.BundlePath, "cluster-resources/storage-errors.json", marshalErrors(storageErrors))
+	})
 
 	// crds
-	customResourceDefinitions, crdErrors := crds(ctx, client, c.ClientConfig)
-	output.SaveResult(c.BundlePath, "cluster-resources/custom-resource-definitions.json", bytes.NewBuffer(customResourceDefinitions))
-	output.SaveResult(c.BundlePath, "cluster-resources/custom-resource-definitions-errors.json", marshalErrors(crdErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		customResourceDefinitions, crdErrors := crds(ctx, client, c.ClientConfig)
+		output.SaveResult(c.BundlePath, "cluster-resources/custom-resource-definitions.json", bytes.NewBuffer(customResourceDefinitions))
+		output.SaveResult(c.BundlePath, "cluster-resources/custom-resource-definitions-errors.json", marshalErrors(crdErrors))
+	})
 
 	// crs
-	customResources, crErrors := crs(ctx, dynamicClient, client, c.ClientConfig, namespaceNames)
-	for k, v := range customResources {
-		output.SaveResult(c.BundlePath, fmt.Sprintf("cluster-resources/custom-resources/%v", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/custom-resources/custom-resources-errors.json", marshalErrors(crErrors))
-
-	// imagepullsecrets
-	imagePullSecrets, pullSecretsErrors := imagePullSecrets(ctx, client, namespaceNames)
-	for k, v := range imagePullSecrets {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/image-pull-secrets", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/image-pull-secrets-errors.json", marshalErrors(pullSecretsErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		customResources, crErrors := crs(ctx, dynamicClient, client, c.ClientConfig, namespaceNames)
+		for k, v := range customResources {
+			output.SaveResult(c.BundlePath, fmt.Sprintf("cluster-resources/custom-resources/%v", k), bytes.NewBuffer(v))
+		}
+		output.SaveResult(c.BundlePath, "cluster-resources/custom-resources/custom-resources-errors.json", marshalErrors(crErrors))
+	})
 
 	// nodes
-	nodes, nodeErrors := nodes(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/nodes.json", bytes.NewBuffer(nodes))
-	output.SaveResult(c.BundlePath, "cluster-resources/nodes-errors.json", marshalErrors(nodeErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		nodes, nodeErrors := nodes(ctx, client)
+		output.SaveResult(c.BundlePath, "cluster-resources/nodes.json", bytes.NewBuffer(nodes))
+		output.SaveResult(c.BundlePath, "cluster-resources/nodes-errors.json", marshalErrors(nodeErrors))
+	})
 
-	groups, resources, groupsResourcesErrors := apiResources(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/groups.json", bytes.NewBuffer(groups))
-	output.SaveResult(c.BundlePath, "cluster-resources/resources.json", bytes.NewBuffer(resources))
-	output.SaveResult(c.BundlePath, "cluster-resources/groups-resources-errors.json", marshalErrors(groupsResourcesErrors))
-
-	// limit ranges
-	limitRanges, limitRangesErrors := limitRanges(ctx, client, namespaceNames)
-	for k, v := range limitRanges {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/limitranges", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/limitranges-errors.json", marshalErrors(limitRangesErrors))
-
-	//Events
-	events, eventsErrors := events(ctx, client, namespaceNames)
-	for k, v := range events {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/events", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/events-errors.json", marshalErrors(eventsErrors))
+	// apiResources
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		groups, resources, groupsResourcesErrors := apiResources(ctx, client)
+		output.SaveResult(c.BundlePath, "cluster-resources/groups.json", bytes.NewBuffer(groups))
+		output.SaveResult(c.BundlePath, "cluster-resources/resources.json", bytes.NewBuffer(resources))
+		output.SaveResult(c.BundlePath, "cluster-resources/groups-resources-errors.json", marshalErrors(groupsResourcesErrors))
+	})
 
 	//Persistent Volumes
-	pvs, pvsErrors := pvs(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/pvs.json", bytes.NewBuffer(pvs))
-	output.SaveResult(c.BundlePath, "cluster-resources/pvs-errors.json", marshalErrors(pvsErrors))
-
-	//Persistent Volume Claims
-	pvcs, pvcsErrors := pvcs(ctx, client, namespaceNames)
-	for k, v := range pvcs {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/pvcs", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/pvcs-errors.json", marshalErrors(pvcsErrors))
-
-	//Roles
-	roles, rolesErrors := roles(ctx, client, namespaceNames)
-	for k, v := range roles {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/roles", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/roles-errors.json", marshalErrors(rolesErrors))
-
-	//Role Bindings
-	roleBindings, roleBindingsErrors := roleBindings(ctx, client, namespaceNames)
-	for k, v := range roleBindings {
-		output.SaveResult(c.BundlePath, path.Join("cluster-resources/rolebindings", k), bytes.NewBuffer(v))
-	}
-	output.SaveResult(c.BundlePath, "cluster-resources/rolebindings-errors.json", marshalErrors(roleBindingsErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		pvs, pvsErrors := pvs(ctx, client)
+		output.SaveResult(c.BundlePath, "cluster-resources/pvs.json", bytes.NewBuffer(pvs))
+		output.SaveResult(c.BundlePath, "cluster-resources/pvs-errors.json", marshalErrors(pvsErrors))
+	})
 
 	//Cluster Roles
-	clusterRoles, clusterRolesErrors := clusterRoles(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/clusterroles.json", bytes.NewBuffer(clusterRoles))
-	output.SaveResult(c.BundlePath, "cluster-resources/clusterroles-errors.json", marshalErrors(clusterRolesErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		clusterRoles, clusterRolesErrors := clusterRoles(ctx, client)
+		output.SaveResult(c.BundlePath, "cluster-resources/clusterroles.json", bytes.NewBuffer(clusterRoles))
+		output.SaveResult(c.BundlePath, "cluster-resources/clusterroles-errors.json", marshalErrors(clusterRolesErrors))
+	})
 
 	//Cluster Role Bindings
-	clusterRoleBindings, clusterRoleBindingsErrors := clusterRoleBindings(ctx, client)
-	output.SaveResult(c.BundlePath, "cluster-resources/clusterRoleBindings.json", bytes.NewBuffer(clusterRoleBindings))
-	output.SaveResult(c.BundlePath, "cluster-resources/clusterRoleBindings-errors.json", marshalErrors(clusterRoleBindingsErrors))
+	clusterResourceCollectors = append(clusterResourceCollectors, func() {
+		clusterRoleBindings, clusterRoleBindingsErrors := clusterRoleBindings(ctx, client)
+		output.SaveResult(c.BundlePath, "cluster-resources/clusterRoleBindings.json", bytes.NewBuffer(clusterRoleBindings))
+		output.SaveResult(c.BundlePath, "cluster-resources/clusterRoleBindings-errors.json", marshalErrors(clusterRoleBindingsErrors))
+	})
 
+	// run the collectors
+
+	maxNbConcurrentGoroutines := 5
+	concurrentGoroutines := make(chan struct{}, maxNbConcurrentGoroutines)
+
+	for _, thisClusterResourceCollector := range clusterResourceCollectors {
+		wg.Add(1)
+		go func(crCollector getClusterResource) {
+			defer wg.Done()
+			concurrentGoroutines <- struct{}{}
+			crCollector()
+			<-concurrentGoroutines
+		}(thisClusterResourceCollector)
+	}
+	wg.Wait()
 	return output, nil
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -7,4 +7,6 @@ const (
 	DEFAULT_CLIENT_BURST = 100
 	// DEFAULT_CLIENT_USER_AGENT is an field that specifies the caller of troubleshoot request.
 	DEFAULT_CLIENT_USER_AGENT = "ReplicatedTroubleshoot"
+	// DEFAULT_MAX_NB_CONCURRENT_COLLECTORS specifies the maximum number of goroutines to run at once during collection.
+	DEFAULT_MAX_NB_CONCURRENT_COLLECTORS = 5
 )


### PR DESCRIPTION
## Description, Motivation and Context

Adds concurrency to the clusterResources collector, in an attempt to speed it up

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
