### PR TITLE
fix(collectors): store unhealthy pod logs correctly

### DIFF
--- a/pkg/collect/logs_test.go
+++ b/pkg/collect/logs_test.go
@@ -85,12 +85,14 @@ func Test_savePodLogs(t *testing.T) {
 		name              string
 		withContainerName bool
 		collectorName     string
+		createSymLinks    bool
 		want              CollectorResult
 	}{
 		{
 			name:              "with container name",
 			withContainerName: true,
 			collectorName:     "all-logs",
+			createSymLinks:    true,
 			want: CollectorResult{
 				"all-logs/test-pod/nginx.log":                                          []byte("fake logs"),
 				"all-logs/test-pod/nginx-previous.log":                                 []byte("fake logs"),
@@ -102,6 +104,7 @@ func Test_savePodLogs(t *testing.T) {
 			name:              "without container name",
 			withContainerName: false,
 			collectorName:     "all-logs",
+			createSymLinks:    true,
 			want: CollectorResult{
 				"all-logs/test-pod.log":                                                []byte("fake logs"),
 				"all-logs/test-pod-previous.log":                                       []byte("fake logs"),
@@ -112,9 +115,20 @@ func Test_savePodLogs(t *testing.T) {
 		{
 			name:              "without container or collector names",
 			withContainerName: false,
+			createSymLinks:    true,
 			want: CollectorResult{
 				"/test-pod.log":          []byte("fake logs"),
 				"/test-pod-previous.log": []byte("fake logs"),
+				"cluster-resources/pods/logs/my-namespace/test-pod/nginx.log":          []byte("fake logs"),
+				"cluster-resources/pods/logs/my-namespace/test-pod/nginx-previous.log": []byte("fake logs"),
+			},
+		},
+		{
+			name:              "without sym links",
+			withContainerName: true,
+			collectorName:     "all-logs",
+			createSymLinks:    false,
+			want: CollectorResult{
 				"cluster-resources/pods/logs/my-namespace/test-pod/nginx.log":          []byte("fake logs"),
 				"cluster-resources/pods/logs/my-namespace/test-pod/nginx-previous.log": []byte("fake logs"),
 			},
@@ -144,7 +158,7 @@ func Test_savePodLogs(t *testing.T) {
 			if !tt.withContainerName {
 				containerName = ""
 			}
-			got, err := savePodLogsWithInterface(ctx, "", client, pod, tt.collectorName, containerName, limits, false)
+			got, err := savePodLogsWithInterface(ctx, "", client, pod, tt.collectorName, containerName, limits, false, tt.createSymLinks)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -179,7 +179,7 @@ func runWithoutTimeout(ctx context.Context, bundlePath string, clientConfig *res
 	limits := troubleshootv1beta2.LogLimits{
 		MaxLines: 10000,
 	}
-	podLogs, err := savePodLogs(ctx, bundlePath, client, pod, collectorName, "", &limits, true)
+	podLogs, err := savePodLogs(ctx, bundlePath, client, pod, collectorName, "", &limits, true, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod logs")
 	}


### PR DESCRIPTION
## Description, Motivation and Context

The symlinking logs feature led to a regression where symlinks of unhealthy pods were overwritting logs in the support bundle. This fix allows the cluster resources collector to instruct the logs collector not to symlink logs, which in turn ensures logs are not overwritten.

Before
<img width="850" alt="image" src="https://user-images.githubusercontent.com/681087/207671580-07ede47a-3504-442c-8e8d-716887f2b466.png">

After
<img width="851" alt="image" src="https://user-images.githubusercontent.com/681087/207671922-f603e7d5-5573-4604-99f1-04a29d7c1767.png">

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #908

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
