### PR TITLE
fixed merge conflicts

### DIFF
--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -100,6 +100,7 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 						}
 						for k, v := range podLogs {
 							output[k] = v
+							resultCh <- output
 						}
 					}
 				} else {
@@ -115,6 +116,7 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 						}
 						for k, v := range containerLogs {
 							output[k] = v
+							resultCh <- output
 						}
 					}
 				}

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 	"strings"
 	"time"
@@ -46,67 +47,94 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 
 	ctx := context.Background()
 
-	if c.SinceTime != nil {
-		if c.Collector.Limits == nil {
-			c.Collector.Limits = new(troubleshootv1beta2.LogLimits)
+	const timeout = 60 //timeout in seconds used for context timeout value
+
+	// timeout context
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), timeout*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	resultCh := make(chan CollectorResult, 1)
+
+	//wrapped code go func for context timeout solution
+	go func() {
+
+		output := NewResult()
+
+		if c.SinceTime != nil {
+			if c.Collector.Limits == nil {
+				c.Collector.Limits = new(troubleshootv1beta2.LogLimits)
+			}
+			c.Collector.Limits.SinceTime = metav1.NewTime(*c.SinceTime)
 		}
-		c.Collector.Limits.SinceTime = metav1.NewTime(*c.SinceTime)
-	}
 
-	pods, podsErrors := listPodsInSelectors(ctx, client, c.Collector.Namespace, c.Collector.Selector)
-	if len(podsErrors) > 0 {
-		output.SaveResult(c.BundlePath, getLogsErrorsFileName(c.Collector), marshalErrors(podsErrors))
-	}
+		pods, podsErrors := listPodsInSelectors(ctx, client, c.Collector.Namespace, c.Collector.Selector)
+		if len(podsErrors) > 0 {
+			output.SaveResult(c.BundlePath, getLogsErrorsFileName(c.Collector), marshalErrors(podsErrors))
+		}
 
-	if len(pods) > 0 {
-		for _, pod := range pods {
-			if len(c.Collector.ContainerNames) == 0 {
-				// make a list of all the containers in the pod, so that we can get logs from all of them
-				containerNames := []string{}
-				for _, container := range pod.Spec.Containers {
-					containerNames = append(containerNames, container.Name)
-				}
-				for _, container := range pod.Spec.InitContainers {
-					containerNames = append(containerNames, container.Name)
-				}
+		if len(pods) > 0 {
+			for _, pod := range pods {
+				if len(c.Collector.ContainerNames) == 0 {
+					// make a list of all the containers in the pod, so that we can get logs from all of them
+					containerNames := []string{}
+					for _, container := range pod.Spec.Containers {
+						containerNames = append(containerNames, container.Name)
+					}
+					for _, container := range pod.Spec.InitContainers {
+						containerNames = append(containerNames, container.Name)
+					}
 
-				for _, containerName := range containerNames {
-					podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
-					if err != nil {
-						key := fmt.Sprintf("%s/%s-errors.json", c.Collector.Name, pod.Name)
-						if containerName != "" {
-							key = fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, containerName)
-						}
-						err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
+					for _, containerName := range containerNames {
+						podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
 						if err != nil {
-							return nil, err
+							key := fmt.Sprintf("%s/%s-errors.json", c.Collector.Name, pod.Name)
+							if containerName != "" {
+								key = fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, containerName)
+							}
+							err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
+							if err != nil {
+								log.Println(err)
+							}
+							continue
 						}
-						continue
+						for k, v := range podLogs {
+							output[k] = v
+						}
 					}
-					for k, v := range podLogs {
-						output[k] = v
-					}
-				}
-			} else {
-				for _, container := range c.Collector.ContainerNames {
-					containerLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, container, c.Collector.Limits, false, true)
-					if err != nil {
-						key := fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, container)
-						err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
+				} else {
+					for _, container := range c.Collector.ContainerNames {
+						containerLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, container, c.Collector.Limits, false, true)
 						if err != nil {
-							return nil, err
+							key := fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, container)
+							err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
+							if err != nil {
+								log.Println(err)
+							}
+							continue
 						}
-						continue
-					}
-					for k, v := range containerLogs {
-						output[k] = v
+						for k, v := range containerLogs {
+							output[k] = v
+						}
 					}
 				}
 			}
+			resultCh <- output
 		}
-	}
 
-	return output, nil
+	}()
+
+	select {
+	case <-ctxTimeout.Done():
+		return nil, errors.New("context timeout exceeded")
+	case output := <-resultCh:
+		return output, nil
+	case err := <-errCh:
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return output, err
+	}
 }
 
 func listPodsInSelectors(ctx context.Context, client kubernetes.Interface, namespace string, selector []string) ([]corev1.Pod, []string) {

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"path/filepath"
 	"strings"
 	"time"
@@ -94,7 +93,7 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 							}
 							err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
 							if err != nil {
-								log.Println(err)
+								errCh <- err
 							}
 							continue
 						}
@@ -110,7 +109,7 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 							key := fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, container)
 							err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
 							if err != nil {
-								log.Println(err)
+								errCh <- err
 							}
 							continue
 						}


### PR DESCRIPTION
## Description, Motivation and Context

This change wraps the log collector code into a go function and implements a timeout context.  The intention is to limit the amount of time Troubleshoot will wait for a pod log to be collected.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [X] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
https://replicated.zoom.us/rec/share/OmbJglomqirmDdi_OW9h4NaTs5FdxNDxy0SrTI_A1Bzv8SnZKWkw026eSmcV_KDE.bw6loRj6SqU6oxhy?startTime=1671059574000
Passcode: f2YY3=D2