### PR TITLE
Use GenerateName for runpod collector

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -333,7 +333,7 @@ the %s Admin Console to begin analysis.`
 			return nil
 		}
 
-		fmt.Printf("%s\n", response.ArchivePath)
+		fmt.Printf("\n%s\n", response.ArchivePath)
 		return nil
 	}
 

--- a/examples/preflight/e2e.yaml
+++ b/examples/preflight/e2e.yaml
@@ -44,7 +44,7 @@ spec:
               message: You have at least 5 replicas
     - textAnalyze:
         checkName: Said hi!
-        fileName: /static-hi.log
+        fileName: /static-hi*.log
         regex: 'hi static'
         outcomes:
           - fail:

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"sync"
 	"time"
@@ -119,9 +120,9 @@ func runPodWithSpec(ctx context.Context, client *kubernetes.Clientset, runPodCol
 
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-			Labels:    podLabels,
+			GenerateName: fmt.Sprintf("%s-", podName),
+			Namespace:    namespace,
+			Labels:       podLabels,
 		},
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",


### PR DESCRIPTION
## Description, Motivation and Context

Uses `generateName` to give a unique name to the Pods that are created by the `runPod` collector. This will prevent conflicts in the event that an old runPod collector is still running from a failed run, or if one day the `runPod` collector were to be run conurrently

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
