### PR TITLE
feat(cluster_resources): increase default client burst and qps

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,7 +1,10 @@
 package constants
 
 const (
-	DEFAULT_CLIENT_QPS        = 100
-	DEFAULT_CLIENT_BURST      = 100
+	// DEFAULT_CLIENT_QPS indicates the maximum QPS from troubleshoot client.
+	DEFAULT_CLIENT_QPS = 100
+	// DEFAULT_CLIENT_QPS is maximum burst for throttle.
+	DEFAULT_CLIENT_BURST = 100
+	// DEFAULT_CLIENT_USER_AGENT is an field that specifies the caller of troubleshoot request.
 	DEFAULT_CLIENT_USER_AGENT = "ReplicatedTroubleshoot"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,7 @@
+package constants
+
+const (
+	DEFAULT_CLIENT_QPS        = 100
+	DEFAULT_CLIENT_BURST      = 100
+	DEFAULT_CLIENT_USER_AGENT = "ReplicatedTroubleshoot"
+)

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -11,6 +11,7 @@ import (
 	analyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/replicatedhq/troubleshoot/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -130,6 +131,10 @@ func Collect(opts CollectOpts, p *troubleshootv1beta2.Preflight) (CollectResult,
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
 	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
+
+	opts.KubernetesRestConfig.QPS = 100
+	opts.KubernetesRestConfig.Burst = 100
+	opts.KubernetesRestConfig.UserAgent = fmt.Sprintf("ReplicatedTroubleshoot/%s", version.Version())
 
 	k8sClient, err := kubernetes.NewForConfig(opts.KubernetesRestConfig)
 	if err != nil {

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -11,6 +11,7 @@ import (
 	analyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	"github.com/replicatedhq/troubleshoot/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -132,9 +133,9 @@ func Collect(opts CollectOpts, p *troubleshootv1beta2.Preflight) (CollectResult,
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
 	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
 
-	opts.KubernetesRestConfig.QPS = 100
-	opts.KubernetesRestConfig.Burst = 100
-	opts.KubernetesRestConfig.UserAgent = fmt.Sprintf("ReplicatedTroubleshoot/%s", version.Version())
+	opts.KubernetesRestConfig.QPS = constants.DEFAULT_CLIENT_QPS
+	opts.KubernetesRestConfig.Burst = constants.DEFAULT_CLIENT_BURST
+	opts.KubernetesRestConfig.UserAgent = fmt.Sprintf("%s/%s", constants.DEFAULT_CLIENT_USER_AGENT, version.Version())
 
 	k8sClient, err := kubernetes.NewForConfig(opts.KubernetesRestConfig)
 	if err != nil {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -13,6 +13,7 @@ import (
 	analyze "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	"github.com/replicatedhq/troubleshoot/pkg/convert"
 	"github.com/replicatedhq/troubleshoot/pkg/version"
 	"gopkg.in/yaml.v2"
@@ -77,9 +78,9 @@ func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactor
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
 	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
 
-	opts.KubernetesRestConfig.QPS = 100
-	opts.KubernetesRestConfig.Burst = 100
-	opts.KubernetesRestConfig.UserAgent = fmt.Sprintf("ReplicatedTroubleshoot/%s", version.Version())
+	opts.KubernetesRestConfig.QPS = constants.DEFAULT_CLIENT_QPS
+	opts.KubernetesRestConfig.Burst = constants.DEFAULT_CLIENT_BURST
+	opts.KubernetesRestConfig.UserAgent = fmt.Sprintf("%s/%s", constants.DEFAULT_CLIENT_USER_AGENT, version.Version())
 
 	k8sClient, err := kubernetes.NewForConfig(opts.KubernetesRestConfig)
 	if err != nil {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -77,6 +77,10 @@ func runCollectors(collectors []*troubleshootv1beta2.Collect, additionalRedactor
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
 	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
 
+	opts.KubernetesRestConfig.QPS = 100
+	opts.KubernetesRestConfig.Burst = 100
+	opts.KubernetesRestConfig.UserAgent = fmt.Sprintf("ReplicatedTroubleshoot/%s", version.Version())
+
 	k8sClient, err := kubernetes.NewForConfig(opts.KubernetesRestConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate Kubernetes client")


### PR DESCRIPTION
## Description, Motivation and Context

- Increase default QPS from 5 to 100
- Increase default Burst from 10 to 100
- Add UserAgent Header to identify it is from Troubleshoot once it is increasing the number of queries

Shortcut:
- https://app.shortcut.com/replicated/story/22748/preflights-are-very-slow-on-openshift

Issues: 
- https://github.com/replicated-collab/settlemint-replicated/issues/87
- https://github.com/replicated-collab/schrodinger-replicated/issues/62

Reference:
- https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/k8sutil/k8sutil.go#L109

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
