### PR TITLE
fix: collect rbac permissions error

### DIFF
--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -172,7 +172,6 @@ func Collect(opts CollectOpts, p *troubleshootv1beta2.Preflight) (CollectResult,
 			allCollectors = append(allCollectors, collectors...)
 		}
 
-		foundForbidden = false
 		for _, collector := range collectors {
 			for _, e := range collector.GetRBACErrors() {
 				foundForbidden = true


### PR DESCRIPTION
## Description, Motivation and Context

This PR fixes an issue where the `Collect(...)` function was not returning the expected error in cases where a collector failed because of RBAC permissions.  This is because `foundForbidden` was being reset to `false` on each iteration of the for loop, so even if it had previously been set to `true`, the final result may be incorrect.

This can be reproduced by running the preflight binary with the `--collect-without-permissions=false`.  The the expected behavior is the the program exits with: `Error: failed to collect in cluster: insufficient permissions to run all collectors`, but because of this bug, it does not.

Fixes: #929

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
