### PR TITLE
If no pods are selected for log collector, do not wait for timeout

### DIFF
--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -117,6 +117,8 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 					}
 				}
 			}
+		} else {
+			resultCh <- output
 		}
 	}()
 


### PR DESCRIPTION
## Description, Motivation and Context

In the logs collector, if a selector doesn't match any pods, the following select will wait for the context to time out since nothing writes to the result channel.  This adds a simple writer in the case when there are no pods selected, so that the code can move on.

Fixes: #931

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
