### PR TITLE
preflight: fix segfault when collector's are not defined in YAML

### DIFF
--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -84,7 +84,9 @@ func (cr RemoteCollectResult) IsRBACAllowed() bool {
 // CollectHost runs the collection phase of host preflight checks
 func CollectHost(opts CollectOpts, p *troubleshootv1beta2.HostPreflight) (CollectResult, error) {
 	collectSpecs := make([]*troubleshootv1beta2.HostCollect, 0, 0)
-	collectSpecs = append(collectSpecs, p.Spec.Collectors...)
+	if p != nil && p.Spec.Collectors != nil {
+		collectSpecs = append(collectSpecs, p.Spec.Collectors...)
+	}
 
 	allCollectedData := make(map[string][]byte)
 
@@ -128,7 +130,9 @@ func Collect(opts CollectOpts, p *troubleshootv1beta2.Preflight) (CollectResult,
 	var foundForbidden bool
 
 	collectSpecs := make([]*troubleshootv1beta2.Collect, 0, 0)
-	collectSpecs = append(collectSpecs, p.Spec.Collectors...)
+	if p != nil && p.Spec.Collectors != nil {
+		collectSpecs = append(collectSpecs, p.Spec.Collectors...)
+	}
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}})
 	collectSpecs = collect.EnsureCollectorInList(collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}})
 	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
@@ -267,7 +271,9 @@ func Collect(opts CollectOpts, p *troubleshootv1beta2.Preflight) (CollectResult,
 // Collect runs the collection phase of preflight checks
 func CollectRemote(opts CollectOpts, p *troubleshootv1beta2.HostPreflight) (CollectResult, error) {
 	collectSpecs := make([]*troubleshootv1beta2.RemoteCollect, 0, 0)
-	collectSpecs = append(collectSpecs, p.Spec.RemoteCollectors...)
+	if p != nil && p.Spec.RemoteCollectors != nil {
+		collectSpecs = append(collectSpecs, p.Spec.RemoteCollectors...)
+	}
 
 	allCollectedData := make(map[string][]byte)
 

--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -132,7 +132,7 @@ func RunPreflights(interactive bool, output string, format string, args []string
 					preflightSpec = ConcatPreflightSpec(preflightSpec, spec)
 				}
 			} else {
-				uploadResultSpecs = append(uploadResultSpecs, preflightSpec)
+				uploadResultSpecs = append(uploadResultSpecs, spec)
 			}
 		} else if spec, ok := obj.(*troubleshootv1beta2.HostPreflight); ok {
 			if i == 0 {


### PR DESCRIPTION
## Description, Motivation and Context

When testing `kubectl preflight` to attempt to fix https://github.com/replicatedhq/troubleshoot/issues/905#issuecomment-1366994118 - I noticed a `SIGSEGV` if there are no `collectors` under `spec` in the input YAML.

This PR at least avoids an early crash, doesn't fix the root cause of https://github.com/replicatedhq/troubleshoot/issues/905 yet though.

```
~/git/replicatedhq/troubleshoot/cmd/preflight main *4 ?1 ❯ ./preflight --format=yaml --interactive=false --output=/tmp/output ~/troubleshoot905/troubleshoot_v1beta2_preflight.yaml                   8s 13:07:59
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x118 pc=0x1048488a4]

goroutine 1 [running]:
github.com/replicatedhq/troubleshoot/pkg/preflight.Collect({{0x0, 0x0}, 0x1, 0x14000acfd40, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...)
	/Users/nathan/git/replicatedhq/troubleshoot/pkg/preflight/collect.go:131 +0x54
github.com/replicatedhq/troubleshoot/pkg/preflight.collectInCluster(0x0, 0x1400010ec00)
	/Users/nathan/git/replicatedhq/troubleshoot/pkg/preflight/run.go:317 +0x194
github.com/replicatedhq/troubleshoot/pkg/preflight.RunPreflights(0x0, {0x16d21399f, 0xb}, {0x16d21397d, 0x4}, {0x14000727280, 0x1, 0x0?})
	/Users/nathan/git/replicatedhq/troubleshoot/pkg/preflight/run.go:176 +0xc74
github.com/replicatedhq/troubleshoot/cmd/preflight/cli.RootCmd.func2(0x14000a1c300?, {0x14000727280, 0x1, 0x4})
	/Users/nathan/git/replicatedhq/troubleshoot/cmd/preflight/cli/root.go:33 +0x9c
github.com/spf13/cobra.(*Command).execute(0x14000a1c300, {0x1400012e010, 0x4, 0x4})
	/Users/nathan/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x14000a1c300)
	/Users/nathan/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/nathan/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/replicatedhq/troubleshoot/cmd/preflight/cli.InitAndExecute()
	/Users/nathan/git/replicatedhq/troubleshoot/cmd/preflight/cli/root.go:50 +0x20
main.main()
	/Users/nathan/git/replicatedhq/troubleshoot/cmd/preflight/main.go:9 +0x1c
```

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
