### PR TITLE
preflight: add yaml output format

### DIFF
--- a/pkg/preflight/stdout_results.go
+++ b/pkg/preflight/stdout_results.go
@@ -40,29 +40,29 @@ func showStdoutResultsHuman(preflightName string, analyzeResults []*analyzerunne
 	return nil
 }
 
-type StdoutResultOutput struct {
+type stdoutResultOutput struct {
 	Title   string `json:"title" yaml:"title"`
 	Message string `json:"message" yaml:"message"`
 	URI     string `json:"uri,omitempty" yaml:"uri,omitempty"`
 	Strict  bool   `json:"strict,omitempty" yaml:"strict,omitempty"`
 }
 
-type StdoutOutput struct {
-	Pass []StdoutResultOutput `json:"pass,omitempty" yaml:"pass,omitempty"`
-	Warn []StdoutResultOutput `json:"warn,omitempty" yaml:"warn,omitempty"`
-	Fail []StdoutResultOutput `json:"fail,omitempty" yaml:"fail,omitempty"`
+type stdoutOutput struct {
+	Pass []stdoutResultOutput `json:"pass,omitempty" yaml:"pass,omitempty"`
+	Warn []stdoutResultOutput `json:"warn,omitempty" yaml:"warn,omitempty"`
+	Fail []stdoutResultOutput `json:"fail,omitempty" yaml:"fail,omitempty"`
 }
 
 // Used by both JSON and YAML outputs
-func showStdoutResultsStructured(preflightName string, analyzeResults []*analyzerunner.AnalyzeResult) *StdoutOutput {
-	output := StdoutOutput{
-		Pass: []StdoutResultOutput{},
-		Warn: []StdoutResultOutput{},
-		Fail: []StdoutResultOutput{},
+func showStdoutResultsStructured(preflightName string, analyzeResults []*analyzerunner.AnalyzeResult) *stdoutOutput {
+	output := stdoutOutput{
+		Pass: []stdoutResultOutput{},
+		Warn: []stdoutResultOutput{},
+		Fail: []stdoutResultOutput{},
 	}
 
 	for _, analyzeResult := range analyzeResults {
-		resultOutput := StdoutResultOutput{
+		resultOutput := stdoutResultOutput{
 			Title:   analyzeResult.Title,
 			Message: analyzeResult.Message,
 			URI:     analyzeResult.URI,


### PR DESCRIPTION
## Description, Motivation and Context

`kubectl preflight --format=yaml` returns an error currently, `Error: unknown output format: "yaml"`.

This adds a valid YAML output format.

Fixes: https://github.com/replicatedhq/troubleshoot/issues/905

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->