### PR TITLE
Improve build-test-deploy GitHub Actions performance

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -192,7 +192,7 @@ jobs:
           name: collect
           path: bin/collect
 
-  goreleaser-test-collect:
+  goreleaser-test:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') != true
     steps:
@@ -210,47 +210,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --id collect
-
-  goreleaser-test-preflight:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --id preflight
-
-  goreleaser-test-support-bundle:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --id support-bundle
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml
 
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -192,7 +192,7 @@ jobs:
           name: collect
           path: bin/collect
 
-  goreleaser-test:
+  goreleaser-test-darwin-amd64:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') != true
     steps:
@@ -210,7 +210,125 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
+        env:
+          GOARCH: amd64
+          GOOS: darwin
+
+  goreleaser-test-linux-amd64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
+        env:
+          GOARCH: amd64
+          GOOS: linux
+
+  goreleaser-test-windows-amd64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
+        env:
+          GOARCH: amd64
+          GOOS: windows
+
+  goreleaser-test-darwin-arm64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
+        env:
+          GOARCH: arm64
+          GOOS: darwin
+
+  goreleaser-test-linux-arm64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
+        env:
+          GOARCH: arm64
+          GOOS: linux
+
+  goreleaser-test-windows-arm64:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
+        env:
+          GOARCH: arm64
+          GOOS: windows
 
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -192,7 +192,7 @@ jobs:
           name: collect
           path: bin/collect
 
-  goreleaser-test:
+  goreleaser-test-collect:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') != true
     steps:
@@ -210,7 +210,47 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --id collect
+
+  goreleaser-test-preflight:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --id preflight
+
+  goreleaser-test-support-bundle:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: "v0.183.0"
+          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --id support-bundle
 
   goreleaser:
     runs-on: ubuntu-latest

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -5,6 +5,8 @@ release:
     name: troubleshoot
 builds:
   - id: preflight
+    # NOTE: if you add any additional goos/goarch values, ensure you update ../.github/workflows/build-test-deploy.yaml
+    # with the respective goreleaser-test-* jobs
     goos:
       - linux
       - darwin


### PR DESCRIPTION
## Description, Motivation and Context

Split `goreleaser-test` into 6 GitHub Action's, based on `GOARCH`/`GOOS` (sharing a single goreleaser config file). This allows GitHub to execute them in parallel.

Rationale: `goreleaser-test` was taking 12-14mins and is the outlier longest action to execute right now on this repo, for every PR...

I didn't touch the tagged release action, that should remain as-is (a single atomic operation) and that doesn't get executed that often.

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
