### PR TITLE
GitHub Action goreleaser-test - convert to a matrix

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -192,9 +192,13 @@ jobs:
           name: collect
           path: bin/collect
 
-  goreleaser-test-darwin-amd64:
+  goreleaser-test:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') != true
+    strategy:
+      matrix:
+        goarch: [amd64, arm64]
+        goos: [darwin, linux, windows]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -212,123 +216,8 @@ jobs:
           version: "v0.183.0"
           args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
         env:
-          GOARCH: amd64
-          GOOS: darwin
-
-  goreleaser-test-linux-amd64:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
-        env:
-          GOARCH: amd64
-          GOOS: linux
-
-  goreleaser-test-windows-amd64:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
-        env:
-          GOARCH: amd64
-          GOOS: windows
-
-  goreleaser-test-darwin-arm64:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
-        env:
-          GOARCH: arm64
-          GOOS: darwin
-
-  goreleaser-test-linux-arm64:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
-        env:
-          GOARCH: arm64
-          GOOS: linux
-
-  goreleaser-test-windows-arm64:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') != true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: "v0.183.0"
-          args: build --rm-dist --snapshot --config deploy/.goreleaser.yaml --single-target
-        env:
-          GOARCH: arm64
-          GOOS: windows
+          GOARCH: ${{ matrix.goarch }}
+          GOOS: ${{ matrix.goos }}
 
   goreleaser:
     runs-on: ubuntu-latest

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -6,7 +6,7 @@ release:
 builds:
   - id: preflight
     # NOTE: if you add any additional goos/goarch values, ensure you update ../.github/workflows/build-test-deploy.yaml
-    # with the respective goreleaser-test-* jobs
+    # specifically the matrix values for goreleaser-test
     goos:
       - linux
       - darwin


### PR DESCRIPTION
## Description, Motivation and Context

This is a cleaner way to perform the 6~ (current) GitHub Action jobs for `goreleaser-test` without repetition.

Same outcome as before, but DRY.

Improvement to https://github.com/replicatedhq/troubleshoot/pull/941

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
