### PR TITLE
fix: Collect logs from all pods specified in logs collector spec

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "time"
+
 const (
 	// DEFAULT_CLIENT_QPS indicates the maximum QPS from troubleshoot client.
 	DEFAULT_CLIENT_QPS = 100
@@ -9,4 +11,6 @@ const (
 	DEFAULT_CLIENT_USER_AGENT = "ReplicatedTroubleshoot"
 	// VersionFilename is the name of the file that contains the support bundle version.
 	VersionFilename = "version.yaml"
+	// DEFAULT_LOGS_COLLECTOR_TIMEOUT is the default timeout for logs collector.
+	DEFAULT_LOGS_COLLECTOR_TIMEOUT = 60 * time.Second
 )


### PR DESCRIPTION
## Description, Motivation and Context

Ensure the go routine in the logs collector signals completion (via a channel) when all logs from the expected pods are collected.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
-->

Fixes: #945

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
