### PR TITLE
Fixes issue 985. update readme to change the flags on the cosign command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ A signed SBOM  that includes Troubleshoot dependencies is included in each relea
 The following example illustrates using [cosign](https://github.com/sigstore/cosign) to verify that **troubleshoot-sbom.tgz** has
 not been tampered with.
 ```
-$ cosign verify-blob -key key.pub -signature troubleshoot-sbom.tgz.sig troubleshoot-sbom.tgz
+$ cosign verify-blob --key key.pub --signature troubleshoot-sbom.tgz.sig troubleshoot-sbom.tgz
 Verified OK
 ```


### PR DESCRIPTION

## Description, Motivation and Context

Fixes issue 985. 
Update README to change the flags on the cosign command. the use -key and -signature are getting deprecated. Update the documentation so the cosign command documented should instead use double dashes on these flags. 

Use of --key and --signature instead -key and -signature

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes #985 

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
