### PR TITLE
Kube certs collector davidr

### DIFF
--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -162,6 +162,10 @@ type HostRun struct {
 	Args              []string `json:"args"`
 }
 
+type KubeSSLCertCollect struct {
+	CollectorMeta `json:",inline" yaml:",inline"`
+}
+
 type HostCollect struct {
 	CPU                   *CPU                   `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	Memory                *Memory                `json:"memory,omitempty" yaml:"memory,omitempty"`
@@ -183,6 +187,7 @@ type HostCollect struct {
 	HostServices          *HostServices          `json:"hostServices,omitempty" yaml:"hostServices,omitempty"`
 	HostOS                *HostOS                `json:"hostOS,omitempty" yaml:"hostOS,omitempty"`
 	HostRun               *HostRun               `json:"run,omitempty" yaml:"run,omitempty"`
+	KubeSSLCertCollect    *KubeSSLCertCollect    `json:"KubeSSLCertCollect,omitempty" yaml:"KubeSSLCertCollect,omitempty"`
 }
 
 func (c *HostCollect) GetName() string {

--- a/pkg/collect/host_collector.go
+++ b/pkg/collect/host_collector.go
@@ -55,6 +55,9 @@ func GetHostCollector(collector *troubleshootv1beta2.HostCollect, bundlePath str
 		return &CollectHostOS{collector.HostOS, bundlePath}, true
 	case collector.HostRun != nil:
 		return &CollectHostRun{collector.HostRun, bundlePath}, true
+	case collector.KubeSSLCertCollect != nil:
+		return &CollectKubeSSLCertInfo{collector.KubeSSLCertCollect, bundlePath}, true
+
 	default:
 		return nil, false
 	}

--- a/pkg/collect/host_kube_ssl_cert_collector
+++ b/pkg/collect/host_kube_ssl_cert_collector
@@ -1,8 +1,7 @@
-package main
+package collect
 
 import (
 	"bytes"
-	"context"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -12,31 +11,24 @@ import (
 	"path/filepath"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
-// boiler plate collector struct
-type CollectHostKubeSSLCertInfo struct {
-	Collector    *troubleshootv1beta2.SSLCertInfo
-	BundlePath   string
-	Namespace    string
-	ClientConfig *rest.Config
-	Client       kubernetes.Interface
-	Context      context.Context
-	RBACErrors
+type CollectKubeSSLCertInfo struct {
+	hostCollector *troubleshootv1beta2.Certificate
+	BundlePath    string
 }
 
-func (c *CollectHostKubeSSLCertInfo) Title() string {
+func (c *CollectKubeSSLCertInfo) Title() string {
 	return getCollectorName(c)
 }
 
-func (c *CollectHostKubeSSLCertInfo) IsExcluded() (bool, error) {
+func (c *CollectKubeSSLCertInfo) IsExcluded() (bool, error) {
 	return isExcluded(c.Collector.Exclude)
 }
 
 // SSL Certificate Struct
-type sslCert struct {
+type KubeSSLCertCollect struct {
 	CertName         string    `json:"Certificate Name"`
 	DNSNames         []string  `json:"DNS Names"`
 	IssuerCommonName string    `json:"Issuer"`
@@ -52,31 +44,11 @@ type location struct {
 }
 
 func (c *CollectSSLCertInfo) Collect(progressChan chan<- interface{}) (CollectorResult, error) {
+
 	output := NewResult()
-	/*
-		// Go Client Config -- start
-		var kubeconfig *string
-		if home := homedir.HomeDir(); home != "" {
-			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-		} else {
-			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-		}
-		flag.Parse()
-		// uses the current context in kubeconfig
-		config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
-		if err != nil {
-			panic(err.Error())
-		}
-		// creates the clientsets
-		clientset, err := kubernetes.NewForConfig(config)
-		if err != nil {
-			panic(err.Error())
-		}
-		// Go Client Config -- end
-	*/
 
 	// Json object initilization - start
-	var certInfo []sslCert
+	var certInfo []KubeSSLCertCollect
 	var certJson = []byte("[]")
 	errJson := json.Unmarshal(certJson, &certInfo)
 	if errJson != nil {
@@ -93,7 +65,7 @@ func (c *CollectSSLCertInfo) Collect(progressChan chan<- interface{}) (Collector
 		log.Println(err)
 	}
 
-	results := KubeCertCollector(GetCertificatesNames, c.Client)
+	results := KubeCertCollector(GetCertificatesNames)
 
 	output.SaveResult(c.BundlePath, "certificates.json", bytes.NewBuffer(results))
 
@@ -128,9 +100,9 @@ func GetKubeCertsFromFilePath(dirPath, ext string) ([]string, error) {
 
 // This function collects information for all SSL certificates (CertNames) located in the dirPath;
 // includes all sub directories.
-func KubeCertCollector(certNames []string, client kubernetes.Interface) []byte {
+func KubeCertCollector(certNames []string) []byte {
 	currentTime := time.Now()
-	var certInfo []sslCert
+	var certInfo []KubeSSLCertCollect
 	var certJson = []byte("[]")
 	err := json.Unmarshal(certJson, &certInfo)
 	if err != nil {
@@ -157,7 +129,7 @@ func KubeCertCollector(certNames []string, client kubernetes.Interface) []byte {
 		if errParse != nil {
 			log.Println(errParse)
 		}
-		certInfo = append(certInfo, sslCert{
+		certInfo = append(certInfo, KubeSSLCertCollect{
 			CertName:         file,
 			DNSNames:         parsedCert.DNSNames,
 			IssuerCommonName: parsedCert.Issuer.CommonName,

--- a/pkg/collect/host_kube_ssl_cert_collector
+++ b/pkg/collect/host_kube_ssl_cert_collector
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// boiler plate collector struct
+type CollectHostKubeSSLCertInfo struct {
+	Collector    *troubleshootv1beta2.SSLCertInfo
+	BundlePath   string
+	Namespace    string
+	ClientConfig *rest.Config
+	Client       kubernetes.Interface
+	Context      context.Context
+	RBACErrors
+}
+
+func (c *CollectHostKubeSSLCertInfo) Title() string {
+	return getCollectorName(c)
+}
+
+func (c *CollectHostKubeSSLCertInfo) IsExcluded() (bool, error) {
+	return isExcluded(c.Collector.Exclude)
+}
+
+// SSL Certificate Struct
+type sslCert struct {
+	CertName         string    `json:"Certificate Name"`
+	DNSNames         []string  `json:"DNS Names"`
+	IssuerCommonName string    `json:"Issuer"`
+	Organizations    []string  `json:"Issuer Organizations"`
+	CertDate         time.Time `json:"Certificate Expiration Date"`
+	IsValid          bool      `json:"IsValid"`
+	Location         location  `json:"Location,omitempty"`
+}
+
+// SSL Cert Location Struct
+type location struct {
+	FilePath string `json:"File Path,omitempty"`
+}
+
+func (c *CollectSSLCertInfo) Collect(progressChan chan<- interface{}) (CollectorResult, error) {
+	output := NewResult()
+	/*
+		// Go Client Config -- start
+		var kubeconfig *string
+		if home := homedir.HomeDir(); home != "" {
+			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		} else {
+			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+		}
+		flag.Parse()
+		// uses the current context in kubeconfig
+		config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			panic(err.Error())
+		}
+		// creates the clientsets
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			panic(err.Error())
+		}
+		// Go Client Config -- end
+	*/
+
+	// Json object initilization - start
+	var certInfo []sslCert
+	var certJson = []byte("[]")
+	errJson := json.Unmarshal(certJson, &certInfo)
+	if errJson != nil {
+		log.Println(errJson)
+	}
+	// Json object initilization - end
+
+	//file path & extension variables
+	dirPath := "/etc/kubernetes/pki"
+	ext := "*.crt"
+
+	GetCertificatesNames, err := GetKubeCertsFromFilePath(dirPath, ext)
+	if err != nil {
+		log.Println(err)
+	}
+
+	results := KubeCertCollector(GetCertificatesNames, c.Client)
+
+	output.SaveResult(c.BundlePath, "certificates.json", bytes.NewBuffer(results))
+
+	//log.Println(string(results))
+	return output, err
+
+}
+
+// This function collects certificate names with a .crt extension within the defined dirPath.
+// Output is a slice of certificate names (certNames) that are fed into the KubeCertCollector function.
+func GetKubeCertsFromFilePath(dirPath, ext string) ([]string, error) {
+	var matches []string
+	err := filepath.Walk(dirPath, func(dirPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if matched, err := filepath.Match(ext, filepath.Base(dirPath)); err != nil {
+			return err
+		} else if matched {
+			matches = append(matches, dirPath)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return matches, nil
+}
+
+// This function collects information for all SSL certificates (CertNames) located in the dirPath;
+// includes all sub directories.
+func KubeCertCollector(certNames []string, client kubernetes.Interface) []byte {
+	currentTime := time.Now()
+	var certInfo []sslCert
+	var certJson = []byte("[]")
+	err := json.Unmarshal(certJson, &certInfo)
+	if err != nil {
+		log.Println(err)
+	}
+
+	for _, cert := range certNames {
+
+		path, file := filepath.Split(cert)
+		filePath := path + file
+
+		certFile, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			panic(err)
+		}
+
+		block, _ := pem.Decode(certFile)
+		if block == nil {
+			panic("Failed to parse certificate file")
+		}
+
+		//parsed SSL certificate
+		parsedCert, errParse := x509.ParseCertificate(block.Bytes)
+		if errParse != nil {
+			log.Println(errParse)
+		}
+		certInfo = append(certInfo, sslCert{
+			CertName:         file,
+			DNSNames:         parsedCert.DNSNames,
+			IssuerCommonName: parsedCert.Issuer.CommonName,
+			Organizations:    parsedCert.Issuer.Organization,
+			CertDate:         parsedCert.NotAfter,
+			IsValid:          currentTime.Before(parsedCert.NotAfter),
+			Location: location{
+				FilePath: path,
+			},
+		})
+		certJson, _ = json.MarshalIndent(certInfo, "", "\t")
+	}
+	return certJson
+}

--- a/pkg/collect/host_kube_ssl_cert_collector.go
+++ b/pkg/collect/host_kube_ssl_cert_collector.go
@@ -15,7 +15,7 @@ import (
 )
 
 type CollectKubeSSLCertInfo struct {
-	hostCollector *troubleshootv1beta2.Certificate
+	hostCollector *troubleshootv1beta2.KubeSSLCertCollect
 	BundlePath    string
 }
 
@@ -24,7 +24,7 @@ func (c *CollectKubeSSLCertInfo) Title() string {
 }
 
 func (c *CollectKubeSSLCertInfo) IsExcluded() (bool, error) {
-	return isExcluded(c.Collector.Exclude)
+	return isExcluded(c.hostCollector.Exclude)
 }
 
 // SSL Certificate Struct
@@ -43,7 +43,7 @@ type location struct {
 	FilePath string `json:"File Path,omitempty"`
 }
 
-func (c *CollectSSLCertInfo) Collect(progressChan chan<- interface{}) (CollectorResult, error) {
+func (c *CollectKubeSSLCertInfo) Collect(progressChan chan<- interface{}) (map[string][]byte, error) {
 
 	output := NewResult()
 
@@ -67,7 +67,7 @@ func (c *CollectSSLCertInfo) Collect(progressChan chan<- interface{}) (Collector
 
 	results := KubeCertCollector(GetCertificatesNames)
 
-	output.SaveResult(c.BundlePath, "certificates.json", bytes.NewBuffer(results))
+	output.SaveResult(c.BundlePath, "ssl/kube_ssl_certificates.json", bytes.NewBuffer(results))
 
 	//log.Println(string(results))
 	return output, err


### PR DESCRIPTION
Context: Parse K8s SSL certificates so they can be analyzed for validity (ie: expiration date, other)

Summary of Change:
- Added a host collector that collects SSL certificates from the following path host path: /etc/kubernetes/pki
- Output is a json file (see example below)

file: ssl_certificates/kube_ssl_certificates.json

[
	{
		"Certificate Name": "apiserver-etcd-client.crt",
		"DNS Names": null,
		"Issuer": "etcd-ca",
		"Issuer Organizations": null,
		"Certificate Expiration Date": "2023-12-14T20:18:59Z",
		"IsValid": true,
		"Location": {
			"File Path": "/etc/kubernetes/pki/"
		}
	},
	{
		"Certificate Name": "apiserver-kubelet-client.crt",
		"DNS Names": null,
		"Issuer": "kubernetes",
		"Issuer Organizations": null,
		"Certificate Expiration Date": "2023-12-14T20:18:57Z",
		"IsValid": true,
		"Location": {
			"File Path": "/etc/kubernetes/pki/"
		}
	},
	{
		"Certificate Name": "apiserver.crt",
		"DNS Names": [
			"davidr-timeouts",
			"kubernetes",
			"kubernetes.default",
			"kubernetes.default.svc",
			"kubernetes.default.svc.cluster.local"
		],
		"Issuer": "kubernetes",
		"Issuer Organizations": null,
		"Certificate Expiration Date": "2023-12-14T20:18:57Z",
		"IsValid": true,
		"Location": {
			"File Path": "/etc/kubernetes/pki/"
		}
	},


<!--- If it relates to an open issue, please link to the issue here.
e.g.
New Feature: [issue-762](https://github.com/replicatedhq/troubleshoot/issues/762).
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
	Note tests created yet.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

TODO: add functionality to retrieve and validate ssl certificate via URL.  However, please review progress to date.