### PR TITLE
feat(spec): get support bundle secret matching label selector

### DIFF
--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
+	corev1 "k8s.io/api/core/v1"
+	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -50,4 +52,22 @@ func LoadFromSecretMatchingLabel(client kubernetes.Interface, labelSelector stri
 	}
 
 	return secretsMatchingKey, nil
+}
+
+func GetSecretMatchingLabel(client kubernetes.Interface, labelSelector string, namespace string, key string) (*corev1.Secret, error) {
+
+	secrets, err := client.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, secret := range secrets.Items {
+		_, ok := secret.Data[key]
+		if !ok {
+			continue
+		}
+		return &secret, nil
+	}
+
+	return nil, kuberneteserrors.NewNotFound(corev1.Resource("secret"), "support bundle spec")
 }


### PR DESCRIPTION
## Description, Motivation and Context

- get support bundle secret matching label selector

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
feature: [sc-65659](https://app.shortcut.com/replicated/story/65659/troubleshoot-call-troubleshoot-to-search-for-labels-rather-than-provide-secret-uri)

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
