### PR TITLE
chore: chore: update binaries used to build manifests and k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,13 +124,13 @@ docs: fmt vet
 	./bin/docsgen
 
 controller-gen:
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.2
 CONTROLLER_GEN=$(shell which controller-gen)
 
 .PHONY: client-gen
 client-gen:
 ifeq (, $(shell which client-gen))
-	go install k8s.io/code-generator/cmd/client-gen@v0.22.2
+	go install k8s.io/code-generator/cmd/client-gen@v0.26.1
 CLIENT_GEN=$(shell go env GOPATH)/bin/client-gen
 else
 CLIENT_GEN=$(shell which client-gen)

--- a/config/crds/troubleshoot.replicated.com_analyzers.yaml
+++ b/config/crds/troubleshoot.replicated.com_analyzers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: analyzers.troubleshoot.replicated.com
 spec:
@@ -746,9 +745,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.replicated.com_collectors.yaml
+++ b/config/crds/troubleshoot.replicated.com_collectors.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: collectors.troubleshoot.replicated.com
 spec:
@@ -329,9 +328,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.replicated.com_preflights.yaml
+++ b/config/crds/troubleshoot.replicated.com_preflights.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: preflights.troubleshoot.replicated.com
 spec:
@@ -1003,9 +1002,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.replicated.com_redactors.yaml
+++ b/config/crds/troubleshoot.replicated.com_redactors.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: redactors.troubleshoot.replicated.com
 spec:
@@ -79,9 +78,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.replicated.com_supportbundles.yaml
+++ b/config/crds/troubleshoot.replicated.com_supportbundles.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: supportbundles.troubleshoot.replicated.com
 spec:
@@ -1032,9 +1031,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: analyzers.troubleshoot.sh
 spec:
@@ -2360,9 +2359,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: collectors.troubleshoot.sh
 spec:
@@ -684,6 +683,7 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           weight:
                                             description: Weight associated with matching
                                               the corresponding nodeSelectorTerm,
@@ -797,10 +797,12 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                       required:
                                       - nodeSelectorTerms
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
                                   description: Describes pod affinity scheduling rules
@@ -893,6 +895,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -962,6 +965,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -1081,6 +1085,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -1144,6 +1149,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -1264,6 +1270,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -1333,6 +1340,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -1452,6 +1460,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -1515,6 +1524,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -1640,6 +1650,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -1659,6 +1670,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -1688,6 +1700,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -1710,6 +1723,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -1743,6 +1757,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -1762,6 +1777,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -3118,6 +3134,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -3137,6 +3154,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -3166,6 +3184,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -3188,6 +3207,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -3221,6 +3241,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -3240,6 +3261,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -4501,6 +4523,7 @@ spec:
                                       uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
                               description: 'List of initialization containers belonging
@@ -4605,6 +4628,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -4624,6 +4648,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -4653,6 +4678,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -4675,6 +4701,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -4708,6 +4735,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -4727,6 +4755,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -6488,6 +6517,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
@@ -6606,12 +6636,12 @@ spec:
                                       spread constraint. - DoNotSchedule (default)
                                       tells the scheduler not to schedule it. - ScheduleAnyway
                                       tells the scheduler to schedule the pod in any
-                                      location,   but giving higher precedence to
-                                      topologies that would help reduce the   skew.
-                                      A constraint is considered "Unsatisfiable" for
-                                      an incoming pod if and only if every possible
-                                      node assignment for that pod would violate "MaxSkew"
-                                      on some topology. For example, in a 3-zone cluster,
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew. A constraint
+                                      is considered "Unsatisfiable" for an incoming
+                                      pod if and only if every possible node assignment
+                                      for that pod would violate "MaxSkew" on some
+                                      topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
                                       | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
@@ -6782,6 +6812,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is optional: User is the
                                           rados user name, default is admin More info:
@@ -6820,6 +6851,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeID:
                                         description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -6904,6 +6936,7 @@ spec:
                                           ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   csi:
                                     description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
@@ -6939,6 +6972,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       readOnly:
                                         description: readOnly specifies a read-only
                                           configuration for the volume. Defaults to
@@ -7000,6 +7034,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             mode:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
@@ -7051,6 +7086,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           required:
                                           - path
                                           type: object
@@ -7093,13 +7129,13 @@ spec:
                                       and deleted when the pod is removed. \n Use
                                       this if: a) the volume is only needed while
                                       the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity    tracking
+                                      like restoring from snapshot or capacity tracking
                                       are needed, c) the storage driver is specified
                                       through a storage class, and d) the storage
                                       driver supports dynamic volume provisioning
-                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more    information on the connection between
-                                      this volume type    and PersistentVolumeClaim).
+                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more information on the connection between
+                                      this volume type and PersistentVolumeClaim).
                                       \n Use PersistentVolumeClaim or one of the vendor-specific
                                       APIs for volumes that persist for longer than
                                       the lifecycle of an individual pod. \n Use CSI
@@ -7198,6 +7234,7 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               dataSourceRef:
                                                 description: 'dataSourceRef specifies
                                                   the object from which to populate
@@ -7226,19 +7263,19 @@ spec:
                                                   differences between dataSource and
                                                   dataSourceRef: * While dataSource
                                                   only allows two specific types of
-                                                  objects, dataSourceRef   allows
-                                                  any non-core object, as well as
-                                                  PersistentVolumeClaim objects. *
-                                                  While dataSource ignores disallowed
-                                                  values (dropping them), dataSourceRef   preserves
-                                                  all values, and generates an error
-                                                  if a disallowed value is   specified.
-                                                  * While dataSource only allows local
-                                                  objects, dataSourceRef allows objects   in
-                                                  any namespaces. (Beta) Using this
-                                                  field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled. (Alpha)
-                                                  Using the namespace field of dataSourceRef
+                                                  objects, dataSourceRef allows any
+                                                  non-core object, as well as PersistentVolumeClaim
+                                                  objects. * While dataSource ignores
+                                                  disallowed values (dropping them),
+                                                  dataSourceRef preserves all values,
+                                                  and generates an error if a disallowed
+                                                  value is specified. * While dataSource
+                                                  only allows local objects, dataSourceRef
+                                                  allows objects in any namespaces.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled. (Alpha) Using
+                                                  the namespace field of dataSourceRef
                                                   requires the CrossNamespaceVolumeDataSource
                                                   feature gate to be enabled.'
                                                 properties:
@@ -7406,6 +7443,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               storageClassName:
                                                 description: 'storageClassName is
                                                   the name of the StorageClass required
@@ -7509,6 +7547,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - driver
                                     type: object
@@ -7711,6 +7750,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       targetPortal:
                                         description: targetPortal is iSCSI Target
                                           Portal. The Portal is either an IP or ip_addr:port
@@ -7907,6 +7947,7 @@ spec:
                                                     be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             downwardAPI:
                                               description: downwardAPI information
                                                 about the downwardAPI data to project
@@ -7940,6 +7981,7 @@ spec:
                                                         required:
                                                         - fieldPath
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
@@ -8000,6 +8042,7 @@ spec:
                                                         required:
                                                         - resource
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                     required:
                                                     - path
                                                     type: object
@@ -8078,6 +8121,7 @@ spec:
                                                     must be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             serviceAccountToken:
                                               description: serviceAccountToken is
                                                 information about the serviceAccountToken
@@ -8210,6 +8254,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is the rados user name.
                                           Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -8255,6 +8300,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       sslEnabled:
                                         description: sslEnabled Flag enable/disable
                                           SSL communication with Gateway, default
@@ -8387,6 +8433,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeName:
                                         description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
@@ -8504,9 +8551,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: hostcollectors.troubleshoot.sh
 spec:
@@ -1315,9 +1314,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: hostpreflights.troubleshoot.sh
 spec:
@@ -1603,9 +1602,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: preflights.troubleshoot.sh
 spec:
@@ -2076,6 +2075,7 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           weight:
                                             description: Weight associated with matching
                                               the corresponding nodeSelectorTerm,
@@ -2189,10 +2189,12 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                       required:
                                       - nodeSelectorTerms
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
                                   description: Describes pod affinity scheduling rules
@@ -2285,6 +2287,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -2354,6 +2357,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -2473,6 +2477,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -2536,6 +2541,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -2656,6 +2662,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -2725,6 +2732,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -2844,6 +2852,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -2907,6 +2916,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -3032,6 +3042,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -3051,6 +3062,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -3080,6 +3092,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -3102,6 +3115,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -3135,6 +3149,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -3154,6 +3169,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -4510,6 +4526,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -4529,6 +4546,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -4558,6 +4576,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -4580,6 +4599,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -4613,6 +4633,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -4632,6 +4653,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -5893,6 +5915,7 @@ spec:
                                       uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
                               description: 'List of initialization containers belonging
@@ -5997,6 +6020,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -6016,6 +6040,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -6045,6 +6070,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -6067,6 +6093,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -6100,6 +6127,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -6119,6 +6147,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -7880,6 +7909,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
@@ -7998,12 +8028,12 @@ spec:
                                       spread constraint. - DoNotSchedule (default)
                                       tells the scheduler not to schedule it. - ScheduleAnyway
                                       tells the scheduler to schedule the pod in any
-                                      location,   but giving higher precedence to
-                                      topologies that would help reduce the   skew.
-                                      A constraint is considered "Unsatisfiable" for
-                                      an incoming pod if and only if every possible
-                                      node assignment for that pod would violate "MaxSkew"
-                                      on some topology. For example, in a 3-zone cluster,
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew. A constraint
+                                      is considered "Unsatisfiable" for an incoming
+                                      pod if and only if every possible node assignment
+                                      for that pod would violate "MaxSkew" on some
+                                      topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
                                       | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
@@ -8174,6 +8204,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is optional: User is the
                                           rados user name, default is admin More info:
@@ -8212,6 +8243,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeID:
                                         description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -8296,6 +8328,7 @@ spec:
                                           ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   csi:
                                     description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
@@ -8331,6 +8364,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       readOnly:
                                         description: readOnly specifies a read-only
                                           configuration for the volume. Defaults to
@@ -8392,6 +8426,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             mode:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
@@ -8443,6 +8478,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           required:
                                           - path
                                           type: object
@@ -8485,13 +8521,13 @@ spec:
                                       and deleted when the pod is removed. \n Use
                                       this if: a) the volume is only needed while
                                       the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity    tracking
+                                      like restoring from snapshot or capacity tracking
                                       are needed, c) the storage driver is specified
                                       through a storage class, and d) the storage
                                       driver supports dynamic volume provisioning
-                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more    information on the connection between
-                                      this volume type    and PersistentVolumeClaim).
+                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more information on the connection between
+                                      this volume type and PersistentVolumeClaim).
                                       \n Use PersistentVolumeClaim or one of the vendor-specific
                                       APIs for volumes that persist for longer than
                                       the lifecycle of an individual pod. \n Use CSI
@@ -8590,6 +8626,7 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               dataSourceRef:
                                                 description: 'dataSourceRef specifies
                                                   the object from which to populate
@@ -8618,19 +8655,19 @@ spec:
                                                   differences between dataSource and
                                                   dataSourceRef: * While dataSource
                                                   only allows two specific types of
-                                                  objects, dataSourceRef   allows
-                                                  any non-core object, as well as
-                                                  PersistentVolumeClaim objects. *
-                                                  While dataSource ignores disallowed
-                                                  values (dropping them), dataSourceRef   preserves
-                                                  all values, and generates an error
-                                                  if a disallowed value is   specified.
-                                                  * While dataSource only allows local
-                                                  objects, dataSourceRef allows objects   in
-                                                  any namespaces. (Beta) Using this
-                                                  field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled. (Alpha)
-                                                  Using the namespace field of dataSourceRef
+                                                  objects, dataSourceRef allows any
+                                                  non-core object, as well as PersistentVolumeClaim
+                                                  objects. * While dataSource ignores
+                                                  disallowed values (dropping them),
+                                                  dataSourceRef preserves all values,
+                                                  and generates an error if a disallowed
+                                                  value is specified. * While dataSource
+                                                  only allows local objects, dataSourceRef
+                                                  allows objects in any namespaces.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled. (Alpha) Using
+                                                  the namespace field of dataSourceRef
                                                   requires the CrossNamespaceVolumeDataSource
                                                   feature gate to be enabled.'
                                                 properties:
@@ -8798,6 +8835,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               storageClassName:
                                                 description: 'storageClassName is
                                                   the name of the StorageClass required
@@ -8901,6 +8939,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - driver
                                     type: object
@@ -9103,6 +9142,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       targetPortal:
                                         description: targetPortal is iSCSI Target
                                           Portal. The Portal is either an IP or ip_addr:port
@@ -9299,6 +9339,7 @@ spec:
                                                     be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             downwardAPI:
                                               description: downwardAPI information
                                                 about the downwardAPI data to project
@@ -9332,6 +9373,7 @@ spec:
                                                         required:
                                                         - fieldPath
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
@@ -9392,6 +9434,7 @@ spec:
                                                         required:
                                                         - resource
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                     required:
                                                     - path
                                                     type: object
@@ -9470,6 +9513,7 @@ spec:
                                                     must be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             serviceAccountToken:
                                               description: serviceAccountToken is
                                                 information about the serviceAccountToken
@@ -9602,6 +9646,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is the rados user name.
                                           Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -9647,6 +9692,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       sslEnabled:
                                         description: sslEnabled Flag enable/disable
                                           SSL communication with Gateway, default
@@ -9779,6 +9825,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeName:
                                         description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
@@ -10186,9 +10233,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_redactors.yaml
+++ b/config/crds/troubleshoot.sh_redactors.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: redactors.troubleshoot.sh
 spec:
@@ -79,9 +78,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_remotecollectors.yaml
+++ b/config/crds/troubleshoot.sh_remotecollectors.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: remotecollectors.troubleshoot.sh
 spec:
@@ -366,9 +365,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: supportbundles.troubleshoot.sh
 spec:
@@ -2107,6 +2106,7 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           weight:
                                             description: Weight associated with matching
                                               the corresponding nodeSelectorTerm,
@@ -2220,10 +2220,12 @@ spec:
                                                   type: object
                                                 type: array
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           type: array
                                       required:
                                       - nodeSelectorTerms
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                                 podAffinity:
                                   description: Describes pod affinity scheduling rules
@@ -2316,6 +2318,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -2385,6 +2388,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -2504,6 +2508,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -2567,6 +2572,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -2687,6 +2693,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaceSelector:
                                                 description: A label query over the
                                                   set of namespaces that the term
@@ -2756,6 +2763,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               namespaces:
                                                 description: namespaces specifies
                                                   a static list of namespace names
@@ -2875,6 +2883,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaceSelector:
                                             description: A label query over the set
                                               of namespaces that the term applies
@@ -2938,6 +2947,7 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           namespaces:
                                             description: namespaces specifies a static
                                               list of namespace names that the term
@@ -3063,6 +3073,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -3082,6 +3093,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -3111,6 +3123,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -3133,6 +3146,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -3166,6 +3180,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -3185,6 +3200,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -4541,6 +4557,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -4560,6 +4577,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -4589,6 +4607,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -4611,6 +4630,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -4644,6 +4664,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -4663,6 +4684,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -5924,6 +5946,7 @@ spec:
                                       uid?'
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
                               description: 'List of initialization containers belonging
@@ -6028,6 +6051,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             fieldRef:
                                               description: 'Selects a field of the
                                                 pod: supports metadata.name, metadata.namespace,
@@ -6047,6 +6071,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               description: 'Selects a resource of
                                                 the container: only resources limits
@@ -6076,6 +6101,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             secretKeyRef:
                                               description: Selects a key of a secret
                                                 in the pod's namespace
@@ -6098,6 +6124,7 @@ spec:
                                               required:
                                               - key
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           type: object
                                       required:
                                       - name
@@ -6131,6 +6158,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         prefix:
                                           description: An optional identifier to prepend
                                             to each key in the ConfigMap. Must be
@@ -6150,6 +6178,7 @@ spec:
                                                 must be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       type: object
                                     type: array
                                   image:
@@ -7911,6 +7940,7 @@ spec:
                                           "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
@@ -8029,12 +8059,12 @@ spec:
                                       spread constraint. - DoNotSchedule (default)
                                       tells the scheduler not to schedule it. - ScheduleAnyway
                                       tells the scheduler to schedule the pod in any
-                                      location,   but giving higher precedence to
-                                      topologies that would help reduce the   skew.
-                                      A constraint is considered "Unsatisfiable" for
-                                      an incoming pod if and only if every possible
-                                      node assignment for that pod would violate "MaxSkew"
-                                      on some topology. For example, in a 3-zone cluster,
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew. A constraint
+                                      is considered "Unsatisfiable" for an incoming
+                                      pod if and only if every possible node assignment
+                                      for that pod would violate "MaxSkew" on some
+                                      topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
                                       | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
@@ -8205,6 +8235,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is optional: User is the
                                           rados user name, default is admin More info:
@@ -8243,6 +8274,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeID:
                                         description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -8327,6 +8359,7 @@ spec:
                                           ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   csi:
                                     description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
@@ -8362,6 +8395,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       readOnly:
                                         description: readOnly specifies a read-only
                                           configuration for the volume. Defaults to
@@ -8423,6 +8457,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             mode:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
@@ -8474,6 +8509,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           required:
                                           - path
                                           type: object
@@ -8516,13 +8552,13 @@ spec:
                                       and deleted when the pod is removed. \n Use
                                       this if: a) the volume is only needed while
                                       the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity    tracking
+                                      like restoring from snapshot or capacity tracking
                                       are needed, c) the storage driver is specified
                                       through a storage class, and d) the storage
                                       driver supports dynamic volume provisioning
-                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more    information on the connection between
-                                      this volume type    and PersistentVolumeClaim).
+                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more information on the connection between
+                                      this volume type and PersistentVolumeClaim).
                                       \n Use PersistentVolumeClaim or one of the vendor-specific
                                       APIs for volumes that persist for longer than
                                       the lifecycle of an individual pod. \n Use CSI
@@ -8621,6 +8657,7 @@ spec:
                                                 - kind
                                                 - name
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               dataSourceRef:
                                                 description: 'dataSourceRef specifies
                                                   the object from which to populate
@@ -8649,19 +8686,19 @@ spec:
                                                   differences between dataSource and
                                                   dataSourceRef: * While dataSource
                                                   only allows two specific types of
-                                                  objects, dataSourceRef   allows
-                                                  any non-core object, as well as
-                                                  PersistentVolumeClaim objects. *
-                                                  While dataSource ignores disallowed
-                                                  values (dropping them), dataSourceRef   preserves
-                                                  all values, and generates an error
-                                                  if a disallowed value is   specified.
-                                                  * While dataSource only allows local
-                                                  objects, dataSourceRef allows objects   in
-                                                  any namespaces. (Beta) Using this
-                                                  field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled. (Alpha)
-                                                  Using the namespace field of dataSourceRef
+                                                  objects, dataSourceRef allows any
+                                                  non-core object, as well as PersistentVolumeClaim
+                                                  objects. * While dataSource ignores
+                                                  disallowed values (dropping them),
+                                                  dataSourceRef preserves all values,
+                                                  and generates an error if a disallowed
+                                                  value is specified. * While dataSource
+                                                  only allows local objects, dataSourceRef
+                                                  allows objects in any namespaces.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled. (Alpha) Using
+                                                  the namespace field of dataSourceRef
                                                   requires the CrossNamespaceVolumeDataSource
                                                   feature gate to be enabled.'
                                                 properties:
@@ -8829,6 +8866,7 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               storageClassName:
                                                 description: 'storageClassName is
                                                   the name of the StorageClass required
@@ -8932,6 +8970,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - driver
                                     type: object
@@ -9134,6 +9173,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       targetPortal:
                                         description: targetPortal is iSCSI Target
                                           Portal. The Portal is either an IP or ip_addr:port
@@ -9330,6 +9370,7 @@ spec:
                                                     be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             downwardAPI:
                                               description: downwardAPI information
                                                 about the downwardAPI data to project
@@ -9363,6 +9404,7 @@ spec:
                                                         required:
                                                         - fieldPath
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                       mode:
                                                         description: 'Optional: mode
                                                           bits used to set permissions
@@ -9423,6 +9465,7 @@ spec:
                                                         required:
                                                         - resource
                                                         type: object
+                                                        x-kubernetes-map-type: atomic
                                                     required:
                                                     - path
                                                     type: object
@@ -9501,6 +9544,7 @@ spec:
                                                     must be defined
                                                   type: boolean
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             serviceAccountToken:
                                               description: serviceAccountToken is
                                                 information about the serviceAccountToken
@@ -9633,6 +9677,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       user:
                                         description: 'user is the rados user name.
                                           Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -9678,6 +9723,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       sslEnabled:
                                         description: sslEnabled Flag enable/disable
                                           SSL communication with Gateway, default
@@ -9810,6 +9856,7 @@ spec:
                                               kind, uid?'
                                             type: string
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       volumeName:
                                         description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
@@ -11203,9 +11250,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_analyzer.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_analyzer.go
@@ -116,7 +116,7 @@ func (c *FakeAnalyzers) UpdateStatus(ctx context.Context, analyzer *v1beta1.Anal
 // Delete takes name of the analyzer and deletes it. Returns an error if one occurs.
 func (c *FakeAnalyzers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(analyzersResource, c.ns, name, opts), &v1beta1.Analyzer{})
+		Invokes(testing.NewDeleteAction(analyzersResource, c.ns, name), &v1beta1.Analyzer{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_collector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_collector.go
@@ -116,7 +116,7 @@ func (c *FakeCollectors) UpdateStatus(ctx context.Context, collector *v1beta1.Co
 // Delete takes name of the collector and deletes it. Returns an error if one occurs.
 func (c *FakeCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(collectorsResource, c.ns, name, opts), &v1beta1.Collector{})
+		Invokes(testing.NewDeleteAction(collectorsResource, c.ns, name), &v1beta1.Collector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_preflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_preflight.go
@@ -116,7 +116,7 @@ func (c *FakePreflights) UpdateStatus(ctx context.Context, preflight *v1beta1.Pr
 // Delete takes name of the preflight and deletes it. Returns an error if one occurs.
 func (c *FakePreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(preflightsResource, c.ns, name, opts), &v1beta1.Preflight{})
+		Invokes(testing.NewDeleteAction(preflightsResource, c.ns, name), &v1beta1.Preflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_redactor.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_redactor.go
@@ -116,7 +116,7 @@ func (c *FakeRedactors) UpdateStatus(ctx context.Context, redactor *v1beta1.Reda
 // Delete takes name of the redactor and deletes it. Returns an error if one occurs.
 func (c *FakeRedactors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(redactorsResource, c.ns, name, opts), &v1beta1.Redactor{})
+		Invokes(testing.NewDeleteAction(redactorsResource, c.ns, name), &v1beta1.Redactor{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_supportbundle.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_supportbundle.go
@@ -116,7 +116,7 @@ func (c *FakeSupportBundles) UpdateStatus(ctx context.Context, supportBundle *v1
 // Delete takes name of the supportBundle and deletes it. Returns an error if one occurs.
 func (c *FakeSupportBundles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(supportbundlesResource, c.ns, name, opts), &v1beta1.SupportBundle{})
+		Invokes(testing.NewDeleteAction(supportbundlesResource, c.ns, name), &v1beta1.SupportBundle{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/troubleshoot_client.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/troubleshoot_client.go
@@ -18,8 +18,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"net/http"
-
 	v1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -60,28 +58,12 @@ func (c *TroubleshootV1beta1Client) SupportBundles(namespace string) SupportBund
 }
 
 // NewForConfig creates a new TroubleshootV1beta1Client for the given config.
-// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
-// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TroubleshootV1beta1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	httpClient, err := rest.HTTPClientFor(&config)
-	if err != nil {
-		return nil, err
-	}
-	return NewForConfigAndClient(&config, httpClient)
-}
-
-// NewForConfigAndClient creates a new TroubleshootV1beta1Client for the given config and http client.
-// Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TroubleshootV1beta1Client, error) {
-	config := *c
-	if err := setConfigDefaults(&config); err != nil {
-		return nil, err
-	}
-	client, err := rest.RESTClientForConfigAndClient(&config, h)
+	client, err := rest.RESTClientFor(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_analyzer.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_analyzer.go
@@ -116,7 +116,7 @@ func (c *FakeAnalyzers) UpdateStatus(ctx context.Context, analyzer *v1beta2.Anal
 // Delete takes name of the analyzer and deletes it. Returns an error if one occurs.
 func (c *FakeAnalyzers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(analyzersResource, c.ns, name, opts), &v1beta2.Analyzer{})
+		Invokes(testing.NewDeleteAction(analyzersResource, c.ns, name), &v1beta2.Analyzer{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_collector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_collector.go
@@ -116,7 +116,7 @@ func (c *FakeCollectors) UpdateStatus(ctx context.Context, collector *v1beta2.Co
 // Delete takes name of the collector and deletes it. Returns an error if one occurs.
 func (c *FakeCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(collectorsResource, c.ns, name, opts), &v1beta2.Collector{})
+		Invokes(testing.NewDeleteAction(collectorsResource, c.ns, name), &v1beta2.Collector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostcollector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostcollector.go
@@ -116,7 +116,7 @@ func (c *FakeHostCollectors) UpdateStatus(ctx context.Context, hostCollector *v1
 // Delete takes name of the hostCollector and deletes it. Returns an error if one occurs.
 func (c *FakeHostCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(hostcollectorsResource, c.ns, name, opts), &v1beta2.HostCollector{})
+		Invokes(testing.NewDeleteAction(hostcollectorsResource, c.ns, name), &v1beta2.HostCollector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostpreflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostpreflight.go
@@ -116,7 +116,7 @@ func (c *FakeHostPreflights) UpdateStatus(ctx context.Context, hostPreflight *v1
 // Delete takes name of the hostPreflight and deletes it. Returns an error if one occurs.
 func (c *FakeHostPreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(hostpreflightsResource, c.ns, name, opts), &v1beta2.HostPreflight{})
+		Invokes(testing.NewDeleteAction(hostpreflightsResource, c.ns, name), &v1beta2.HostPreflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_preflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_preflight.go
@@ -116,7 +116,7 @@ func (c *FakePreflights) UpdateStatus(ctx context.Context, preflight *v1beta2.Pr
 // Delete takes name of the preflight and deletes it. Returns an error if one occurs.
 func (c *FakePreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(preflightsResource, c.ns, name, opts), &v1beta2.Preflight{})
+		Invokes(testing.NewDeleteAction(preflightsResource, c.ns, name), &v1beta2.Preflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_redactor.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_redactor.go
@@ -116,7 +116,7 @@ func (c *FakeRedactors) UpdateStatus(ctx context.Context, redactor *v1beta2.Reda
 // Delete takes name of the redactor and deletes it. Returns an error if one occurs.
 func (c *FakeRedactors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(redactorsResource, c.ns, name, opts), &v1beta2.Redactor{})
+		Invokes(testing.NewDeleteAction(redactorsResource, c.ns, name), &v1beta2.Redactor{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_remotecollector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_remotecollector.go
@@ -116,7 +116,7 @@ func (c *FakeRemoteCollectors) UpdateStatus(ctx context.Context, remoteCollector
 // Delete takes name of the remoteCollector and deletes it. Returns an error if one occurs.
 func (c *FakeRemoteCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(remotecollectorsResource, c.ns, name, opts), &v1beta2.RemoteCollector{})
+		Invokes(testing.NewDeleteAction(remotecollectorsResource, c.ns, name), &v1beta2.RemoteCollector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_supportbundle.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_supportbundle.go
@@ -116,7 +116,7 @@ func (c *FakeSupportBundles) UpdateStatus(ctx context.Context, supportBundle *v1
 // Delete takes name of the supportBundle and deletes it. Returns an error if one occurs.
 func (c *FakeSupportBundles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(supportbundlesResource, c.ns, name, opts), &v1beta2.SupportBundle{})
+		Invokes(testing.NewDeleteAction(supportbundlesResource, c.ns, name), &v1beta2.SupportBundle{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/troubleshoot_client.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/troubleshoot_client.go
@@ -18,8 +18,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"net/http"
-
 	v1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -75,28 +73,12 @@ func (c *TroubleshootV1beta2Client) SupportBundles(namespace string) SupportBund
 }
 
 // NewForConfig creates a new TroubleshootV1beta2Client for the given config.
-// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
-// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TroubleshootV1beta2Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	httpClient, err := rest.HTTPClientFor(&config)
-	if err != nil {
-		return nil, err
-	}
-	return NewForConfigAndClient(&config, httpClient)
-}
-
-// NewForConfigAndClient creates a new TroubleshootV1beta2Client for the given config and http client.
-// Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TroubleshootV1beta2Client, error) {
-	config := *c
-	if err := setConfigDefaults(&config); err != nil {
-		return nil, err
-	}
-	client, err := rest.RESTClientForConfigAndClient(&config, h)
+	client, err := rest.RESTClientFor(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -903,7 +903,8 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "weight": {
                                       "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
@@ -985,10 +986,12 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-map-type": "atomic"
                               }
                             }
                           },
@@ -1054,7 +1057,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -1096,7 +1100,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaces": {
                                           "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -1169,7 +1174,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -1211,7 +1217,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaces": {
                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -1291,7 +1298,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -1333,7 +1341,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaces": {
                                           "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -1406,7 +1415,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -1448,7 +1458,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaces": {
                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -1537,7 +1548,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -1554,7 +1566,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -1584,7 +1597,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -1605,7 +1619,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -1631,7 +1646,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -1649,7 +1665,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -2727,7 +2744,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -2744,7 +2762,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -2774,7 +2793,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -2795,7 +2815,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -2821,7 +2842,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -2839,7 +2861,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -3863,7 +3886,8 @@
                               "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
-                          }
+                          },
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
                       "initContainers": {
@@ -3931,7 +3955,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -3948,7 +3973,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -3978,7 +4004,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -3999,7 +4026,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -4025,7 +4053,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -4043,7 +4072,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -5378,7 +5408,8 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "matchLabelKeys": {
                               "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.",
@@ -5411,7 +5442,7 @@
                               "type": "string"
                             },
                             "whenUnsatisfiable": {
-                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
                               "type": "string"
                             }
                           }
@@ -5548,7 +5579,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "user": {
                                   "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
@@ -5579,7 +5611,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "volumeID": {
                                   "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
@@ -5631,7 +5664,8 @@
                                   "description": "optional specify whether the ConfigMap or its keys must be defined",
                                   "type": "boolean"
                                 }
-                              }
+                              },
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "csi": {
                               "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
@@ -5656,7 +5690,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
@@ -5705,7 +5740,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "mode": {
                                         "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -5744,7 +5780,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -5775,7 +5812,7 @@
                               }
                             },
                             "ephemeral": {
-                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                               "type": "object",
                               "properties": {
                                 "volumeClaimTemplate": {
@@ -5820,10 +5857,11 @@
                                               "description": "Name is the name of resource being referenced",
                                               "type": "string"
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "dataSourceRef": {
-                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. * While dataSource only allows local objects, dataSourceRef allows objects   in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                                           "type": "object",
                                           "required": [
                                             "kind",
@@ -5947,7 +5985,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "storageClassName": {
                                           "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
@@ -6034,7 +6073,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 }
                               }
                             },
@@ -6195,7 +6235,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "targetPortal": {
                                   "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
@@ -6339,7 +6380,8 @@
                                             "description": "optional specify whether the ConfigMap or its keys must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "downwardAPI": {
                                         "description": "downwardAPI information about the downwardAPI data to project",
@@ -6370,7 +6412,8 @@
                                                       "description": "Path of the field to select in the specified API version.",
                                                       "type": "string"
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "mode": {
                                                   "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -6409,7 +6452,8 @@
                                                       "description": "Required: resource to select",
                                                       "type": "string"
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
                                             }
@@ -6455,7 +6499,8 @@
                                             "description": "optional field specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "serviceAccountToken": {
                                         "description": "serviceAccountToken is information about the serviceAccountToken data to project",
@@ -6561,7 +6606,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "user": {
                                   "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -6602,7 +6648,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "sslEnabled": {
                                   "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
@@ -6692,7 +6739,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "volumeName": {
                                   "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3047,7 +3047,8 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "weight": {
                                       "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
@@ -3129,10 +3130,12 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-map-type": "atomic"
                               }
                             }
                           },
@@ -3198,7 +3201,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3240,7 +3244,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaces": {
                                           "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3313,7 +3318,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3355,7 +3361,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaces": {
                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3435,7 +3442,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3477,7 +3485,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaces": {
                                           "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3550,7 +3559,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3592,7 +3602,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaces": {
                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3681,7 +3692,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -3698,7 +3710,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -3728,7 +3741,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -3749,7 +3763,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -3775,7 +3790,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -3793,7 +3809,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -4871,7 +4888,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -4888,7 +4906,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -4918,7 +4937,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -4939,7 +4959,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -4965,7 +4986,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -4983,7 +5005,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -6007,7 +6030,8 @@
                               "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
-                          }
+                          },
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
                       "initContainers": {
@@ -6075,7 +6099,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -6092,7 +6117,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -6122,7 +6148,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -6143,7 +6170,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -6169,7 +6197,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -6187,7 +6216,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -7522,7 +7552,8 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "matchLabelKeys": {
                               "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.",
@@ -7555,7 +7586,7 @@
                               "type": "string"
                             },
                             "whenUnsatisfiable": {
-                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
                               "type": "string"
                             }
                           }
@@ -7692,7 +7723,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "user": {
                                   "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
@@ -7723,7 +7755,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "volumeID": {
                                   "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
@@ -7775,7 +7808,8 @@
                                   "description": "optional specify whether the ConfigMap or its keys must be defined",
                                   "type": "boolean"
                                 }
-                              }
+                              },
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "csi": {
                               "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
@@ -7800,7 +7834,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
@@ -7849,7 +7884,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "mode": {
                                         "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -7888,7 +7924,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -7919,7 +7956,7 @@
                               }
                             },
                             "ephemeral": {
-                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                               "type": "object",
                               "properties": {
                                 "volumeClaimTemplate": {
@@ -7964,10 +8001,11 @@
                                               "description": "Name is the name of resource being referenced",
                                               "type": "string"
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "dataSourceRef": {
-                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. * While dataSource only allows local objects, dataSourceRef allows objects   in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                                           "type": "object",
                                           "required": [
                                             "kind",
@@ -8091,7 +8129,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "storageClassName": {
                                           "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
@@ -8178,7 +8217,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 }
                               }
                             },
@@ -8339,7 +8379,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "targetPortal": {
                                   "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
@@ -8483,7 +8524,8 @@
                                             "description": "optional specify whether the ConfigMap or its keys must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "downwardAPI": {
                                         "description": "downwardAPI information about the downwardAPI data to project",
@@ -8514,7 +8556,8 @@
                                                       "description": "Path of the field to select in the specified API version.",
                                                       "type": "string"
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "mode": {
                                                   "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -8553,7 +8596,8 @@
                                                       "description": "Required: resource to select",
                                                       "type": "string"
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
                                             }
@@ -8599,7 +8643,8 @@
                                             "description": "optional field specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "serviceAccountToken": {
                                         "description": "serviceAccountToken is information about the serviceAccountToken data to project",
@@ -8705,7 +8750,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "user": {
                                   "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -8746,7 +8792,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "sslEnabled": {
                                   "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
@@ -8836,7 +8883,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "volumeName": {
                                   "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -3093,7 +3093,8 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "weight": {
                                       "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
@@ -3175,10 +3176,12 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-map-type": "atomic"
                               }
                             }
                           },
@@ -3244,7 +3247,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3286,7 +3290,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaces": {
                                           "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3359,7 +3364,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3401,7 +3407,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaces": {
                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3481,7 +3488,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3523,7 +3531,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "namespaces": {
                                           "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3596,7 +3605,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
@@ -3638,7 +3648,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "namespaces": {
                                       "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
@@ -3727,7 +3738,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -3744,7 +3756,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -3774,7 +3787,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -3795,7 +3809,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -3821,7 +3836,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -3839,7 +3855,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -4917,7 +4934,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -4934,7 +4952,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -4964,7 +4983,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -4985,7 +5005,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -5011,7 +5032,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -5029,7 +5051,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -6053,7 +6076,8 @@
                               "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                               "type": "string"
                             }
-                          }
+                          },
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
                       "initContainers": {
@@ -6121,7 +6145,8 @@
                                             "description": "Specify whether the ConfigMap or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "fieldRef": {
                                         "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['\u003cKEY\u003e']`, `metadata.annotations['\u003cKEY\u003e']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
@@ -6138,7 +6163,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "resourceFieldRef": {
                                         "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
@@ -6168,7 +6194,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "secretKeyRef": {
                                         "description": "Selects a key of a secret in the pod's namespace",
@@ -6189,7 +6216,8 @@
                                             "description": "Specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -6215,7 +6243,8 @@
                                         "description": "Specify whether the ConfigMap must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "prefix": {
                                     "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
@@ -6233,7 +6262,8 @@
                                         "description": "Specify whether the Secret must be defined",
                                         "type": "boolean"
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 }
                               }
@@ -7568,7 +7598,8 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "matchLabelKeys": {
                               "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.",
@@ -7601,7 +7632,7 @@
                               "type": "string"
                             },
                             "whenUnsatisfiable": {
-                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
                               "type": "string"
                             }
                           }
@@ -7738,7 +7769,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "user": {
                                   "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
@@ -7769,7 +7801,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "volumeID": {
                                   "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
@@ -7821,7 +7854,8 @@
                                   "description": "optional specify whether the ConfigMap or its keys must be defined",
                                   "type": "boolean"
                                 }
-                              }
+                              },
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "csi": {
                               "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
@@ -7846,7 +7880,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
@@ -7895,7 +7930,8 @@
                                             "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "mode": {
                                         "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -7934,7 +7970,8 @@
                                             "description": "Required: resource to select",
                                             "type": "string"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     }
                                   }
@@ -7965,7 +8002,7 @@
                               }
                             },
                             "ephemeral": {
-                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
                               "type": "object",
                               "properties": {
                                 "volumeClaimTemplate": {
@@ -8010,10 +8047,11 @@
                                               "description": "Name is the name of resource being referenced",
                                               "type": "string"
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "dataSourceRef": {
-                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. * While dataSource only allows local objects, dataSourceRef allows objects   in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                                           "type": "object",
                                           "required": [
                                             "kind",
@@ -8137,7 +8175,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "storageClassName": {
                                           "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
@@ -8224,7 +8263,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 }
                               }
                             },
@@ -8385,7 +8425,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "targetPortal": {
                                   "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
@@ -8529,7 +8570,8 @@
                                             "description": "optional specify whether the ConfigMap or its keys must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "downwardAPI": {
                                         "description": "downwardAPI information about the downwardAPI data to project",
@@ -8560,7 +8602,8 @@
                                                       "description": "Path of the field to select in the specified API version.",
                                                       "type": "string"
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "mode": {
                                                   "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -8599,7 +8642,8 @@
                                                       "description": "Required: resource to select",
                                                       "type": "string"
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
                                             }
@@ -8645,7 +8689,8 @@
                                             "description": "optional field specify whether the Secret or its key must be defined",
                                             "type": "boolean"
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "serviceAccountToken": {
                                         "description": "serviceAccountToken is information about the serviceAccountToken data to project",
@@ -8751,7 +8796,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "user": {
                                   "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -8792,7 +8838,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "sslEnabled": {
                                   "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
@@ -8882,7 +8929,8 @@
                                       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
                                       "type": "string"
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "volumeName": {
                                   "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",


### PR DESCRIPTION
## Description, Motivation and Context

chore: update binaries used to build manifests and k8s
- client-gen version from v0.22.0 to v0.26.1
- controller-gen version from v0.7.0 to v0.11.2
- k8s pacth from 1.26.0 to 1.26.1

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
