### PR TITLE
fix: address runtime error of nil pointer about concatenating preflig…

### DIFF
--- a/pkg/preflight/concat.go
+++ b/pkg/preflight/concat.go
@@ -5,17 +5,33 @@ import (
 )
 
 func ConcatPreflightSpec(target *troubleshootv1beta2.Preflight, source *troubleshootv1beta2.Preflight) *troubleshootv1beta2.Preflight {
-	newSpec := target.DeepCopy()
-	newSpec.Spec.Collectors = append(target.Spec.Collectors, source.Spec.Collectors...)
-	newSpec.Spec.RemoteCollectors = append(target.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
-	newSpec.Spec.Analyzers = append(target.Spec.Analyzers, source.Spec.Analyzers...)
+	if source == nil {
+		return target
+	}
+	var newSpec *troubleshootv1beta2.Preflight
+	if target == nil {
+		newSpec = source
+	} else {
+		newSpec = target.DeepCopy()
+		newSpec.Spec.Collectors = append(newSpec.Spec.Collectors, source.Spec.Collectors...)
+		newSpec.Spec.RemoteCollectors = append(newSpec.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
+		newSpec.Spec.Analyzers = append(newSpec.Spec.Analyzers, source.Spec.Analyzers...)
+	}
 	return newSpec
 }
 
 func ConcatHostPreflightSpec(target *troubleshootv1beta2.HostPreflight, source *troubleshootv1beta2.HostPreflight) *troubleshootv1beta2.HostPreflight {
-	newSpec := target.DeepCopy()
-	newSpec.Spec.Collectors = append(target.Spec.Collectors, source.Spec.Collectors...)
-	newSpec.Spec.RemoteCollectors = append(target.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
-	newSpec.Spec.Analyzers = append(target.Spec.Analyzers, source.Spec.Analyzers...)
+	if source == nil {
+		return target
+	}
+	var newSpec *troubleshootv1beta2.HostPreflight
+	if target == nil {
+		newSpec = source
+	} else {
+		newSpec = target.DeepCopy()
+		newSpec.Spec.Collectors = append(newSpec.Spec.Collectors, source.Spec.Collectors...)
+		newSpec.Spec.RemoteCollectors = append(newSpec.Spec.RemoteCollectors, source.Spec.RemoteCollectors...)
+		newSpec.Spec.Analyzers = append(newSpec.Spec.Analyzers, source.Spec.Analyzers...)
+	}
 	return newSpec
 }

--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -49,7 +49,7 @@ func RunPreflights(interactive bool, output string, format string, args []string
 	var uploadResultSpecs []*troubleshootv1beta2.Preflight
 	var err error
 
-	for i, v := range args {
+	for _, v := range args {
 		if strings.HasPrefix(v, "secret/") {
 			// format secret/namespace-name/secret-name
 			pathParts := strings.Split(v, "/")
@@ -126,20 +126,12 @@ func RunPreflights(interactive bool, output string, format string, args []string
 
 		if spec, ok := obj.(*troubleshootv1beta2.Preflight); ok {
 			if spec.Spec.UploadResultsTo == "" {
-				if i == 0 {
-					preflightSpec = spec
-				} else {
-					preflightSpec = ConcatPreflightSpec(preflightSpec, spec)
-				}
+				preflightSpec = ConcatPreflightSpec(preflightSpec, spec)
 			} else {
 				uploadResultSpecs = append(uploadResultSpecs, spec)
 			}
 		} else if spec, ok := obj.(*troubleshootv1beta2.HostPreflight); ok {
-			if i == 0 {
-				hostPreflightSpec = spec
-			} else {
-				hostPreflightSpec = ConcatHostPreflightSpec(hostPreflightSpec, spec)
-			}
+			hostPreflightSpec = ConcatHostPreflightSpec(hostPreflightSpec, spec)
 		}
 	}
 


### PR DESCRIPTION
…ht spec with hostpreflight spec in preflight run.go

## Description, Motivation and Context

This pr is intend to fix a nil pointer error about concatenating spec in preflight module.

**Steps To Reproduce bug**
 **cmd : preflight examples/preflight/host/cpu.yaml  examples/preflight/node-resources.yaml**

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x120 pc=0x10268e9bc]

goroutine 1 [running]:
github.com/replicatedhq/troubleshoot/pkg/preflight.ConcatPreflightSpec(0x0, 0x14000918180)
        /Users/yangmeili/work/tmp/troubleshoot/pkg/preflight/concat.go:9 +0x5c
       ... (omitting other error stacks )


<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
