### PR TITLE
chore: Refactor in cluster analysers

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -88,436 +88,33 @@ func Analyze(analyzer *troubleshootv1beta2.Analyze, getFile getCollectedFileCont
 		return nil, errors.New("nil analyzer")
 	}
 
-	if analyzer.ClusterVersion != nil {
-		isExcluded, err := isExcluded(analyzer.ClusterVersion.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeClusterVersion(analyzer.ClusterVersion, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.ClusterVersion.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.StorageClass != nil {
-		isExcluded, err := isExcluded(analyzer.StorageClass.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeStorageClass(analyzer.StorageClass, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.StorageClass.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.CustomResourceDefinition != nil {
-		isExcluded, err := isExcluded(analyzer.CustomResourceDefinition.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeCustomResourceDefinition(analyzer.CustomResourceDefinition, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.CustomResourceDefinition.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Ingress != nil {
-		isExcluded, err := isExcluded(analyzer.Ingress.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeIngress(analyzer.Ingress, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.Ingress.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Secret != nil {
-		isExcluded, err := isExcluded(analyzer.Secret.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeSecret(analyzer.Secret, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.Secret.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.ConfigMap != nil {
-		isExcluded, err := isExcluded(analyzer.ConfigMap.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeConfigMap(analyzer.ConfigMap, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.ConfigMap.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.ImagePullSecret != nil {
-		isExcluded, err := isExcluded(analyzer.ImagePullSecret.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeImagePullSecret(analyzer.ImagePullSecret, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.ImagePullSecret.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.DeploymentStatus != nil {
-		isExcluded, err := isExcluded(analyzer.DeploymentStatus.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := analyzeDeploymentStatus(analyzer.DeploymentStatus, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.DeploymentStatus.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
-	}
-	if analyzer.ClusterResource != nil {
-		isExcluded, err := isExcluded(analyzer.ClusterResource.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeResource(analyzer.ClusterResource, getFile)
-		if err != nil {
-			return nil, err
-		}
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.StatefulsetStatus != nil {
-		isExcluded, err := isExcluded(analyzer.StatefulsetStatus.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := analyzeStatefulsetStatus(analyzer.StatefulsetStatus, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.StatefulsetStatus.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
-	}
-	if analyzer.JobStatus != nil {
-		isExcluded, err := isExcluded(analyzer.JobStatus.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := analyzeJobStatus(analyzer.JobStatus, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.JobStatus.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
-	}
-	if analyzer.ReplicaSetStatus != nil {
-		isExcluded, err := isExcluded(analyzer.ReplicaSetStatus.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := analyzeReplicaSetStatus(analyzer.ReplicaSetStatus, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.ReplicaSetStatus.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
-	}
-	if analyzer.ClusterPodStatuses != nil {
-		isExcluded, err := isExcluded(analyzer.ClusterPodStatuses.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := clusterPodStatuses(analyzer.ClusterPodStatuses, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.ClusterPodStatuses.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
-	}
-	if analyzer.ContainerRuntime != nil {
-		isExcluded, err := isExcluded(analyzer.ContainerRuntime.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeContainerRuntime(analyzer.ContainerRuntime, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.ContainerRuntime.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Distribution != nil {
-		isExcluded, err := isExcluded(analyzer.Distribution.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeDistribution(analyzer.Distribution, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.Distribution.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.NodeResources != nil {
-		isExcluded, err := isExcluded(analyzer.NodeResources.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeNodeResources(analyzer.NodeResources, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.NodeResources.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.TextAnalyze != nil {
-		isExcluded, err := isExcluded(analyzer.TextAnalyze.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := analyzeTextAnalyze(analyzer.TextAnalyze, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.TextAnalyze.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
-	}
-	if analyzer.YamlCompare != nil {
-		isExcluded, err := isExcluded(analyzer.YamlCompare.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeYamlCompare(analyzer.YamlCompare, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.YamlCompare.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.JsonCompare != nil {
-		isExcluded, err := isExcluded(analyzer.JsonCompare.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeJsonCompare(analyzer.JsonCompare, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.JsonCompare.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Postgres != nil {
-		isExcluded, err := isExcluded(analyzer.Postgres.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzePostgres(analyzer.Postgres, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.Postgres.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Mysql != nil {
-		isExcluded, err := isExcluded(analyzer.Mysql.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeMysql(analyzer.Mysql, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.Mysql.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Redis != nil {
-		isExcluded, err := isExcluded(analyzer.Redis.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeRedis(analyzer.Redis, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.Redis.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.CephStatus != nil {
-		isExcluded, err := isExcluded(analyzer.CephStatus.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := cephStatus(analyzer.CephStatus, getFile)
-		if err != nil {
-			return nil, err
-		}
-		if result != nil {
-			result.Strict = analyzer.CephStatus.Strict.BoolOrDefaultFalse()
-		}
-		return []*AnalyzeResult{result}, nil
-	}
-	if analyzer.Longhorn != nil {
-		isExcluded, err := isExcluded(analyzer.Longhorn.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := longhorn(analyzer.Longhorn, getFile, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.Longhorn.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
+	analyzerInst := getAnalyzer(analyzer)
+	if analyzerInst == nil {
+		return []*AnalyzeResult{{
+			IsFail:  true,
+			Title:   "nonexistent analyzer",
+			Message: "Analyzer not found",
+		}}, nil
 	}
 
-	if analyzer.RegistryImages != nil {
-		isExcluded, err := isExcluded(analyzer.RegistryImages.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeRegistry(analyzer.RegistryImages, getFile)
-		if err != nil {
-			return nil, err
-		}
-		result.Strict = analyzer.RegistryImages.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
+	isExcluded, err := analyzerInst.IsExcluded()
+	if err != nil {
+		return nil, err
+	}
+	if isExcluded {
+		return nil, nil
 	}
 
-	if analyzer.WeaveReport != nil {
-		isExcluded, err := isExcluded(analyzer.WeaveReport.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		results, err := analyzeWeaveReport(analyzer.WeaveReport, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		for i := range results {
-			results[i].Strict = analyzer.WeaveReport.Strict.BoolOrDefaultFalse()
-		}
-		return results, nil
+	results, err := analyzerInst.Analyze(getFile, findFiles)
+	if err != nil {
+		return nil, err
 	}
 
-	if analyzer.Sysctl != nil {
-		isExcluded, err := isExcluded(analyzer.Sysctl.Exclude)
-		if err != nil {
-			return nil, err
-		}
-		if isExcluded {
-			return nil, nil
-		}
-		result, err := analyzeSysctl(analyzer.Sysctl, findFiles)
-		if err != nil {
-			return nil, err
-		}
-		if result == nil {
-			return []*AnalyzeResult{}, nil
-		}
-		result.Strict = analyzer.Sysctl.Strict.BoolOrDefaultFalse()
-		return []*AnalyzeResult{result}, nil
+	if results == nil {
+		results = []*AnalyzeResult{}
 	}
 
-	return nil, errors.New("invalid analyzer")
+	return results, nil
 }
 
 func GetExcludeFlag(analyzer *troubleshootv1beta2.Analyze) *multitype.BoolOrString {
@@ -540,4 +137,71 @@ func GetExcludeFlag(analyzer *troubleshootv1beta2.Analyze) *multitype.BoolOrStri
 	}
 
 	return nil
+}
+
+type Analyzer interface {
+	Title() string
+	IsExcluded() (bool, error)
+	Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error)
+}
+
+func getAnalyzer(analyzer *troubleshootv1beta2.Analyze) Analyzer {
+	switch {
+	case analyzer.ClusterVersion != nil:
+		return &AnalyzeClusterVersion{analyzer: analyzer.ClusterVersion}
+	case analyzer.StorageClass != nil:
+		return &AnalyzeStorageClass{analyzer: analyzer.StorageClass}
+	case analyzer.CustomResourceDefinition != nil:
+		return &AnalyzeCustomResourceDefinition{analyzer: analyzer.CustomResourceDefinition}
+	case analyzer.Ingress != nil:
+		return &AnalyzeIngress{analyzer: analyzer.Ingress}
+	case analyzer.Secret != nil:
+		return &AnalyzeSecret{analyzer: analyzer.Secret}
+	case analyzer.ConfigMap != nil:
+		return &AnalyzeConfigMap{analyzer: analyzer.ConfigMap}
+	case analyzer.ImagePullSecret != nil:
+		return &AnalyzeImagePullSecret{analyzer: analyzer.ImagePullSecret}
+	case analyzer.DeploymentStatus != nil:
+		return &AnalyzeDeploymentStatus{analyzer: analyzer.DeploymentStatus}
+	case analyzer.StatefulsetStatus != nil:
+		return &AnalyzeStatefulsetStatus{analyzer: analyzer.StatefulsetStatus}
+	case analyzer.JobStatus != nil:
+		return &AnalyzeJobStatus{analyzer: analyzer.JobStatus}
+	case analyzer.ReplicaSetStatus != nil:
+		return &AnalyzeReplicaSetStatus{analyzer: analyzer.ReplicaSetStatus}
+	case analyzer.ClusterPodStatuses != nil:
+		return &AnalyzeClusterPodStatuses{analyzer: analyzer.ClusterPodStatuses}
+	case analyzer.ContainerRuntime != nil:
+		return &AnalyzeContainerRuntime{analyzer: analyzer.ContainerRuntime}
+	case analyzer.Distribution != nil:
+		return &AnalyzeDistribution{analyzer: analyzer.Distribution}
+	case analyzer.NodeResources != nil:
+		return &AnalyzeNodeResources{analyzer: analyzer.NodeResources}
+	case analyzer.TextAnalyze != nil:
+		return &AnalyzeTextAnalyze{analyzer: analyzer.TextAnalyze}
+	case analyzer.YamlCompare != nil:
+		return &AnalyzeYamlCompare{analyzer: analyzer.YamlCompare}
+	case analyzer.JsonCompare != nil:
+		return &AnalyzeJsonCompare{analyzer: analyzer.JsonCompare}
+	case analyzer.Postgres != nil:
+		return &AnalyzePostgres{analyzer: analyzer.Postgres}
+	case analyzer.Mysql != nil:
+		return &AnalyzeMysql{analyzer: analyzer.Mysql}
+	case analyzer.Redis != nil:
+		return &AnalyzeRedis{analyzer: analyzer.Redis}
+	case analyzer.CephStatus != nil:
+		return &AnalyzeCephStatus{analyzer: analyzer.CephStatus}
+	case analyzer.Longhorn != nil:
+		return &AnalyzeLonghorn{analyzer: analyzer.Longhorn}
+	case analyzer.RegistryImages != nil:
+		return &AnalyzeRegistryImages{analyzer: analyzer.RegistryImages}
+	case analyzer.WeaveReport != nil:
+		return &AnalyzeWeaveReport{analyzer: analyzer.WeaveReport}
+	case analyzer.Sysctl != nil:
+		return &AnalyzeSysctl{analyzer: analyzer.Sysctl}
+	case analyzer.ClusterResource != nil:
+		return &AnalyzeClusterResource{analyzer: analyzer.ClusterResource}
+	default:
+		return nil
+	}
 }

--- a/pkg/analyze/analyzer_test.go
+++ b/pkg/analyze/analyzer_test.go
@@ -65,3 +65,9 @@ func Test_GetExcludeFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalyzeWithNilAnalyzer(t *testing.T) {
+	got, err := Analyze(nil, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, got)
+}

--- a/pkg/analyze/ceph_test.go
+++ b/pkg/analyze/ceph_test.go
@@ -273,7 +273,11 @@ func Test_cephStatus(t *testing.T) {
 				}
 			}
 
-			actual, err := cephStatus(&test.analyzer, test.getFile)
+			a := AnalyzeCephStatus{
+				analyzer: &test.analyzer,
+			}
+
+			actual, err := a.cephStatus(&test.analyzer, test.getFile)
 			req.NoError(err)
 
 			assert.Equal(t, test.expectResult, actual)

--- a/pkg/analyze/configmap_test.go
+++ b/pkg/analyze/configmap_test.go
@@ -199,7 +199,12 @@ func Test_analyzeConfigMap(t *testing.T) {
 				}
 				return contents, nil
 			}
-			got, err := analyzeConfigMap(tt.analyzer, getCollectedFileContents)
+
+			a := AnalyzeConfigMap{
+				analyzer: tt.analyzer,
+			}
+
+			got, err := a.analyzeConfigMap(tt.analyzer, getCollectedFileContents)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/analyze/container_runtime_test.go
+++ b/pkg/analyze/container_runtime_test.go
@@ -113,7 +113,11 @@ func Test_containerRuntime(t *testing.T) {
 				return test.files[n], nil
 			}
 
-			actual, err := analyzeContainerRuntime(&test.analyzer, getFiles)
+			a := AnalyzeContainerRuntime{
+				analyzer: &test.analyzer,
+			}
+
+			actual, err := a.analyzeContainerRuntime(&test.analyzer, getFiles)
 			req.NoError(err)
 
 			assert.Equal(t, &test.expectResult, actual)

--- a/pkg/analyze/crd.go
+++ b/pkg/analyze/crd.go
@@ -9,8 +9,34 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
-func analyzeCustomResourceDefinition(analyzer *troubleshootv1beta2.CustomResourceDefinition, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
-	crdData, err := getCollectedFileContents(fmt.Sprintf("%s/%s.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCE_DEFINITIONS))
+type AnalyzeCustomResourceDefinition struct {
+	analyzer *troubleshootv1beta2.CustomResourceDefinition
+}
+
+func (a *AnalyzeCustomResourceDefinition) Title() string {
+	title := a.analyzer.CheckName
+	if title == "" {
+		title = fmt.Sprintf("Custom resource definition %s", a.analyzer.CustomResourceDefinitionName)
+	}
+
+	return title
+}
+
+func (a *AnalyzeCustomResourceDefinition) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeCustomResourceDefinition) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	result, err := a.analyzeCustomResourceDefinition(a.analyzer, getFile)
+	if err != nil {
+		return nil, err
+	}
+	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	return []*AnalyzeResult{result}, nil
+}
+
+func (a *AnalyzeCustomResourceDefinition) analyzeCustomResourceDefinition(analyzer *troubleshootv1beta2.CustomResourceDefinition, getFile getCollectedFileContents) (*AnalyzeResult, error) {
+	crdData, err := getFile(fmt.Sprintf("%s/%s.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCE_DEFINITIONS))
 	if err != nil {
 		return nil, err
 	}
@@ -20,13 +46,8 @@ func analyzeCustomResourceDefinition(analyzer *troubleshootv1beta2.CustomResourc
 		return nil, err
 	}
 
-	title := analyzer.CheckName
-	if title == "" {
-		title = fmt.Sprintf("Custom resource definition %s", analyzer.CustomResourceDefinitionName)
-	}
-
 	result := AnalyzeResult{
-		Title:   title,
+		Title:   a.Title(),
 		IconKey: "kubernetes_custom_resource_definition",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/custom-resource-definition.svg?w=13&h=16",
 	}

--- a/pkg/analyze/image_pull_secret.go
+++ b/pkg/analyze/image_pull_secret.go
@@ -9,7 +9,33 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/constants"
 )
 
-func analyzeImagePullSecret(analyzer *troubleshootv1beta2.ImagePullSecret, getChildCollectedFileContents getChildCollectedFileContents) (*AnalyzeResult, error) {
+type AnalyzeImagePullSecret struct {
+	analyzer *troubleshootv1beta2.ImagePullSecret
+}
+
+func (a *AnalyzeImagePullSecret) Title() string {
+	title := a.analyzer.CheckName
+	if title == "" {
+		title = "Image Pull Secrets"
+	}
+
+	return title
+}
+
+func (a *AnalyzeImagePullSecret) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeImagePullSecret) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	result, err := a.analyzeImagePullSecret(a.analyzer, findFiles)
+	if err != nil {
+		return nil, err
+	}
+	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	return []*AnalyzeResult{result}, nil
+}
+
+func (a *AnalyzeImagePullSecret) analyzeImagePullSecret(analyzer *troubleshootv1beta2.ImagePullSecret, getChildCollectedFileContents getChildCollectedFileContents) (*AnalyzeResult, error) {
 	var excludeFiles = []string{}
 	imagePullSecrets, err := getChildCollectedFileContents(fmt.Sprintf("%s/%s", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_IMAGE_PULL_SECRETS), excludeFiles)
 	if err != nil {
@@ -25,13 +51,9 @@ func analyzeImagePullSecret(analyzer *troubleshootv1beta2.ImagePullSecret, getCh
 			passOutcome = outcome.Pass
 		}
 	}
-	title := analyzer.CheckName
-	if title == "" {
-		title = "Image Pull Secrets"
-	}
 
 	result := AnalyzeResult{
-		Title:   title,
+		Title:   a.Title(),
 		IconKey: "kubernetes_image_pull_secret",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/image-pull-secret.svg?w=16&h=14",
 		IsFail:  true,

--- a/pkg/analyze/ingress.go
+++ b/pkg/analyze/ingress.go
@@ -10,7 +10,33 @@ import (
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
-func analyzeIngress(analyzer *troubleshootv1beta2.Ingress, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+type AnalyzeIngress struct {
+	analyzer *troubleshootv1beta2.Ingress
+}
+
+func (a *AnalyzeIngress) Title() string {
+	title := a.analyzer.CheckName
+	if title == "" {
+		title = fmt.Sprintf("Ingress %s", a.analyzer.IngressName)
+	}
+
+	return title
+}
+
+func (a *AnalyzeIngress) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeIngress) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	result, err := a.analyzeIngress(a.analyzer, getFile)
+	if err != nil {
+		return nil, err
+	}
+	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	return []*AnalyzeResult{result}, nil
+}
+
+func (a *AnalyzeIngress) analyzeIngress(analyzer *troubleshootv1beta2.Ingress, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
 	ingressData, err := getCollectedFileContents(filepath.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_INGRESS, fmt.Sprintf("%s.json", analyzer.Namespace)))
 	if err != nil {
 		return nil, err
@@ -21,13 +47,8 @@ func analyzeIngress(analyzer *troubleshootv1beta2.Ingress, getCollectedFileConte
 		return nil, err
 	}
 
-	title := analyzer.CheckName
-	if title == "" {
-		title = fmt.Sprintf("Ingress %s", analyzer.IngressName)
-	}
-
 	result := AnalyzeResult{
-		Title:   title,
+		Title:   a.Title(),
 		IconKey: "kubernetes_ingress",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/ingress-controller.svg?w=20&h=13",
 	}

--- a/pkg/analyze/json_compare_test.go
+++ b/pkg/analyze/json_compare_test.go
@@ -551,7 +551,11 @@ func Test_jsonCompare(t *testing.T) {
 				return test.fileContents, nil
 			}
 
-			actual, err := analyzeJsonCompare(&test.analyzer, getCollectedFileContents)
+			a := AnalyzeJsonCompare{
+				analyzer: &test.analyzer,
+			}
+
+			actual, err := a.analyzeJsonCompare(&test.analyzer, getCollectedFileContents)
 			if !test.isError {
 				req.NoError(err)
 				req.Equal(test.expectResult, *actual)

--- a/pkg/analyze/longhorn.go
+++ b/pkg/analyze/longhorn.go
@@ -17,6 +17,29 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type AnalyzeLonghorn struct {
+	analyzer *troubleshootv1beta2.LonghornAnalyze
+}
+
+func (a *AnalyzeLonghorn) Title() string {
+	return "Longhorn analyzer"
+}
+
+func (a *AnalyzeLonghorn) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeLonghorn) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	results, err := longhorn(a.analyzer, getFile, findFiles)
+	if err != nil {
+		return nil, err
+	}
+	for i := range results {
+		results[i].Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	}
+	return results, nil
+}
+
 func longhorn(analyzer *troubleshootv1beta2.LonghornAnalyze, getFileContents getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
 	ns := collect.DefaultLonghornNamespace
 	if analyzer.Namespace != "" {

--- a/pkg/analyze/node_resources_test.go
+++ b/pkg/analyze/node_resources_test.go
@@ -936,7 +936,11 @@ func Test_analyzeNodeResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 
-			got, err := analyzeNodeResources(tt.analyzer, getExampleNodeContents)
+			a := AnalyzeNodeResources{
+				analyzer: tt.analyzer,
+			}
+
+			got, err := a.analyzeNodeResources(tt.analyzer, getExampleNodeContents)
 			req.NoError(err)
 			req.Equal(tt.want, got)
 		})

--- a/pkg/analyze/redis.go
+++ b/pkg/analyze/redis.go
@@ -10,13 +10,43 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
 )
 
-func analyzeRedis(analyzer *troubleshootv1beta2.DatabaseAnalyze, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
-	collectorName := analyzer.CollectorName
+type AnalyzeRedis struct {
+	analyzer *troubleshootv1beta2.DatabaseAnalyze
+}
+
+func (a *AnalyzeRedis) Title() string {
+	title := a.analyzer.CheckName
+	if title == "" {
+		title = a.collectorName()
+	}
+
+	return title
+}
+
+func (a *AnalyzeRedis) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeRedis) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	result, err := a.analyzeRedis(a.analyzer, getFile)
+	if err != nil {
+		return nil, err
+	}
+	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	return []*AnalyzeResult{result}, nil
+}
+
+func (a *AnalyzeRedis) collectorName() string {
+	collectorName := a.analyzer.CollectorName
 	if collectorName == "" {
 		collectorName = "redis"
 	}
 
-	fullPath := path.Join("redis", fmt.Sprintf("%s.json", collectorName))
+	return collectorName
+}
+
+func (a *AnalyzeRedis) analyzeRedis(analyzer *troubleshootv1beta2.DatabaseAnalyze, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+	fullPath := path.Join("redis", fmt.Sprintf("%s.json", a.collectorName()))
 
 	collected, err := getCollectedFileContents(fullPath)
 	if err != nil {
@@ -28,13 +58,8 @@ func analyzeRedis(analyzer *troubleshootv1beta2.DatabaseAnalyze, getCollectedFil
 		return nil, errors.Wrap(err, "failed to unmarshal database connection result")
 	}
 
-	title := analyzer.CheckName
-	if title == "" {
-		title = collectorName
-	}
-
 	result := &AnalyzeResult{
-		Title:   title,
+		Title:   a.Title(),
 		IconKey: "kubernetes_redis_analyze",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/redis-analyze.svg",
 	}

--- a/pkg/analyze/secret.go
+++ b/pkg/analyze/secret.go
@@ -8,7 +8,33 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
 )
 
-func analyzeSecret(analyzer *troubleshootv1beta2.AnalyzeSecret, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+type AnalyzeSecret struct {
+	analyzer *troubleshootv1beta2.AnalyzeSecret
+}
+
+func (a *AnalyzeSecret) Title() string {
+	title := a.analyzer.CheckName
+	if title == "" {
+		title = fmt.Sprintf("Secret %s", a.analyzer.SecretName)
+	}
+
+	return title
+}
+
+func (a *AnalyzeSecret) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeSecret) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	result, err := a.analyzeSecret(a.analyzer, getFile)
+	if err != nil {
+		return nil, err
+	}
+	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	return []*AnalyzeResult{result}, nil
+}
+
+func (a *AnalyzeSecret) analyzeSecret(analyzer *troubleshootv1beta2.AnalyzeSecret, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
 	filename := collect.GetSecretFileName(
 		&troubleshootv1beta2.Secret{
 			Namespace: analyzer.Namespace,
@@ -28,13 +54,8 @@ func analyzeSecret(analyzer *troubleshootv1beta2.AnalyzeSecret, getCollectedFile
 		return nil, err
 	}
 
-	title := analyzer.CheckName
-	if title == "" {
-		title = fmt.Sprintf("Secret %s", analyzer.SecretName)
-	}
-
 	result := AnalyzeResult{
-		Title:   title,
+		Title:   a.Title(),
 		IconKey: "kubernetes_analyze_secret",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/secret.svg?w=13&h=16",
 	}

--- a/pkg/analyze/secret_test.go
+++ b/pkg/analyze/secret_test.go
@@ -200,7 +200,10 @@ func Test_analyzeSecret(t *testing.T) {
 				}
 				return contents, nil
 			}
-			got, err := analyzeSecret(tt.analyzer, getCollectedFileContents)
+			a := AnalyzeSecret{
+				analyzer: tt.analyzer,
+			}
+			got, err := a.analyzeSecret(tt.analyzer, getCollectedFileContents)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/analyze/storage_class.go
+++ b/pkg/analyze/storage_class.go
@@ -9,7 +9,37 @@ import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 )
 
-func analyzeStorageClass(analyzer *troubleshootv1beta2.StorageClass, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
+type AnalyzeStorageClass struct {
+	analyzer *troubleshootv1beta2.StorageClass
+}
+
+func (a *AnalyzeStorageClass) Title() string {
+	title := a.analyzer.CheckName
+	if title == "" {
+		if a.analyzer.StorageClassName != "" {
+			title = fmt.Sprintf("Storage class %s", a.analyzer.StorageClassName)
+		} else {
+			title = "Default Storage Class"
+		}
+	}
+
+	return title
+}
+
+func (a *AnalyzeStorageClass) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeStorageClass) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	result, err := a.analyzeStorageClass(a.analyzer, getFile)
+	if err != nil {
+		return nil, err
+	}
+	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	return []*AnalyzeResult{result}, nil
+}
+
+func (a *AnalyzeStorageClass) analyzeStorageClass(analyzer *troubleshootv1beta2.StorageClass, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
 	storageClassesData, err := getCollectedFileContents(fmt.Sprintf("%s/%s.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_STORAGE_CLASS))
 	if err != nil {
 		return nil, err
@@ -20,23 +50,14 @@ func analyzeStorageClass(analyzer *troubleshootv1beta2.StorageClass, getCollecte
 		return nil, err
 	}
 
-	title := analyzer.CheckName
-	if title == "" {
-		if analyzer.StorageClassName != "" {
-			title = fmt.Sprintf("Storage class %s", analyzer.StorageClassName)
-		} else {
-			title = "Default Storage Class"
-		}
-	}
-
 	result := AnalyzeResult{
-		Title:   title,
+		Title:   a.Title(),
 		IconKey: "kubernetes_storage_class",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/storage-class.svg?w=12&h=12",
 	}
 
 	for _, storageClass := range storageClasses.Items {
-		val, _ := storageClass.Annotations["storageclass.kubernetes.io/is-default-class"]
+		val := storageClass.Annotations["storageclass.kubernetes.io/is-default-class"]
 		if (storageClass.Name == analyzer.StorageClassName) || (analyzer.StorageClassName == "" && val == "true") {
 			result.IsPass = true
 			for _, outcome := range analyzer.Outcomes {

--- a/pkg/analyze/sysctl_test.go
+++ b/pkg/analyze/sysctl_test.go
@@ -403,7 +403,11 @@ func TestAnalyzeSysctl(t *testing.T) {
 			var findFiles = func(glob string, _ []string) (map[string][]byte, error) {
 				return test.files, nil
 			}
-			got, err := analyzeSysctl(test.analyzer, findFiles)
+
+			a := AnalyzeSysctl{
+				analyzer: test.analyzer,
+			}
+			got, err := a.analyzeSysctl(test.analyzer, findFiles)
 
 			assert.NoError(t, err)
 

--- a/pkg/analyze/text_analyze_test.go
+++ b/pkg/analyze/text_analyze_test.go
@@ -727,7 +727,11 @@ func Test_textAnalyze(t *testing.T) {
 				return matching, nil
 			}
 
-			actual, err := analyzeTextAnalyze(&test.analyzer, getFiles)
+			a := AnalyzeTextAnalyze{
+				analyzer: &test.analyzer,
+			}
+
+			actual, err := a.analyzeTextAnalyze(&test.analyzer, getFiles)
 			req.NoError(err)
 
 			unPointered := []AnalyzeResult{}

--- a/pkg/analyze/weave.go
+++ b/pkg/analyze/weave.go
@@ -39,6 +39,29 @@ type WeaveAttributes struct {
 	Name      string `json:"name"`
 }
 
+type AnalyzeWeaveReport struct {
+	analyzer *troubleshootv1beta2.WeaveReportAnalyze
+}
+
+func (a *AnalyzeWeaveReport) Title() string {
+	return "Weave CNI"
+}
+
+func (a *AnalyzeWeaveReport) IsExcluded() (bool, error) {
+	return isExcluded(a.analyzer.Exclude)
+}
+
+func (a *AnalyzeWeaveReport) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+	results, err := analyzeWeaveReport(a.analyzer, findFiles)
+	if err != nil {
+		return nil, err
+	}
+	for i := range results {
+		results[i].Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+	}
+	return results, nil
+}
+
 func analyzeWeaveReport(analyzer *troubleshootv1beta2.WeaveReportAnalyze, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
 	excludeFiles := []string{}
 	files, err := findFiles(analyzer.ReportFileGlob, excludeFiles)

--- a/pkg/analyze/yaml_compare_test.go
+++ b/pkg/analyze/yaml_compare_test.go
@@ -440,7 +440,11 @@ otherstuff:
 				return test.fileContents, nil
 			}
 
-			actual, err := analyzeYamlCompare(&test.analyzer, getCollectedFileContents)
+			a := AnalyzeYamlCompare{
+				analyzer: &test.analyzer,
+			}
+
+			actual, err := a.analyzeYamlCompare(&test.analyzer, getCollectedFileContents)
 			if !test.isError {
 				req.NoError(err)
 				req.Equal(test.expectResult, *actual)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -33,7 +33,7 @@ const (
 	CLUSTER_RESOURCES_STORAGE_CLASS               = "storage-classes"
 	CLUSTER_RESOURCES_CUSTOM_RESOURCE_DEFINITIONS = "custom-resource-definitions"
 	CLUSTER_RESOURCES_CUSTOM_RESOURCES            = "custom-resources"
-	CLUSTER_RESOURCES_IMAGE_PULL_SECRETS          = "image-pull-secrets"
+	CLUSTER_RESOURCES_IMAGE_PULL_SECRETS          = "image-pull-secrets" // nolint:gosec
 	CLUSTER_RESOURCES_NODES                       = "nodes"
 	CLUSTER_RESOURCES_GROUPS                      = "groups"
 	CLUSTER_RESOURCES_RESOURCES                   = "resources"


### PR DESCRIPTION
## Description, Motivation and Context

There are quite many changes in this PR, but none of them add/remove any functionality. The changes done are as follows
* Have all in-cluster analysers implement the following interface
```go
type Analyzer interface {
	Title() string
	IsExcluded() (bool, error)
	Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error)
}
```
* Create a `getAnalyzer` factory function which is used to construct an analyser object which exposes the analysing business logic via `Analyze` method.
* Clean up `Analyze` function by removing all the analyser specific implementation

This will allow other parts of the code base that operate on all analysers to have a uniform way of making API calls e.g getting a name of an analyser now would be `analyser.Title()`.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #995 

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
