### PR TITLE
CONTRIBUTING.md: adding a quick copy paste local dev setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,42 @@ To get started we recommend:
 
 6. Install [golangci-lint] linter and run `make lint` to execute additional code linters.
 
+### Quick Start Local Development (MacOS)
+
+First install [colima](https://github.com/abiosoft/colima):
+
+```
+brew install colima
+```
+
+Start a colima VM with a single node Kubernetes cluster:
+
+```
+colima start --kubernetes
+```
+
+Then spawn a Docker container with a Go toolchain, with access to the Kubernetes cluster:
+
+```
+docker run -it --rm --network host -v $(pwd):/src -v $HOME/.kube:/root/.kube golang:1.19.5-bullseye bash
+```
+
+A quick test (in the Docker container):
+
+```
+make preflight support-bundle
+bin/preflight config/samples/troubleshoot_v1beta2_preflight.yaml
+bin/preflight examples/preflight/sample-preflight.yaml
+```
+
+If you need `kubectl` in the Docker container for diagnostics:
+
+```
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+rm -f kubectl
+```
+
 ### Testing
 
 To run the tests locally run the following:


### PR DESCRIPTION
## Description, Motivation and Context

adding a quick copy paste local dev setup 

uses Docker/colima with local K8s

rationale: I want to be able to code in airgap environments (eg. on planes), and/or with ~0 latency, and not rely on VMs or remote K8s clusters etc :)

open to suggestions re different approaches or shuffling the logic I've documented here to places like the `Makefile` etc

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
