### PR TITLE
chore: Don't print which error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 
 .PHONY: client-gen
 client-gen:
-ifeq (, $(shell which client-gen))
+ifeq (, $(shell which client-gen 2>/dev/null))
 	go install k8s.io/code-generator/cmd/client-gen@v0.26.1
 CLIENT_GEN=$(shell go env GOPATH)/bin/client-gen
 else


### PR DESCRIPTION
## Description, Motivation and Context

The `which` binary is used to detect if `client-gen` is installed, and if it's not, the Makefile will install it. The initial detection prints an error if it's not found. This is misleading, as it is actually an expected situation.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No