### PR TITLE
make schema error longhorn.go:287 error

### DIFF
--- a/pkg/collect/longhorn.go
+++ b/pkg/collect/longhorn.go
@@ -235,6 +235,7 @@ func (c *CollectLonghorn) Collect(progressChan chan<- interface{}) (CollectorRes
 	var wg sync.WaitGroup
 
 	for _, volume := range volumes.Items {
+		volume := volume
 		if volume.Status.State != longhorntypes.VolumeStateDetached {
 			// cannot checksum volumes in use
 			continue


### PR DESCRIPTION
## Description

I came across this error when I attempted run the command “make schemas”:

root@davidr-test01:~/repos/troubleshoot# make schemas
go fmt ./pkg/... ./cmd/... ./internal/...
go vet -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -installsuffix netgo ./pkg/... ./cmd/... ./internal/...
# github.com/replicatedhq/troubleshoot/pkg/collect
pkg/collect/longhorn.go:287:35: loop variable volume captured by func literal

I consulted Ethan and he recommended to remedy this error that we add the following line underneath line 237 in pkg/collect/longhorn.go:  volume := volume.

After adding I can successfully run the “make schemas” command:

root@davidr-test01:~/repos/troubleshoot# make schemas
go fmt ./pkg/... ./cmd/... ./internal/...
go vet -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -installsuffix netgo ./pkg/... ./cmd/... ./internal/...
go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.2
controller-gen crd +output:dir=./config/crds  paths=./pkg/apis/troubleshoot/v1beta1
controller-gen crd +output:dir=./config/crds  paths=./pkg/apis/troubleshoot/v1beta2
go build -ldflags " -s -w -X github.com/replicatedhq/troubleshoot/pkg/version.version=`git describe --tags --dirty` -X github.com/replicatedhq/troubleshoot/pkg/version.gitSHA=`git rev-parse HEAD` -X github.com/replicatedhq/troubleshoot/pkg/version.buildTime=`date -u +"%Y-%m-%dT%H:%M:%SZ"` " -o bin/schemagen github.com/replicatedhq/troubleshoot/cmd/schemagen
./bin/schemagen --output-dir ./schemas


Notwithstanding, please review this [slack comm](https://replicated.slack.com/archives/C016DU6CXNE/p1676918142495549) as Dmitriy has some additional recommendations.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No