### PR TITLE
improve clarity of collector progress msg

### DIFF
--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -168,7 +168,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 				continue
 			}
 		}
-		opts.CollectorProgressCallback(opts.ProgressChan, collector.Title())
+		opts.CollectorProgressCallback(opts.ProgressChan, fmt.Sprintf("running collector %s", collector.Title()))
 		result, err := collector.Collect(opts.ProgressChan)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
## Description, Motivation and Context

SC-61012

This pr modifies the progress message passed into the channel from troubleshoot to indicate that a particular collector is being run.  Previously, it would only pass the name of the collector and it was not clear if the collector was starting or had finished.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
