### PR TITLE
fix: Use namespace from the collector spec for Ceph

### DIFF
--- a/pkg/collect/ceph.go
+++ b/pkg/collect/ceph.go
@@ -128,11 +128,11 @@ func (c *CollectCeph) IsExcluded() (bool, error) {
 func (c *CollectCeph) Collect(progressChan chan<- interface{}) (CollectorResult, error) {
 	ctx := context.TODO()
 
-	if c.Namespace == "" {
-		c.Namespace = DefaultCephNamespace
+	if c.Collector.Namespace == "" {
+		c.Collector.Namespace = DefaultCephNamespace
 	}
 
-	pod, err := findRookCephToolsPod(ctx, c, c.Namespace)
+	pod, err := findRookCephToolsPod(ctx, c, c.Collector.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (c *CollectCeph) Collect(progressChan chan<- interface{}) (CollectorResult,
 		for _, command := range CephCommands {
 			err := cephCommandExec(ctx, progressChan, c, c.Collector, pod, command, output)
 			if err != nil {
-				pathPrefix := GetCephCollectorFilepath(c.Collector.CollectorName, c.Namespace)
+				pathPrefix := GetCephCollectorFilepath(c.Collector.CollectorName, c.Collector.Namespace)
 				dstFileName := path.Join(pathPrefix, fmt.Sprintf("%s.%s-error", command.ID, command.Format))
 				output.SaveResult(c.BundlePath, dstFileName, strings.NewReader(err.Error()))
 			}


### PR DESCRIPTION
## Description, Motivation and Context

Correctly use namespace from the ceph collector spec and not from the `kubeconfig` or `--namespace` flag. This is a regression from the struct refactor for collectors

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
