### PR TITLE
feat: support for rhel 9 variants (rhel, centos, ol, rocky)

### DIFF
--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -1198,6 +1198,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        centos9:
+                          items:
+                            type: string
+                          type: array
                         collectorName:
                           type: string
                         exclude:
@@ -1214,6 +1218,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        ol9:
+                          items:
+                            type: string
+                          type: array
                         rhel:
                           items:
                             type: string
@@ -1223,6 +1231,22 @@ spec:
                             type: string
                           type: array
                         rhel8:
+                          items:
+                            type: string
+                          type: array
+                        rhel9:
+                          items:
+                            type: string
+                          type: array
+                        rocky:
+                          items:
+                            type: string
+                          type: array
+                        rocky8:
+                          items:
+                            type: string
+                          type: array
+                        rocky9:
                           items:
                             type: string
                           type: array

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -1198,6 +1198,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        centos9:
+                          items:
+                            type: string
+                          type: array
                         collectorName:
                           type: string
                         exclude:
@@ -1214,6 +1218,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        ol9:
+                          items:
+                            type: string
+                          type: array
                         rhel:
                           items:
                             type: string
@@ -1223,6 +1231,22 @@ spec:
                             type: string
                           type: array
                         rhel8:
+                          items:
+                            type: string
+                          type: array
+                        rhel9:
+                          items:
+                            type: string
+                          type: array
+                        rocky:
+                          items:
+                            type: string
+                          type: array
+                        rocky8:
+                          items:
+                            type: string
+                          type: array
+                        rocky9:
                           items:
                             type: string
                           type: array

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -11130,6 +11130,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        centos9:
+                          items:
+                            type: string
+                          type: array
                         collectorName:
                           type: string
                         exclude:
@@ -11146,6 +11150,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        ol9:
+                          items:
+                            type: string
+                          type: array
                         rhel:
                           items:
                             type: string
@@ -11155,6 +11163,22 @@ spec:
                             type: string
                           type: array
                         rhel8:
+                          items:
+                            type: string
+                          type: array
+                        rhel9:
+                          items:
+                            type: string
+                          type: array
+                        rocky:
+                          items:
+                            type: string
+                          type: array
+                        rocky8:
+                          items:
+                            type: string
+                          type: array
+                        rocky9:
                           items:
                             type: string
                           type: array

--- a/examples/preflight/host/system-packages.yaml
+++ b/examples/preflight/host/system-packages.yaml
@@ -21,11 +21,23 @@ spec:
         rhel8:
           - nfs-utils
           - openssl
+        rhel9:
+          - nfs-utils
+          - openssl
+        rocky8:
+          - nfs-utils
+          - openssl
+        rocky9:
+          - nfs-utils
+          - openssl
         centos:
           - iscsi-initiator-utils
         centos7:
           - libzstd
         centos8:
+          - nfs-utils
+          - openssl
+        centos9:
           - nfs-utils
           - openssl
         ol:
@@ -34,6 +46,8 @@ spec:
           - libzstd
           - openssl
         ol8:
+          - nfs-utils
+        ol9:
           - nfs-utils
         amzn:
           - libzstd

--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -82,12 +82,18 @@ type HostSystemPackages struct {
 	RHEL              []string `json:"rhel,omitempty"`
 	RHEL7             []string `json:"rhel7,omitempty"`
 	RHEL8             []string `json:"rhel8,omitempty"`
+	RHEL9             []string `json:"rhel9,omitempty"`
+	RockyLinux        []string `json:"rocky,omitempty"`
+	RockyLinux8       []string `json:"rocky8,omitempty"`
+	RockyLinux9       []string `json:"rocky9,omitempty"`
 	CentOS            []string `json:"centos,omitempty"`
 	CentOS7           []string `json:"centos7,omitempty"`
 	CentOS8           []string `json:"centos8,omitempty"`
+	CentOS9           []string `json:"centos9,omitempty"`
 	OracleLinux       []string `json:"ol,omitempty"`
 	OracleLinux7      []string `json:"ol7,omitempty"`
 	OracleLinux8      []string `json:"ol8,omitempty"`
+	OracleLinux9      []string `json:"ol9,omitempty"`
 	AmazonLinux       []string `json:"amzn,omitempty"`
 	AmazonLinux2      []string `json:"amzn2,omitempty"`
 }

--- a/pkg/apis/troubleshoot/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/troubleshoot/v1beta2/zz_generated.deepcopy.go
@@ -2158,6 +2158,26 @@ func (in *HostSystemPackages) DeepCopyInto(out *HostSystemPackages) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RHEL9 != nil {
+		in, out := &in.RHEL9, &out.RHEL9
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.RockyLinux != nil {
+		in, out := &in.RockyLinux, &out.RockyLinux
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.RockyLinux8 != nil {
+		in, out := &in.RockyLinux8, &out.RockyLinux8
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.RockyLinux9 != nil {
+		in, out := &in.RockyLinux9, &out.RockyLinux9
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.CentOS != nil {
 		in, out := &in.CentOS, &out.CentOS
 		*out = make([]string, len(*in))
@@ -2173,6 +2193,11 @@ func (in *HostSystemPackages) DeepCopyInto(out *HostSystemPackages) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CentOS9 != nil {
+		in, out := &in.CentOS9, &out.CentOS9
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OracleLinux != nil {
 		in, out := &in.OracleLinux, &out.OracleLinux
 		*out = make([]string, len(*in))
@@ -2185,6 +2210,11 @@ func (in *HostSystemPackages) DeepCopyInto(out *HostSystemPackages) {
 	}
 	if in.OracleLinux8 != nil {
 		in, out := &in.OracleLinux8, &out.OracleLinux8
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.OracleLinux9 != nil {
+		in, out := &in.OracleLinux9, &out.OracleLinux9
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/client/troubleshootclientset/clientset.go
+++ b/pkg/client/troubleshootclientset/clientset.go
@@ -19,6 +19,7 @@ package troubleshootclientset
 
 import (
 	"fmt"
+	"net/http"
 
 	troubleshootv1beta1 "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2"
@@ -33,8 +34,7 @@ type Interface interface {
 	TroubleshootV1beta2() troubleshootv1beta2.TroubleshootV1beta2Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	troubleshootV1beta1 *troubleshootv1beta1.TroubleshootV1beta1Client
@@ -62,7 +62,29 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	configShallowCopy := *c
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	// share the transport between all clients
+	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewForConfigAndClient(&configShallowCopy, httpClient)
+}
+
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+// If config's RateLimiter is not set and QPS and Burst are acceptable,
+// NewForConfigAndClient will generate a rate-limiter in configShallowCopy.
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -70,18 +92,19 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
 	var cs Clientset
 	var err error
-	cs.troubleshootV1beta1, err = troubleshootv1beta1.NewForConfig(&configShallowCopy)
+	cs.troubleshootV1beta1, err = troubleshootv1beta1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.troubleshootV1beta2, err = troubleshootv1beta2.NewForConfig(&configShallowCopy)
+	cs.troubleshootV1beta2, err = troubleshootv1beta2.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
+	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -91,12 +114,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.troubleshootV1beta1 = troubleshootv1beta1.NewForConfigOrDie(c)
-	cs.troubleshootV1beta2 = troubleshootv1beta2.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_analyzer.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_analyzer.go
@@ -116,7 +116,7 @@ func (c *FakeAnalyzers) UpdateStatus(ctx context.Context, analyzer *v1beta1.Anal
 // Delete takes name of the analyzer and deletes it. Returns an error if one occurs.
 func (c *FakeAnalyzers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(analyzersResource, c.ns, name), &v1beta1.Analyzer{})
+		Invokes(testing.NewDeleteActionWithOptions(analyzersResource, c.ns, name, opts), &v1beta1.Analyzer{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_collector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_collector.go
@@ -116,7 +116,7 @@ func (c *FakeCollectors) UpdateStatus(ctx context.Context, collector *v1beta1.Co
 // Delete takes name of the collector and deletes it. Returns an error if one occurs.
 func (c *FakeCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(collectorsResource, c.ns, name), &v1beta1.Collector{})
+		Invokes(testing.NewDeleteActionWithOptions(collectorsResource, c.ns, name, opts), &v1beta1.Collector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_preflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_preflight.go
@@ -116,7 +116,7 @@ func (c *FakePreflights) UpdateStatus(ctx context.Context, preflight *v1beta1.Pr
 // Delete takes name of the preflight and deletes it. Returns an error if one occurs.
 func (c *FakePreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(preflightsResource, c.ns, name), &v1beta1.Preflight{})
+		Invokes(testing.NewDeleteActionWithOptions(preflightsResource, c.ns, name, opts), &v1beta1.Preflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_redactor.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_redactor.go
@@ -116,7 +116,7 @@ func (c *FakeRedactors) UpdateStatus(ctx context.Context, redactor *v1beta1.Reda
 // Delete takes name of the redactor and deletes it. Returns an error if one occurs.
 func (c *FakeRedactors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(redactorsResource, c.ns, name), &v1beta1.Redactor{})
+		Invokes(testing.NewDeleteActionWithOptions(redactorsResource, c.ns, name, opts), &v1beta1.Redactor{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_supportbundle.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_supportbundle.go
@@ -116,7 +116,7 @@ func (c *FakeSupportBundles) UpdateStatus(ctx context.Context, supportBundle *v1
 // Delete takes name of the supportBundle and deletes it. Returns an error if one occurs.
 func (c *FakeSupportBundles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(supportbundlesResource, c.ns, name), &v1beta1.SupportBundle{})
+		Invokes(testing.NewDeleteActionWithOptions(supportbundlesResource, c.ns, name, opts), &v1beta1.SupportBundle{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/troubleshoot_client.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/troubleshoot_client.go
@@ -18,6 +18,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"net/http"
+
 	v1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -58,12 +60,28 @@ func (c *TroubleshootV1beta1Client) SupportBundles(namespace string) SupportBund
 }
 
 // NewForConfig creates a new TroubleshootV1beta1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TroubleshootV1beta1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new TroubleshootV1beta1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TroubleshootV1beta1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_analyzer.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_analyzer.go
@@ -116,7 +116,7 @@ func (c *FakeAnalyzers) UpdateStatus(ctx context.Context, analyzer *v1beta2.Anal
 // Delete takes name of the analyzer and deletes it. Returns an error if one occurs.
 func (c *FakeAnalyzers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(analyzersResource, c.ns, name), &v1beta2.Analyzer{})
+		Invokes(testing.NewDeleteActionWithOptions(analyzersResource, c.ns, name, opts), &v1beta2.Analyzer{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_collector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_collector.go
@@ -116,7 +116,7 @@ func (c *FakeCollectors) UpdateStatus(ctx context.Context, collector *v1beta2.Co
 // Delete takes name of the collector and deletes it. Returns an error if one occurs.
 func (c *FakeCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(collectorsResource, c.ns, name), &v1beta2.Collector{})
+		Invokes(testing.NewDeleteActionWithOptions(collectorsResource, c.ns, name, opts), &v1beta2.Collector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostcollector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostcollector.go
@@ -116,7 +116,7 @@ func (c *FakeHostCollectors) UpdateStatus(ctx context.Context, hostCollector *v1
 // Delete takes name of the hostCollector and deletes it. Returns an error if one occurs.
 func (c *FakeHostCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(hostcollectorsResource, c.ns, name), &v1beta2.HostCollector{})
+		Invokes(testing.NewDeleteActionWithOptions(hostcollectorsResource, c.ns, name, opts), &v1beta2.HostCollector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostpreflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostpreflight.go
@@ -116,7 +116,7 @@ func (c *FakeHostPreflights) UpdateStatus(ctx context.Context, hostPreflight *v1
 // Delete takes name of the hostPreflight and deletes it. Returns an error if one occurs.
 func (c *FakeHostPreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(hostpreflightsResource, c.ns, name), &v1beta2.HostPreflight{})
+		Invokes(testing.NewDeleteActionWithOptions(hostpreflightsResource, c.ns, name, opts), &v1beta2.HostPreflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_preflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_preflight.go
@@ -116,7 +116,7 @@ func (c *FakePreflights) UpdateStatus(ctx context.Context, preflight *v1beta2.Pr
 // Delete takes name of the preflight and deletes it. Returns an error if one occurs.
 func (c *FakePreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(preflightsResource, c.ns, name), &v1beta2.Preflight{})
+		Invokes(testing.NewDeleteActionWithOptions(preflightsResource, c.ns, name, opts), &v1beta2.Preflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_redactor.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_redactor.go
@@ -116,7 +116,7 @@ func (c *FakeRedactors) UpdateStatus(ctx context.Context, redactor *v1beta2.Reda
 // Delete takes name of the redactor and deletes it. Returns an error if one occurs.
 func (c *FakeRedactors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(redactorsResource, c.ns, name), &v1beta2.Redactor{})
+		Invokes(testing.NewDeleteActionWithOptions(redactorsResource, c.ns, name, opts), &v1beta2.Redactor{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_remotecollector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_remotecollector.go
@@ -116,7 +116,7 @@ func (c *FakeRemoteCollectors) UpdateStatus(ctx context.Context, remoteCollector
 // Delete takes name of the remoteCollector and deletes it. Returns an error if one occurs.
 func (c *FakeRemoteCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(remotecollectorsResource, c.ns, name), &v1beta2.RemoteCollector{})
+		Invokes(testing.NewDeleteActionWithOptions(remotecollectorsResource, c.ns, name, opts), &v1beta2.RemoteCollector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_supportbundle.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_supportbundle.go
@@ -116,7 +116,7 @@ func (c *FakeSupportBundles) UpdateStatus(ctx context.Context, supportBundle *v1
 // Delete takes name of the supportBundle and deletes it. Returns an error if one occurs.
 func (c *FakeSupportBundles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(supportbundlesResource, c.ns, name), &v1beta2.SupportBundle{})
+		Invokes(testing.NewDeleteActionWithOptions(supportbundlesResource, c.ns, name, opts), &v1beta2.SupportBundle{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/troubleshoot_client.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/troubleshoot_client.go
@@ -18,6 +18,8 @@ limitations under the License.
 package v1beta2
 
 import (
+	"net/http"
+
 	v1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -73,12 +75,28 @@ func (c *TroubleshootV1beta2Client) SupportBundles(namespace string) SupportBund
 }
 
 // NewForConfig creates a new TroubleshootV1beta2Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TroubleshootV1beta2Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new TroubleshootV1beta2Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TroubleshootV1beta2Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collect/host_block_device_test.go
+++ b/pkg/collect/host_block_device_test.go
@@ -1,0 +1,70 @@
+package collect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseLsblkDeviceOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  []byte
+		want    []BlockDeviceInfo
+		wantErr bool
+	}{
+		{
+			name:   "ubuntu 20.04",
+			output: []byte(`NAME="sdb" KNAME="sdb" PKNAME="" TYPE="disk" MAJ:MIN="8:16" SIZE="107374182400" FSTYPE="" MOUNTPOINT="" SERIAL="persistent-disk-1" RO="0" RM="0"`),
+			want: []BlockDeviceInfo{
+				{
+					Name:             "sdb",
+					KernelName:       "sdb",
+					ParentKernelName: "",
+					Type:             "disk",
+					Major:            8,
+					Minor:            16,
+					Size:             107374182400,
+					FilesystemType:   "",
+					Mountpoint:       "",
+					Serial:           "persistent-disk-1",
+					ReadOnly:         false,
+					Removable:        false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "rhel 9",
+			output: []byte(`NAME="sdb" KNAME="sdb" PKNAME="" TYPE="disk" MAJ_MIN="8:16" SIZE="107374182400" FSTYPE="" MOUNTPOINT="" SERIAL="persistent-disk-1" RO="0" RM="0"`),
+			want: []BlockDeviceInfo{
+				{
+					Name:             "sdb",
+					KernelName:       "sdb",
+					ParentKernelName: "",
+					Type:             "disk",
+					Major:            8,
+					Minor:            16,
+					Size:             107374182400,
+					FilesystemType:   "",
+					Mountpoint:       "",
+					Serial:           "persistent-disk-1",
+					ReadOnly:         false,
+					Removable:        false,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLsblkOutput(tt.output)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLsblkOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseLsblkOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/collect/host_system_package.go
+++ b/pkg/collect/host_system_package.go
@@ -92,6 +92,9 @@ func (c *CollectHostSystemPackages) Collect(progressChan chan<- interface{}) (ma
 		if len(c.hostCollector.CentOS8) > 0 && matchMajorVersion(info.OSVersion, "8") {
 			packages = append(packages, c.hostCollector.CentOS8...)
 		}
+		if len(c.hostCollector.CentOS9) > 0 && matchMajorVersion(info.OSVersion, "9") {
+			packages = append(packages, c.hostCollector.CentOS8...)
+		}
 	case "rhel":
 		if len(c.hostCollector.RHEL) > 0 {
 			packages = append(packages, c.hostCollector.RHEL...)
@@ -102,6 +105,9 @@ func (c *CollectHostSystemPackages) Collect(progressChan chan<- interface{}) (ma
 		if len(c.hostCollector.RHEL8) > 0 && matchMajorVersion(info.OSVersion, "8") {
 			packages = append(packages, c.hostCollector.RHEL8...)
 		}
+		if len(c.hostCollector.RHEL9) > 0 && matchMajorVersion(info.OSVersion, "9") {
+			packages = append(packages, c.hostCollector.RHEL9...)
+		}
 	case "ol":
 		if len(c.hostCollector.OracleLinux) > 0 {
 			packages = append(packages, c.hostCollector.OracleLinux...)
@@ -111,6 +117,19 @@ func (c *CollectHostSystemPackages) Collect(progressChan chan<- interface{}) (ma
 		}
 		if len(c.hostCollector.OracleLinux8) > 0 && matchMajorVersion(info.OSVersion, "8") {
 			packages = append(packages, c.hostCollector.OracleLinux8...)
+		}
+		if len(c.hostCollector.OracleLinux9) > 0 && matchMajorVersion(info.OSVersion, "9") {
+			packages = append(packages, c.hostCollector.OracleLinux9...)
+		}
+	case "rocky":
+		if len(c.hostCollector.RockyLinux) > 0 {
+			packages = append(packages, c.hostCollector.RockyLinux...)
+		}
+		if len(c.hostCollector.RockyLinux8) > 0 && matchMajorVersion(info.OSVersion, "8") {
+			packages = append(packages, c.hostCollector.RockyLinux8...)
+		}
+		if len(c.hostCollector.RockyLinux9) > 0 && matchMajorVersion(info.OSVersion, "9") {
+			packages = append(packages, c.hostCollector.RockyLinux9...)
 		}
 	case "amzn":
 		if len(c.hostCollector.AmazonLinux) > 0 {
@@ -132,7 +151,7 @@ func (c *CollectHostSystemPackages) Collect(progressChan chan<- interface{}) (ma
 		switch info.OS {
 		case "ubuntu":
 			cmd = exec.Command("dpkg", "-s", p)
-		case "centos", "rhel", "amzn", "ol":
+		case "centos", "rhel", "amzn", "ol", "rocky":
 			cmd = exec.Command("rpm", "-qi", p)
 		default:
 			return nil, errors.Errorf("unsupported distribution: %s", info.OS)

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -10803,6 +10803,12 @@
                       "type": "string"
                     }
                   },
+                  "centos9": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "collectorName": {
                     "type": "string"
                   },
@@ -10827,6 +10833,12 @@
                       "type": "string"
                     }
                   },
+                  "ol9": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "rhel": {
                     "type": "array",
                     "items": {
@@ -10840,6 +10852,30 @@
                     }
                   },
                   "rhel8": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "rhel9": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "rocky": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "rocky8": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "rocky9": {
                     "type": "array",
                     "items": {
                       "type": "string"


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

Ahead of adding support for RHEL 9 in kURL, adds support for variants including RHEL 9, CentOS 9 Stream, Oracle Linux 9 and Rocky Linux 7,8,9.

Fixes blockDevices hostCollector to work with new modified "MAJ_MIN" header.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls) https://github.com/replicatedhq/troubleshoot.sh/pull/479

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
