### PR TITLE
feat(support-bundle): check if the cluster IsNamespacedScopeRBAC and use current namespace

### DIFF
--- a/pkg/k8sutil/namespace.go
+++ b/pkg/k8sutil/namespace.go
@@ -1,0 +1,34 @@
+package k8sutil
+
+import (
+	"context"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func IsNamespacedScopeRBAC(client kubernetes.Interface) (bool, error) {
+	ctx := context.Background()
+
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "",
+				Verb:      "list",
+				Resource:  "secrets,configmaps",
+			},
+		},
+	}
+
+	resp, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	if resp.Status.Allowed {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}


### PR DESCRIPTION
## Description, Motivation and Context

- add IsNamespacedScope to check if  the user is namespace-scoped RBAC
- if namespace-scoped RBAC, switch to current namespace in kubeconfig instead of all namepaces

How to re-produce it, if you are running it against okteto cluster in kots development, you will get error `Error: no specs found in cluster`. Because the user is namespaced scoped and cannot search all

```
E0317 16:11:10.525947    3226 run.go:137] failed to load support bundle spec from secrets: failed to search for secrets in the cluster: secrets is forbidden: User "system:serviceaccount:okteto:0cc534d8-64a0-4abb-b6dd-f45e055ac018" cannot list resource "secrets" in API group "" at the cluster scope
E0317 16:11:10.693767    3226 run.go:143] failed to load support bundle spec from secrets: failed to search for configmaps in the cluster: configmaps is forbidden: User "system:serviceaccount:okteto:0cc534d8-64a0-4abb-b6dd-f45e055ac018" cannot list resource "configmaps" in API group "" at the cluster scope
E0317 16:11:10.862615    3226 run.go:175] failed to load redactor specs from config maps: failed to search for secrets in the cluster: secrets is forbidden: User "system:serviceaccount:okteto:0cc534d8-64a0-4abb-b6dd-f45e055ac018" cannot list resource "secrets" in API group "" at the cluster scope
E0317 16:11:11.036565    3226 run.go:181] failed to load redactor specs from config maps: failed to search for configmaps in the cluster: configmaps is forbidden: User "system:serviceaccount:okteto:0cc534d8-64a0-4abb-b6dd-f45e055ac018" cannot list resource "configmaps" in API group "" at the cluster scope

============ Collectors summary =============
Suceeded (S), eXcluded (X), Failed (F)
=============================================
No collectors executed

============ Redactors summary =============
No redactors executed

============= Analyzers summary =============
Suceeded (S), eXcluded (X), Failed (F)
=============================================
No analyzers executed

Duration: 0ms
Error: no specs found in cluster
```
<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
