### PR TITLE
feat: Add partition type info to block device collector

### DIFF
--- a/pkg/analyze/host_block_devices.go
+++ b/pkg/analyze/host_block_devices.go
@@ -116,7 +116,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 func compareHostBlockDevicesConditionalToActual(conditional string, minimumAcceptableSize uint64, includeUnmountedPartitions bool, devices []collect.BlockDeviceInfo) (res bool, err error) {
 	parts := strings.Split(conditional, " ")
 	if len(parts) != 3 {
-		return false, fmt.Errorf("Expected exactly 3 parts, got %d", len(parts))
+		return false, fmt.Errorf("expected exactly 3 parts, got %d", len(parts))
 	}
 
 	rx, err := regexp.Compile(parts[0])
@@ -143,7 +143,7 @@ func compareHostBlockDevicesConditionalToActual(conditional string, minimumAccep
 		return count == desiredInt, nil
 	}
 
-	return false, fmt.Errorf("Unexpected operator %q", parts[1])
+	return false, fmt.Errorf("unexpected operator %q", parts[1])
 }
 
 func countEligibleBlockDevices(rx *regexp.Regexp, minimumAcceptableSize uint64, includeUnmountedPartitions bool, devices []collect.BlockDeviceInfo) int {

--- a/pkg/collect/host_block_device.go
+++ b/pkg/collect/host_block_device.go
@@ -13,22 +13,23 @@ import (
 )
 
 type BlockDeviceInfo struct {
-	Name             string `json:"name"`
-	KernelName       string `json:"kernel_name"`
-	ParentKernelName string `json:"parent_kernel_name"`
-	Type             string `json:"type"`
-	Major            int    `json:"major"`
-	Minor            int    `json:"minor"`
-	Size             uint64 `json:"size"`
-	FilesystemType   string `json:"filesystem_type"`
-	Mountpoint       string `json:"mountpoint"`
-	Serial           string `json:"serial"`
-	ReadOnly         bool   `json:"read_only"`
-	Removable        bool   `json:"removable"`
+	Name               string `json:"name"`
+	KernelName         string `json:"kernel_name"`
+	ParentKernelName   string `json:"parent_kernel_name"`
+	Type               string `json:"type"`
+	Major              int    `json:"major"`
+	Minor              int    `json:"minor"`
+	Size               uint64 `json:"size"`
+	FilesystemType     string `json:"filesystem_type"`
+	Mountpoint         string `json:"mountpoint"`
+	Serial             string `json:"serial"`
+	ReadOnly           bool   `json:"read_only"`
+	Removable          bool   `json:"removable"`
+	PartitionTableType string `json:"partition_table_type"`
 }
 
-const lsblkColumns = "NAME,KNAME,PKNAME,TYPE,MAJ:MIN,SIZE,FSTYPE,MOUNTPOINT,SERIAL,RO,RM"
-const lsblkFormat = `NAME=%q KNAME=%q PKNAME=%q TYPE=%q MAJ:MIN="%d:%d" SIZE="%d" FSTYPE=%q MOUNTPOINT=%q SERIAL=%q RO="%d" RM="%d0"`
+const lsblkColumns = "NAME,KNAME,PKNAME,TYPE,MAJ:MIN,SIZE,FSTYPE,MOUNTPOINT,SERIAL,RO,RM,PTTYPE"
+const lsblkFormat = `NAME=%q KNAME=%q PKNAME=%q TYPE=%q MAJ:MIN="%d:%d" SIZE="%d" FSTYPE=%q MOUNTPOINT=%q SERIAL=%q RO="%d" RM="%d0" PTTYPE=%q`
 const HostBlockDevicesPath = `host-collectors/system/block_devices.json`
 
 type CollectHostBlockDevices struct {
@@ -45,6 +46,11 @@ func (c *CollectHostBlockDevices) IsExcluded() (bool, error) {
 }
 
 func (c *CollectHostBlockDevices) Collect(progressChan chan<- interface{}) (map[string][]byte, error) {
+	// TODO: Consider using lsblk --json --output <columns> instead.
+	// This simplifies the parsing logic and also represents a parent/child relationship
+	// between devices when there are partitions.
+	// NOTE: Remember to validate the output of lsblk json
+	// NOTE: Check what version of lsblk --json was introduced.
 	cmd := exec.Command("lsblk", "--noheadings", "--bytes", "--pairs", "-o", lsblkColumns)
 	stdout, err := cmd.Output()
 	if err != nil {
@@ -95,6 +101,7 @@ func parseLsblkOutput(output []byte) ([]BlockDeviceInfo, error) {
 			&bdi.Serial,
 			&ro,
 			&rm,
+			&bdi.PartitionTableType,
 		)
 		bdi.ReadOnly = ro == 1
 		bdi.Removable = rm == 1


### PR DESCRIPTION
## Description, Motivation and Context

A minor improvement in the block devices collector. We now collect the partition type information of a block device.

Fixes: #970

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414 
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
