### PR TITLE
fix: Fix longhorn collector linting error

### DIFF
--- a/pkg/collect/longhorn.go
+++ b/pkg/collect/longhorn.go
@@ -276,19 +276,24 @@ func (c *CollectLonghorn) Collect(progressChan chan<- interface{}) (CollectorRes
 			}
 
 			wg.Add(1)
-			go func(replica longhornv1beta1types.Replica) {
+			go func(repl *longhornv1beta1types.Replica, pName string, cfg *rest.Config, vol *longhornv1beta1types.Volume) {
 				defer wg.Done()
-				checksums, err := GetLonghornReplicaChecksum(c.ClientConfig, replica, podName)
+				checksums, err := GetLonghornReplicaChecksum(cfg, *repl, pName)
 				if err != nil {
-					klog.Errorf("Failed to get replica %s checksum: %v", replica.Name, err)
+					klog.Errorf("Failed to get replica %q checksum: %v", repl.Name, err)
 					return
 				}
 				volsDir := GetLonghornVolumesDirectory(ns)
-				key := filepath.Join(volsDir, volume.Name, "replicachecksums", replica.Name+".txt")
+				key := filepath.Join(volsDir, vol.Name, "replicachecksums", repl.Name+".txt")
+
+				// Locking is required because the output object is shared between goroutines
 				mtx.Lock()
 				output.SaveResult(c.BundlePath, key, bytes.NewBuffer([]byte(checksums)))
 				mtx.Unlock()
-			}(replica)
+
+				// make separate new copies of CR objects so as not to share internal memory
+				// of objects between goroutines
+			}(replica.DeepCopy(), podName, rest.CopyConfig(c.ClientConfig), volume.DeepCopy())
 		}
 	}
 


### PR DESCRIPTION
## Description, Motivation and Context

In go 1.20, `go vet` linter fails if a violation of shared memory between goroutines is caught. This is present in the longhorn collector which this PR fixes.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
