### PR TITLE
Fix race condition in longhorn collector

### DIFF
--- a/pkg/collect/longhorn.go
+++ b/pkg/collect/longhorn.go
@@ -276,7 +276,7 @@ func (c *CollectLonghorn) Collect(progressChan chan<- interface{}) (CollectorRes
 			}
 
 			wg.Add(1)
-			go func(replica longhornv1beta1types.Replica) {
+			go func(replica longhornv1beta1types.Replica, volume longhornv1beta1types.Volume) {
 				defer wg.Done()
 				checksums, err := GetLonghornReplicaChecksum(c.ClientConfig, replica, podName)
 				if err != nil {
@@ -288,7 +288,7 @@ func (c *CollectLonghorn) Collect(progressChan chan<- interface{}) (CollectorRes
 				mtx.Lock()
 				output.SaveResult(c.BundlePath, key, bytes.NewBuffer([]byte(checksums)))
 				mtx.Unlock()
-			}(replica)
+			}(replica, volume)
 		}
 	}
 


### PR DESCRIPTION
## Description, Motivation and Context

Trying to compile troubleshoot with go version go1.20.2 darwin/arm64 I found this issue while running `make vet`:

```
go vet -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -installsuffix netgo ./pkg/... ./cmd/... ./internal/...
# github.com/replicatedhq/troubleshoot/pkg/collect
pkg/collect/longhorn.go:287:35: loop variable volume captured by func literal
```

The error is legitimate. This PR fixes the potential race condition and makes `make vet` suceed.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No