### PR TITLE
chore(ci): use fetch-depth instead of unshallow

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -235,9 +235,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v3
         with:
@@ -262,14 +261,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
 
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
## Description, Motivation and Context

The fetch-depth parameter to the checkout action will provide a full checkout instead of a shallow one that only has the last commit. Using this makes the workflow files a bit more concise and removes an extra step.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No