### PR TITLE
chore: Add community calendar to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ And see our other tool [sbctl](https://github.com/replicatedhq/sbctl) that makes
 
 # Community
 
-For questions about using Troubleshoot, there's a [Replicated Community](https://help.replicated.com/community) forum, and a [#app-troubleshoot channel in Kubernetes Slack](https://kubernetes.slack.com/channels/app-troubleshoot).
+For questions about using Troubleshoot, how to contribute and engaging with the project in any other way, please refer to the following resources and channels.
+
+- [Replicated Community](https://help.replicated.com/community) forum
+- [#app-troubleshoot channel in Kubernetes Slack](https://kubernetes.slack.com/channels/app-troubleshoot)
+- [#Community meetings calendar](https://calendar.google.com/calendar/u/0?cid=Y19mMGx1aGhiZGtscGllOGo5dWpicXMwNnN1a0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t). This happen monthly but dates may change and would be kept upto date in the calendar.
 
 # Software Bill of Materials
 A signed SBOM  that includes Troubleshoot dependencies is included in each release.


### PR DESCRIPTION
## Description, Motivation and Context

To allow people interested in community meetings know when they are, add the calendar to the project's README.