### PR TITLE
fix/clusterPodStatuses: only process `when` conditional if specified

### DIFF
--- a/pkg/analyze/cluster_pod_statuses.go
+++ b/pkg/analyze/cluster_pod_statuses.go
@@ -104,33 +104,36 @@ func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChi
 				continue
 			}
 
-			parts := strings.Split(strings.TrimSpace(when), " ")
-			if len(parts) < 2 {
-				println(fmt.Sprintf("invalid 'when' format: %s\n", when)) // don't stop
-				continue
-			}
-
-			operator := parts[0]
-			reason := parts[1]
+			operator := ""
+			reason := ""
 			match := false
-
-			switch operator {
-			case "=", "==", "===":
-				if reason == "Healthy" {
-					match = !k8sutil.IsPodUnhealthy(&pod)
-				} else {
-					match = reason == string(pod.Status.Phase) || reason == string(pod.Status.Reason)
+			if when != "" {
+				parts := strings.Split(strings.TrimSpace(when), " ")
+				if len(parts) < 2 {
+					println(fmt.Sprintf("invalid 'when' format: %s\n", when)) // don't stop
+					continue
 				}
-			case "!=", "!==":
-				if reason == "Healthy" {
-					match = k8sutil.IsPodUnhealthy(&pod)
-				} else {
-					match = reason != string(pod.Status.Phase) && reason != string(pod.Status.Reason)
-				}
-			}
+				operator = parts[0]
+				reason = parts[1]
 
-			if !match {
-				continue
+				switch operator {
+				case "=", "==", "===":
+					if reason == "Healthy" {
+						match = !k8sutil.IsPodUnhealthy(&pod)
+					} else {
+						match = reason == string(pod.Status.Phase) || reason == string(pod.Status.Reason)
+					}
+				case "!=", "!==":
+					if reason == "Healthy" {
+						match = k8sutil.IsPodUnhealthy(&pod)
+					} else {
+						match = reason != string(pod.Status.Phase) && reason != string(pod.Status.Reason)
+					}
+				}
+
+				if !match {
+					continue
+				}
 			}
 
 			r.InvolvedObject = &corev1.ObjectReference{

--- a/pkg/analyze/cluster_pod_statuses.go
+++ b/pkg/analyze/cluster_pod_statuses.go
@@ -3,7 +3,6 @@ package analyzer
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -13,6 +12,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 type AnalyzeClusterPodStatuses struct {
@@ -100,7 +100,7 @@ func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChi
 				r.URI = outcome.Pass.URI
 				when = outcome.Pass.When
 			} else {
-				println("error: found an empty outcome in a clusterPodStatuses analyzer") // don't stop
+				klog.Error("error: found an empty outcome in a clusterPodStatuses analyzer\n")
 				continue
 			}
 
@@ -110,7 +110,7 @@ func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChi
 			if when != "" {
 				parts := strings.Split(strings.TrimSpace(when), " ")
 				if len(parts) < 2 {
-					println(fmt.Sprintf("invalid 'when' format: %s\n", when)) // don't stop
+					klog.Errorf("invalid 'when' format: %s\n", when)
 					continue
 				}
 				operator = parts[0]

--- a/pkg/analyze/cluster_pod_statuses_test.go
+++ b/pkg/analyze/cluster_pod_statuses_test.go
@@ -1,0 +1,266 @@
+package analyzer
+
+import (
+	"testing"
+
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_ClusterPodStatuses(t *testing.T) {
+	tests := []struct {
+		name         string
+		analyzer     troubleshootv1beta2.ClusterPodStatuses
+		expectResult []*AnalyzeResult
+		files        map[string][]byte
+	}{
+		{
+			name: "pass_when_all_pods_are_healthy_in_specific_namespace",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "pass_when_all_pods_are_healthy_in_specific_namespace",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Restarting the pod may fix the issue.",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{"default"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "pass_when_all_pods_are_healthy_in_specific_namespace",
+					Message: "All Pods are OK.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json":           []byte(defaultPods),
+				"cluster-resources/pods/other.json":             []byte(otherPods),
+				"cluster-resources/pods/default-unhealthy.json": []byte(defaultPodsUnhealthy),
+				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
+			},
+		},
+		{
+			name: "pass_when_pods_are_healthy_in_all_namespaces",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "pass_when_pods_are_healthy_in_all_namespaces",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Restarting the pod may fix the issue.",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "pass_when_pods_are_healthy_in_all_namespaces",
+					Message: "All Pods are OK.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "pass_when_pods_are_healthy_in_all_namespaces",
+					Message: "All Pods are OK.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "other",
+						Name:       "other-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json": []byte(defaultPods),
+				"cluster-resources/pods/other.json":   []byte(otherPods),
+			},
+		},
+		{
+			name: "fail_when_pods_are_unhealthy_in_specific_namespace",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "fail_when_pods_are_unhealthy_in_specific_namespace",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A pod is unhealthy",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{"default-unhealthy"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  false,
+					IsFail:  true,
+					Title:   "fail_when_pods_are_unhealthy_in_specific_namespace",
+					Message: "A pod is unhealthy",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default-unhealthy",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json":           []byte(defaultPods),
+				"cluster-resources/pods/other.json":             []byte(otherPods),
+				"cluster-resources/pods/default-unhealthy.json": []byte(defaultPodsUnhealthy),
+				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
+			},
+		},
+		{
+			name: "fail_when_pods_are_unhealthy_in_any_namespace",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "fail_when_pods_are_unhealthy_in_all_namespaces",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A pod is unhealthy",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  false,
+					IsFail:  true,
+					Title:   "fail_when_pods_are_unhealthy_in_all_namespaces",
+					Message: "A pod is unhealthy",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default-unhealthy",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+				{
+					IsPass:  false,
+					IsWarn:  false,
+					IsFail:  true,
+					Title:   "fail_when_pods_are_unhealthy_in_all_namespaces",
+					Message: "A pod is unhealthy",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "other-unhealthy",
+						Name:       "other-pod-75b66db9b9-nqhp8",
+					},
+				},
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "fail_when_pods_are_unhealthy_in_all_namespaces",
+					Message: "All Pods are OK.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "fail_when_pods_are_unhealthy_in_all_namespaces",
+					Message: "All Pods are OK.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "other",
+						Name:       "other-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json":           []byte(defaultPods),
+				"cluster-resources/pods/other.json":             []byte(otherPods),
+				"cluster-resources/pods/default-unhealthy.json": []byte(defaultPodsUnhealthy),
+				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			getFiles := func(n string, _ []string) (map[string][]byte, error) {
+				if file, ok := test.files[n]; ok {
+					return map[string][]byte{n: file}, nil
+				}
+				return test.files, nil
+			}
+
+			actual, err := clusterPodStatuses(&test.analyzer, getFiles)
+			req.NoError(err)
+			req.Equal(len(test.expectResult), len(actual))
+			for _, a := range actual {
+				assert.Contains(t, test.expectResult, a)
+			}
+		})
+	}
+}

--- a/pkg/analyze/cluster_pod_statuses_test.go
+++ b/pkg/analyze/cluster_pod_statuses_test.go
@@ -160,6 +160,50 @@ func Test_ClusterPodStatuses(t *testing.T) {
 			},
 		},
 		{
+			name: "fail_when_pods_are_unhealthy_in_specific_namespace_using_double_ne",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "fail_when_pods_are_unhealthy_in_specific_namespace_using_double_ne",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "!== Healthy",
+							Message: "A pod is unhealthy",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{"default-unhealthy"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  false,
+					IsFail:  true,
+					Title:   "fail_when_pods_are_unhealthy_in_specific_namespace_using_double_ne",
+					Message: "A pod is unhealthy",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default-unhealthy",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json":           []byte(defaultPods),
+				"cluster-resources/pods/other.json":             []byte(otherPods),
+				"cluster-resources/pods/default-unhealthy.json": []byte(defaultPodsUnhealthy),
+				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
+			},
+		},
+		{
 			name: "fail_when_pods_are_unhealthy_in_any_namespace",
 			analyzer: troubleshootv1beta2.ClusterPodStatuses{
 				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
@@ -232,6 +276,94 @@ func Test_ClusterPodStatuses(t *testing.T) {
 						Kind:       "Pod",
 						Namespace:  "other",
 						Name:       "other-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json":           []byte(defaultPods),
+				"cluster-resources/pods/other.json":             []byte(otherPods),
+				"cluster-resources/pods/default-unhealthy.json": []byte(defaultPodsUnhealthy),
+				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
+			},
+		},
+		{
+			name: "warn_when_pods_are_unhealthy_in_specific_namespace_using_double_equals",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "warn_when_pods_are_unhealthy_in_specific_namespace_using_double_equals",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "== CrashLoopBackOff",
+							Message: "A pod is unhealthy.",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{"default-unhealthy"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "warn_when_pods_are_unhealthy_in_specific_namespace_using_double_equals",
+					Message: "A pod is unhealthy.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default-unhealthy",
+						Name:       "random-pod-75b66db9b9-nqhp8",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/default.json":           []byte(defaultPods),
+				"cluster-resources/pods/other.json":             []byte(otherPods),
+				"cluster-resources/pods/default-unhealthy.json": []byte(defaultPodsUnhealthy),
+				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
+			},
+		},
+		{
+			name: "warn_when_pods_are_unhealthy_in_specific_namespace_using_triple_equals",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "warn_when_pods_are_unhealthy_in_specific_namespace_using_triple_equals",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "=== CrashLoopBackOff",
+							Message: "A pod is unhealthy.",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "",
+							Message: "All Pods are OK.",
+						},
+					},
+				},
+				Namespaces: []string{"default-unhealthy"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "warn_when_pods_are_unhealthy_in_specific_namespace_using_triple_equals",
+					Message: "A pod is unhealthy.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "default-unhealthy",
+						Name:       "random-pod-75b66db9b9-nqhp8",
 					},
 				},
 			},

--- a/pkg/analyze/data_test.go
+++ b/pkg/analyze/data_test.go
@@ -33,3 +33,15 @@ var defaultStatefulSets string
 
 //go:embed files/statefulsets/monitoring.json
 var monitoringStatefulSets string
+
+//go:embed files/pods/default.json
+var defaultPods string
+
+//go:embed files/pods/other.json
+var otherPods string
+
+//go:embed files/pods/default-unhealthy.json
+var defaultPodsUnhealthy string
+
+//go:embed files/pods/other-unhealthy.json
+var otherPodsUnhealthy string

--- a/pkg/analyze/files/pods/default-unhealthy.json
+++ b/pkg/analyze/files/pods/default-unhealthy.json
@@ -1,0 +1,263 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {
+      "resourceVersion": "498"
+    },
+    "items": [
+      {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+          "name": "random-pod-75b66db9b9-nqhp8",
+          "generateName": "random-pod-75b66db9b9-",
+          "namespace": "default-unhealthy",
+          "uid": "e00af024-67ca-440d-9714-999cf8617d58",
+          "resourceVersion": "488",
+          "creationTimestamp": "2023-03-23T16:43:42Z",
+          "labels": {
+            "app.kubernetes.io/appname": "random-pod",
+            "pod-template-hash": "75b66db9b9"
+          },
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "ReplicaSet",
+              "name": "random-pod-75b66db9b9",
+              "uid": "794592d2-539c-4cca-a036-678bd2357c78",
+              "controller": true,
+              "blockOwnerDeletion": true
+            }
+          ],
+          "managedFields": [
+            {
+              "manager": "kube-controller-manager",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:42Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:generateName": {},
+                  "f:labels": {
+                    ".": {},
+                    "f:app.kubernetes.io/appname": {},
+                    "f:pod-template-hash": {}
+                  },
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"794592d2-539c-4cca-a036-678bd2357c78\"}": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"random-pod\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:enableServiceLinks": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            },
+            {
+              "manager": "kubelet",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:46Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  "f:conditions": {
+                    "k:{\"type\":\"ContainersReady\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Initialized\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Ready\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    }
+                  },
+                  "f:containerStatuses": {},
+                  "f:hostIP": {},
+                  "f:phase": {},
+                  "f:podIP": {},
+                  "f:podIPs": {
+                    ".": {},
+                    "k:{\"ip\":\"10.244.0.5\"}": {
+                      ".": {},
+                      "f:ip": {}
+                    }
+                  },
+                  "f:startTime": {}
+                }
+              },
+              "subresource": "status"
+            }
+          ]
+        },
+        "spec": {
+          "volumes": [
+            {
+              "name": "kube-api-access-hz77k",
+              "projected": {
+                "sources": [
+                  {
+                    "serviceAccountToken": {
+                      "expirationSeconds": 3607,
+                      "path": "token"
+                    }
+                  },
+                  {
+                    "configMap": {
+                      "name": "kube-root-ca.crt",
+                      "items": [
+                        {
+                          "key": "ca.crt",
+                          "path": "ca.crt"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "downwardAPI": {
+                      "items": [
+                        {
+                          "path": "namespace",
+                          "fieldRef": {
+                            "apiVersion": "v1",
+                            "fieldPath": "metadata.namespace"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "defaultMode": 420
+              }
+            }
+          ],
+          "containers": [
+            {
+              "name": "random-pod",
+              "image": "random-pod/server:1.27.0-alpine",
+              "resources": {},
+              "volumeMounts": [
+                {
+                  "name": "kube-api-access-hz77k",
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                }
+              ],
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "imagePullPolicy": "IfNotPresent"
+            }
+          ],
+          "restartPolicy": "Always",
+          "terminationGracePeriodSeconds": 30,
+          "dnsPolicy": "ClusterFirst",
+          "serviceAccountName": "default-unhealthy",
+          "serviceAccount": "default-unhealthy",
+          "nodeName": "chart-testing-control-plane",
+          "securityContext": {},
+          "schedulerName": "default-scheduler",
+          "tolerations": [
+            {
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            },
+            {
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            }
+          ],
+          "priority": 0,
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority"
+        },
+        "status": {
+          "phase": "CrashLoopBackOff",
+          "conditions": [
+            {
+              "type": "Initialized",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            },
+            {
+              "type": "Ready",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "ContainersReady",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "PodScheduled",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            }
+          ],
+          "hostIP": "172.18.0.2",
+          "podIP": "10.244.0.5",
+          "podIPs": [
+            {
+              "ip": "10.244.0.5"
+            }
+          ],
+          "startTime": "2023-03-23T16:43:42Z",
+          "containerStatuses": [
+            {
+              "name": "random-pod",
+              "state": {
+                "running": {
+                  "startedAt": "2023-03-23T16:43:45Z"
+                }
+              },
+              "lastState": {},
+              "ready": true,
+              "restartCount": 0,
+              "image": "docker.io/random-pod/server:1.27.0-alpine",
+              "imageID": "docker.io/random-pod/server@sha256:7cd450642c54cc8cce64dd9b4b8664c8480e7df6de880c5e134f4a2ed6446c5c",
+              "containerID": "containerd://58e668ba55950e6d08340f496f5e7f33f3d92cbfcbf366ce5e5f5c50a3926c71",
+              "started": true
+            }
+          ],
+          "qosClass": "BestEffort"
+        }
+      }
+    ]
+  }

--- a/pkg/analyze/files/pods/default.json
+++ b/pkg/analyze/files/pods/default.json
@@ -1,0 +1,263 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {
+      "resourceVersion": "498"
+    },
+    "items": [
+      {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+          "name": "random-pod-75b66db9b9-nqhp8",
+          "generateName": "random-pod-75b66db9b9-",
+          "namespace": "default",
+          "uid": "e00af024-67ca-440d-9714-999cf8617d58",
+          "resourceVersion": "488",
+          "creationTimestamp": "2023-03-23T16:43:42Z",
+          "labels": {
+            "app.kubernetes.io/appname": "random-pod",
+            "pod-template-hash": "75b66db9b9"
+          },
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "ReplicaSet",
+              "name": "random-pod-75b66db9b9",
+              "uid": "794592d2-539c-4cca-a036-678bd2357c78",
+              "controller": true,
+              "blockOwnerDeletion": true
+            }
+          ],
+          "managedFields": [
+            {
+              "manager": "kube-controller-manager",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:42Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:generateName": {},
+                  "f:labels": {
+                    ".": {},
+                    "f:app.kubernetes.io/appname": {},
+                    "f:pod-template-hash": {}
+                  },
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"794592d2-539c-4cca-a036-678bd2357c78\"}": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"random-pod\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:enableServiceLinks": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            },
+            {
+              "manager": "kubelet",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:46Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  "f:conditions": {
+                    "k:{\"type\":\"ContainersReady\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Initialized\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Ready\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    }
+                  },
+                  "f:containerStatuses": {},
+                  "f:hostIP": {},
+                  "f:phase": {},
+                  "f:podIP": {},
+                  "f:podIPs": {
+                    ".": {},
+                    "k:{\"ip\":\"10.244.0.5\"}": {
+                      ".": {},
+                      "f:ip": {}
+                    }
+                  },
+                  "f:startTime": {}
+                }
+              },
+              "subresource": "status"
+            }
+          ]
+        },
+        "spec": {
+          "volumes": [
+            {
+              "name": "kube-api-access-hz77k",
+              "projected": {
+                "sources": [
+                  {
+                    "serviceAccountToken": {
+                      "expirationSeconds": 3607,
+                      "path": "token"
+                    }
+                  },
+                  {
+                    "configMap": {
+                      "name": "kube-root-ca.crt",
+                      "items": [
+                        {
+                          "key": "ca.crt",
+                          "path": "ca.crt"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "downwardAPI": {
+                      "items": [
+                        {
+                          "path": "namespace",
+                          "fieldRef": {
+                            "apiVersion": "v1",
+                            "fieldPath": "metadata.namespace"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "defaultMode": 420
+              }
+            }
+          ],
+          "containers": [
+            {
+              "name": "random-pod",
+              "image": "random-pod/server:1.27.0-alpine",
+              "resources": {},
+              "volumeMounts": [
+                {
+                  "name": "kube-api-access-hz77k",
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                }
+              ],
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "imagePullPolicy": "IfNotPresent"
+            }
+          ],
+          "restartPolicy": "Always",
+          "terminationGracePeriodSeconds": 30,
+          "dnsPolicy": "ClusterFirst",
+          "serviceAccountName": "default",
+          "serviceAccount": "default",
+          "nodeName": "chart-testing-control-plane",
+          "securityContext": {},
+          "schedulerName": "default-scheduler",
+          "tolerations": [
+            {
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            },
+            {
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            }
+          ],
+          "priority": 0,
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority"
+        },
+        "status": {
+          "phase": "Running",
+          "conditions": [
+            {
+              "type": "Initialized",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            },
+            {
+              "type": "Ready",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "ContainersReady",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "PodScheduled",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            }
+          ],
+          "hostIP": "172.18.0.2",
+          "podIP": "10.244.0.5",
+          "podIPs": [
+            {
+              "ip": "10.244.0.5"
+            }
+          ],
+          "startTime": "2023-03-23T16:43:42Z",
+          "containerStatuses": [
+            {
+              "name": "random-pod",
+              "state": {
+                "running": {
+                  "startedAt": "2023-03-23T16:43:45Z"
+                }
+              },
+              "lastState": {},
+              "ready": true,
+              "restartCount": 0,
+              "image": "docker.io/random-pod/server:1.27.0-alpine",
+              "imageID": "docker.io/random-pod/server@sha256:7cd450642c54cc8cce64dd9b4b8664c8480e7df6de880c5e134f4a2ed6446c5c",
+              "containerID": "containerd://58e668ba55950e6d08340f496f5e7f33f3d92cbfcbf366ce5e5f5c50a3926c71",
+              "started": true
+            }
+          ],
+          "qosClass": "BestEffort"
+        }
+      }
+    ]
+  }

--- a/pkg/analyze/files/pods/other-unhealthy.json
+++ b/pkg/analyze/files/pods/other-unhealthy.json
@@ -1,0 +1,263 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {
+      "resourceVersion": "498"
+    },
+    "items": [
+      {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+          "name": "other-pod-75b66db9b9-nqhp8",
+          "generateName": "other-pod-75b66db9b9-",
+          "namespace": "other-unhealthy",
+          "uid": "e00af024-67ca-440d-9714-999cf8617d58",
+          "resourceVersion": "488",
+          "creationTimestamp": "2023-03-23T16:43:42Z",
+          "labels": {
+            "app.kubernetes.io/appname": "other-pod",
+            "pod-template-hash": "75b66db9b9"
+          },
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "ReplicaSet",
+              "name": "other-pod-75b66db9b9",
+              "uid": "794592d2-539c-4cca-a036-678bd2357c78",
+              "controller": true,
+              "blockOwnerDeletion": true
+            }
+          ],
+          "managedFields": [
+            {
+              "manager": "kube-controller-manager",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:42Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:generateName": {},
+                  "f:labels": {
+                    ".": {},
+                    "f:app.kubernetes.io/appname": {},
+                    "f:pod-template-hash": {}
+                  },
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"794592d2-539c-4cca-a036-678bd2357c78\"}": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"other-pod\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:enableServiceLinks": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            },
+            {
+              "manager": "kubelet",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:46Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  "f:conditions": {
+                    "k:{\"type\":\"ContainersReady\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Initialized\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Ready\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    }
+                  },
+                  "f:containerStatuses": {},
+                  "f:hostIP": {},
+                  "f:phase": {},
+                  "f:podIP": {},
+                  "f:podIPs": {
+                    ".": {},
+                    "k:{\"ip\":\"10.244.0.5\"}": {
+                      ".": {},
+                      "f:ip": {}
+                    }
+                  },
+                  "f:startTime": {}
+                }
+              },
+              "subresource": "status"
+            }
+          ]
+        },
+        "spec": {
+          "volumes": [
+            {
+              "name": "kube-api-access-hz77k",
+              "projected": {
+                "sources": [
+                  {
+                    "serviceAccountToken": {
+                      "expirationSeconds": 3607,
+                      "path": "token"
+                    }
+                  },
+                  {
+                    "configMap": {
+                      "name": "kube-root-ca.crt",
+                      "items": [
+                        {
+                          "key": "ca.crt",
+                          "path": "ca.crt"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "downwardAPI": {
+                      "items": [
+                        {
+                          "path": "namespace",
+                          "fieldRef": {
+                            "apiVersion": "v1",
+                            "fieldPath": "metadata.namespace"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "defaultMode": 420
+              }
+            }
+          ],
+          "containers": [
+            {
+              "name": "other-pod",
+              "image": "other-pod/server:1.27.0-alpine",
+              "resources": {},
+              "volumeMounts": [
+                {
+                  "name": "kube-api-access-hz77k",
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                }
+              ],
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "imagePullPolicy": "IfNotPresent"
+            }
+          ],
+          "restartPolicy": "Always",
+          "terminationGracePeriodSeconds": 30,
+          "dnsPolicy": "ClusterFirst",
+          "serviceAccountName": "default",
+          "serviceAccount": "default",
+          "nodeName": "chart-testing-control-plane",
+          "securityContext": {},
+          "schedulerName": "default-scheduler",
+          "tolerations": [
+            {
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            },
+            {
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            }
+          ],
+          "priority": 0,
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority"
+        },
+        "status": {
+          "phase": "CrashLoopBackOff",
+          "conditions": [
+            {
+              "type": "Initialized",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            },
+            {
+              "type": "Ready",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "ContainersReady",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "PodScheduled",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            }
+          ],
+          "hostIP": "172.18.0.2",
+          "podIP": "10.244.0.5",
+          "podIPs": [
+            {
+              "ip": "10.244.0.5"
+            }
+          ],
+          "startTime": "2023-03-23T16:43:42Z",
+          "containerStatuses": [
+            {
+              "name": "other-pod",
+              "state": {
+                "running": {
+                  "startedAt": "2023-03-23T16:43:45Z"
+                }
+              },
+              "lastState": {},
+              "ready": true,
+              "restartCount": 0,
+              "image": "docker.io/other-pod/server:1.27.0-alpine",
+              "imageID": "docker.io/other-pod/server@sha256:7cd450642c54cc8cce64dd9b4b8664c8480e7df6de880c5e134f4a2ed6446c5c",
+              "containerID": "containerd://58e668ba55950e6d08340f496f5e7f33f3d92cbfcbf366ce5e5f5c50a3926c71",
+              "started": true
+            }
+          ],
+          "qosClass": "BestEffort"
+        }
+      }
+    ]
+  }

--- a/pkg/analyze/files/pods/other.json
+++ b/pkg/analyze/files/pods/other.json
@@ -1,0 +1,263 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {
+      "resourceVersion": "498"
+    },
+    "items": [
+      {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+          "name": "other-pod-75b66db9b9-nqhp8",
+          "generateName": "other-pod-75b66db9b9-",
+          "namespace": "other",
+          "uid": "e00af024-67ca-440d-9714-999cf8617d58",
+          "resourceVersion": "488",
+          "creationTimestamp": "2023-03-23T16:43:42Z",
+          "labels": {
+            "app.kubernetes.io/appname": "other-pod",
+            "pod-template-hash": "75b66db9b9"
+          },
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "ReplicaSet",
+              "name": "other-pod-75b66db9b9",
+              "uid": "794592d2-539c-4cca-a036-678bd2357c78",
+              "controller": true,
+              "blockOwnerDeletion": true
+            }
+          ],
+          "managedFields": [
+            {
+              "manager": "kube-controller-manager",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:42Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:generateName": {},
+                  "f:labels": {
+                    ".": {},
+                    "f:app.kubernetes.io/appname": {},
+                    "f:pod-template-hash": {}
+                  },
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"794592d2-539c-4cca-a036-678bd2357c78\"}": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"other-pod\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:resources": {},
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:enableServiceLinks": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            },
+            {
+              "manager": "kubelet",
+              "operation": "Update",
+              "apiVersion": "v1",
+              "time": "2023-03-23T16:43:46Z",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  "f:conditions": {
+                    "k:{\"type\":\"ContainersReady\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Initialized\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    },
+                    "k:{\"type\":\"Ready\"}": {
+                      ".": {},
+                      "f:lastProbeTime": {},
+                      "f:lastTransitionTime": {},
+                      "f:status": {},
+                      "f:type": {}
+                    }
+                  },
+                  "f:containerStatuses": {},
+                  "f:hostIP": {},
+                  "f:phase": {},
+                  "f:podIP": {},
+                  "f:podIPs": {
+                    ".": {},
+                    "k:{\"ip\":\"10.244.0.5\"}": {
+                      ".": {},
+                      "f:ip": {}
+                    }
+                  },
+                  "f:startTime": {}
+                }
+              },
+              "subresource": "status"
+            }
+          ]
+        },
+        "spec": {
+          "volumes": [
+            {
+              "name": "kube-api-access-hz77k",
+              "projected": {
+                "sources": [
+                  {
+                    "serviceAccountToken": {
+                      "expirationSeconds": 3607,
+                      "path": "token"
+                    }
+                  },
+                  {
+                    "configMap": {
+                      "name": "kube-root-ca.crt",
+                      "items": [
+                        {
+                          "key": "ca.crt",
+                          "path": "ca.crt"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "downwardAPI": {
+                      "items": [
+                        {
+                          "path": "namespace",
+                          "fieldRef": {
+                            "apiVersion": "v1",
+                            "fieldPath": "metadata.namespace"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "defaultMode": 420
+              }
+            }
+          ],
+          "containers": [
+            {
+              "name": "other-pod",
+              "image": "other-pod/server:1.27.0-alpine",
+              "resources": {},
+              "volumeMounts": [
+                {
+                  "name": "kube-api-access-hz77k",
+                  "readOnly": true,
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                }
+              ],
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "imagePullPolicy": "IfNotPresent"
+            }
+          ],
+          "restartPolicy": "Always",
+          "terminationGracePeriodSeconds": 30,
+          "dnsPolicy": "ClusterFirst",
+          "serviceAccountName": "default",
+          "serviceAccount": "default",
+          "nodeName": "chart-testing-control-plane",
+          "securityContext": {},
+          "schedulerName": "default-scheduler",
+          "tolerations": [
+            {
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            },
+            {
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "effect": "NoExecute",
+              "tolerationSeconds": 300
+            }
+          ],
+          "priority": 0,
+          "enableServiceLinks": true,
+          "preemptionPolicy": "PreemptLowerPriority"
+        },
+        "status": {
+          "phase": "Running",
+          "conditions": [
+            {
+              "type": "Initialized",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            },
+            {
+              "type": "Ready",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "ContainersReady",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:46Z"
+            },
+            {
+              "type": "PodScheduled",
+              "status": "True",
+              "lastProbeTime": null,
+              "lastTransitionTime": "2023-03-23T16:43:42Z"
+            }
+          ],
+          "hostIP": "172.18.0.2",
+          "podIP": "10.244.0.5",
+          "podIPs": [
+            {
+              "ip": "10.244.0.5"
+            }
+          ],
+          "startTime": "2023-03-23T16:43:42Z",
+          "containerStatuses": [
+            {
+              "name": "other-pod",
+              "state": {
+                "running": {
+                  "startedAt": "2023-03-23T16:43:45Z"
+                }
+              },
+              "lastState": {},
+              "ready": true,
+              "restartCount": 0,
+              "image": "docker.io/other-pod/server:1.27.0-alpine",
+              "imageID": "docker.io/other-pod/server@sha256:7cd450642c54cc8cce64dd9b4b8664c8480e7df6de880c5e134f4a2ed6446c5c",
+              "containerID": "containerd://58e668ba55950e6d08340f496f5e7f33f3d92cbfcbf366ce5e5f5c50a3926c71",
+              "started": true
+            }
+          ],
+          "qosClass": "BestEffort"
+        }
+      }
+    ]
+  }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_analyzer.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_analyzer.go
@@ -116,7 +116,7 @@ func (c *FakeAnalyzers) UpdateStatus(ctx context.Context, analyzer *v1beta1.Anal
 // Delete takes name of the analyzer and deletes it. Returns an error if one occurs.
 func (c *FakeAnalyzers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(analyzersResource, c.ns, name, opts), &v1beta1.Analyzer{})
+		Invokes(testing.NewDeleteAction(analyzersResource, c.ns, name), &v1beta1.Analyzer{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_collector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_collector.go
@@ -116,7 +116,7 @@ func (c *FakeCollectors) UpdateStatus(ctx context.Context, collector *v1beta1.Co
 // Delete takes name of the collector and deletes it. Returns an error if one occurs.
 func (c *FakeCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(collectorsResource, c.ns, name, opts), &v1beta1.Collector{})
+		Invokes(testing.NewDeleteAction(collectorsResource, c.ns, name), &v1beta1.Collector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_preflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_preflight.go
@@ -116,7 +116,7 @@ func (c *FakePreflights) UpdateStatus(ctx context.Context, preflight *v1beta1.Pr
 // Delete takes name of the preflight and deletes it. Returns an error if one occurs.
 func (c *FakePreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(preflightsResource, c.ns, name, opts), &v1beta1.Preflight{})
+		Invokes(testing.NewDeleteAction(preflightsResource, c.ns, name), &v1beta1.Preflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_redactor.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_redactor.go
@@ -116,7 +116,7 @@ func (c *FakeRedactors) UpdateStatus(ctx context.Context, redactor *v1beta1.Reda
 // Delete takes name of the redactor and deletes it. Returns an error if one occurs.
 func (c *FakeRedactors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(redactorsResource, c.ns, name, opts), &v1beta1.Redactor{})
+		Invokes(testing.NewDeleteAction(redactorsResource, c.ns, name), &v1beta1.Redactor{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_supportbundle.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/fake/fake_supportbundle.go
@@ -116,7 +116,7 @@ func (c *FakeSupportBundles) UpdateStatus(ctx context.Context, supportBundle *v1
 // Delete takes name of the supportBundle and deletes it. Returns an error if one occurs.
 func (c *FakeSupportBundles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(supportbundlesResource, c.ns, name, opts), &v1beta1.SupportBundle{})
+		Invokes(testing.NewDeleteAction(supportbundlesResource, c.ns, name), &v1beta1.SupportBundle{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/troubleshoot_client.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta1/troubleshoot_client.go
@@ -18,8 +18,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"net/http"
-
 	v1beta1 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta1"
 	"github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -60,28 +58,12 @@ func (c *TroubleshootV1beta1Client) SupportBundles(namespace string) SupportBund
 }
 
 // NewForConfig creates a new TroubleshootV1beta1Client for the given config.
-// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
-// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TroubleshootV1beta1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	httpClient, err := rest.HTTPClientFor(&config)
-	if err != nil {
-		return nil, err
-	}
-	return NewForConfigAndClient(&config, httpClient)
-}
-
-// NewForConfigAndClient creates a new TroubleshootV1beta1Client for the given config and http client.
-// Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TroubleshootV1beta1Client, error) {
-	config := *c
-	if err := setConfigDefaults(&config); err != nil {
-		return nil, err
-	}
-	client, err := rest.RESTClientForConfigAndClient(&config, h)
+	client, err := rest.RESTClientFor(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_analyzer.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_analyzer.go
@@ -116,7 +116,7 @@ func (c *FakeAnalyzers) UpdateStatus(ctx context.Context, analyzer *v1beta2.Anal
 // Delete takes name of the analyzer and deletes it. Returns an error if one occurs.
 func (c *FakeAnalyzers) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(analyzersResource, c.ns, name, opts), &v1beta2.Analyzer{})
+		Invokes(testing.NewDeleteAction(analyzersResource, c.ns, name), &v1beta2.Analyzer{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_collector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_collector.go
@@ -116,7 +116,7 @@ func (c *FakeCollectors) UpdateStatus(ctx context.Context, collector *v1beta2.Co
 // Delete takes name of the collector and deletes it. Returns an error if one occurs.
 func (c *FakeCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(collectorsResource, c.ns, name, opts), &v1beta2.Collector{})
+		Invokes(testing.NewDeleteAction(collectorsResource, c.ns, name), &v1beta2.Collector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostcollector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostcollector.go
@@ -116,7 +116,7 @@ func (c *FakeHostCollectors) UpdateStatus(ctx context.Context, hostCollector *v1
 // Delete takes name of the hostCollector and deletes it. Returns an error if one occurs.
 func (c *FakeHostCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(hostcollectorsResource, c.ns, name, opts), &v1beta2.HostCollector{})
+		Invokes(testing.NewDeleteAction(hostcollectorsResource, c.ns, name), &v1beta2.HostCollector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostpreflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_hostpreflight.go
@@ -116,7 +116,7 @@ func (c *FakeHostPreflights) UpdateStatus(ctx context.Context, hostPreflight *v1
 // Delete takes name of the hostPreflight and deletes it. Returns an error if one occurs.
 func (c *FakeHostPreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(hostpreflightsResource, c.ns, name, opts), &v1beta2.HostPreflight{})
+		Invokes(testing.NewDeleteAction(hostpreflightsResource, c.ns, name), &v1beta2.HostPreflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_preflight.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_preflight.go
@@ -116,7 +116,7 @@ func (c *FakePreflights) UpdateStatus(ctx context.Context, preflight *v1beta2.Pr
 // Delete takes name of the preflight and deletes it. Returns an error if one occurs.
 func (c *FakePreflights) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(preflightsResource, c.ns, name, opts), &v1beta2.Preflight{})
+		Invokes(testing.NewDeleteAction(preflightsResource, c.ns, name), &v1beta2.Preflight{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_redactor.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_redactor.go
@@ -116,7 +116,7 @@ func (c *FakeRedactors) UpdateStatus(ctx context.Context, redactor *v1beta2.Reda
 // Delete takes name of the redactor and deletes it. Returns an error if one occurs.
 func (c *FakeRedactors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(redactorsResource, c.ns, name, opts), &v1beta2.Redactor{})
+		Invokes(testing.NewDeleteAction(redactorsResource, c.ns, name), &v1beta2.Redactor{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_remotecollector.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_remotecollector.go
@@ -116,7 +116,7 @@ func (c *FakeRemoteCollectors) UpdateStatus(ctx context.Context, remoteCollector
 // Delete takes name of the remoteCollector and deletes it. Returns an error if one occurs.
 func (c *FakeRemoteCollectors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(remotecollectorsResource, c.ns, name, opts), &v1beta2.RemoteCollector{})
+		Invokes(testing.NewDeleteAction(remotecollectorsResource, c.ns, name), &v1beta2.RemoteCollector{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_supportbundle.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/fake/fake_supportbundle.go
@@ -116,7 +116,7 @@ func (c *FakeSupportBundles) UpdateStatus(ctx context.Context, supportBundle *v1
 // Delete takes name of the supportBundle and deletes it. Returns an error if one occurs.
 func (c *FakeSupportBundles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(supportbundlesResource, c.ns, name, opts), &v1beta2.SupportBundle{})
+		Invokes(testing.NewDeleteAction(supportbundlesResource, c.ns, name), &v1beta2.SupportBundle{})
 
 	return err
 }

--- a/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/troubleshoot_client.go
+++ b/pkg/client/troubleshootclientset/typed/troubleshoot/v1beta2/troubleshoot_client.go
@@ -18,8 +18,6 @@ limitations under the License.
 package v1beta2
 
 import (
-	"net/http"
-
 	v1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset/scheme"
 	rest "k8s.io/client-go/rest"
@@ -75,28 +73,12 @@ func (c *TroubleshootV1beta2Client) SupportBundles(namespace string) SupportBund
 }
 
 // NewForConfig creates a new TroubleshootV1beta2Client for the given config.
-// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
-// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TroubleshootV1beta2Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	httpClient, err := rest.HTTPClientFor(&config)
-	if err != nil {
-		return nil, err
-	}
-	return NewForConfigAndClient(&config, httpClient)
-}
-
-// NewForConfigAndClient creates a new TroubleshootV1beta2Client for the given config and http client.
-// Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TroubleshootV1beta2Client, error) {
-	config := *c
-	if err := setConfigDefaults(&config); err != nil {
-		return nil, err
-	}
-	client, err := rest.RESTClientForConfigAndClient(&config, h)
+	client, err := rest.RESTClientFor(&config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description, Motivation and Context

Currently the `when` conditional for the `clusterPodStatuses` analyzer is expected for all outcome types and if not specified the following behavior is seen using the following spec:

```
apiVersion: troubleshoot.sh/v1beta2
kind: Preflight
metadata:
  name: kurl-builtin-oncluster
spec:
  collectors:
    - clusterResources: {}
    - clusterInfo: {}
  analyzers:
    - clusterPodStatuses:
        checkName: "Pod(s) healthy"
        outcomes:
          - warn:
              when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
              message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Restarting the pod may fix the issue."
          - pass:
              message: "All Pods are OK."
```

<img width="421" alt="Screenshot 2023-03-31 at 10 36 27 AM" src="https://user-images.githubusercontent.com/38189728/229154319-2c64cbf2-4b9f-4d9b-ad12-43d495713442.png">

Because `when` isn't set for `pass` you see the above errors. With the changes in this PR, `when` is optional and the expected pattern of having a default outcome at the end of your outcome list is supported.

<img width="978" alt="Screenshot 2023-03-31 at 10 36 02 AM" src="https://user-images.githubusercontent.com/38189728/229155267-b7e44932-b94a-4a6e-aff3-97ba0050d945.png">


Fixes: #1087 

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
