### PR TITLE
fix:Revert namespace filename for cluster-resources back to namespaces.json

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,7 +22,7 @@ const (
 
 	// Cluster Resources Collector Directories
 	CLUSTER_RESOURCES_DIR                         = "cluster-resources"
-	CLUSTER_RESOURCES_NAMESPACES                  = "namespace"
+	CLUSTER_RESOURCES_NAMESPACES                  = "namespacs"
 	CLUSTER_RESOURCES_AUTH_CANI                   = "auth-cani-list"
 	CLUSTER_RESOURCES_PODS                        = "pods"
 	CLUSTER_RESOURCES_PODS_LOGS                   = "pods/logs"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,7 +22,7 @@ const (
 
 	// Cluster Resources Collector Directories
 	CLUSTER_RESOURCES_DIR                         = "cluster-resources"
-	CLUSTER_RESOURCES_NAMESPACES                  = "namespacs"
+	CLUSTER_RESOURCES_NAMESPACES                  = "namespaces"
 	CLUSTER_RESOURCES_AUTH_CANI                   = "auth-cani-list"
 	CLUSTER_RESOURCES_PODS                        = "pods"
 	CLUSTER_RESOURCES_PODS_LOGS                   = "pods/logs"


### PR DESCRIPTION
## Description, Motivation and Context

In https://github.com/replicatedhq/troubleshoot/pull/971 the filename for namespaces in the cluster resources collector was renamed from `namespaces.json` to `namespace.json`. 

Fixes: #1090 

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
