### PR TITLE
fix: Correct arm release file names in krew config

### DIFF
--- a/deploy/krew/preflight.yaml
+++ b/deploy/krew/preflight.yaml
@@ -31,7 +31,7 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/preflight_linux_arm_6.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/preflight_linux_arm.tar.gz" .TagName }}
     files:
     - from: preflight
       to: .

--- a/deploy/krew/support-bundle.yaml
+++ b/deploy/krew/support-bundle.yaml
@@ -31,7 +31,7 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/support-bundle_linux_arm_6.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/replicatedhq/troubleshoot/releases/download/{{ .TagName }}/support-bundle_linux_arm.tar.gz" .TagName }}
     files:
     - from: support-bundle
       to: .


### PR DESCRIPTION
## Description, Motivation and Context

Correct arm release file names selector used when releasing troubleshoot binaries to krew repositories

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
