### PR TITLE
Add stdin and multidoc support to preflight.

### DIFF
--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -76,6 +76,12 @@ func RunPreflights(interactive bool, output string, format string, args []string
 			}
 
 			preflightContent = b
+		} else if v == "-" {
+			b, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return err
+			}
+			preflightContent = b
 		} else {
 			u, err := url.Parse(v)
 			if err != nil {

--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -135,7 +135,7 @@ func RunPreflights(interactive bool, output string, format string, args []string
 
 			var parsedDocHead documentHead
 
-			err := yaml.Unmarshal([]byte(doc),&parsedDocHead)
+			err := yaml.Unmarshal([]byte(doc), &parsedDocHead)
 			if err != nil {
 				return errors.Wrap(err, "failed to parse yaml")
 			}

--- a/test/validate-preflight-e2e.sh
+++ b/test/validate-preflight-e2e.sh
@@ -35,4 +35,11 @@ fi
 
 rm -rf "$tmpdir"
 
+# test stdin
+cat examples/preflight/e2e.yaml | ./bin/preflight --debug --interactive=false --format=json - > "$tmpdir/result.json"
+if [ $? -ne 0 ]; then
+    echo "preflight command failed"
+    exit $EXIT_STATUS
+fi
+
 exit $EXIT_STATUS

--- a/test/validate-preflight-e2e.sh
+++ b/test/validate-preflight-e2e.sh
@@ -33,13 +33,13 @@ echo "Failed preflights found"
 EXIT_STATUS=1
 fi
 
-rm -rf "$tmpdir"
-
 # test stdin
 cat examples/preflight/e2e.yaml | ./bin/preflight --debug --interactive=false --format=json - > "$tmpdir/result.json"
 if [ $? -ne 0 ]; then
     echo "preflight command failed"
     exit $EXIT_STATUS
 fi
+
+rm -rf "$tmpdir"
 
 exit $EXIT_STATUS


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

partially addresses #1111 
Fixes #1109 

Preflight can now accept stdin alongside existing documents like so:

```bash
helm template | preflight -
```

input documents are filtered for valid yaml with the key-value pair: `kind: Preflight`
## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
