### PR TITLE
fix: HostPreflight tcpConnect analyzer should use first matching outcome

### DIFF
--- a/pkg/analyze/host_tcp_connect.go
+++ b/pkg/analyze/host_tcp_connect.go
@@ -40,9 +40,9 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 	}
 
 	var coll resultCollector
+	result := &AnalyzeResult{Title: a.Title()}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
-		result := &AnalyzeResult{Title: a.Title()}
 
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -51,7 +51,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
-
+				break
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -60,6 +60,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				break
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -68,7 +69,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
-
+				break
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -77,6 +78,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				break
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -85,7 +87,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
-
+				break
 			}
 
 			if string(actual.Status) == outcome.Pass.When {
@@ -94,6 +96,7 @@ func (a *AnalyzeHostTCPConnect) Analyze(getCollectedFileContents func(string) ([
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				break
 			}
 		}
 	}

--- a/pkg/analyze/host_tcp_connect_test.go
+++ b/pkg/analyze/host_tcp_connect_test.go
@@ -31,6 +31,11 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 							Message: "Connection was refused",
 						},
 					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "Unexpected TCP connection status",
+						},
+					},
 				},
 			},
 			result: []*AnalyzeResult{
@@ -58,6 +63,11 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 						Pass: &troubleshootv1beta2.SingleOutcome{
 							When:    "connected",
 							Message: "Connection was successful",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "Unexpected TCP connection status",
 						},
 					},
 				},


### PR DESCRIPTION
## Description, Motivation and Context

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

A tcpConnect host preflight check with a fallthrough outcome with no when condition is always true. This changes functionality to choose only the first matching outcome similar to other analyzers.

For a given spec:

```
apiVersion: troubleshoot.sh/v1beta2
kind: HostPreflight
metadata:
  name: weave
spec:
  collectors:
    - tcpConnect:
        collectorName: "162.159.137.43"
        address: '162.159.137.43:80'
        timeout: 5s

  analyzers:
    - tcpConnect:
        checkName: "162.159.137.43:80 TCP connection status"
        collectorName: "162.159.137.43"
        outcomes:
          - warn:
              when: "connection-refused"
              message: Connection to 162.159.137.43:80 was refused
          - warn:
              when: "connection-timeout"
              message: Timed out connecting to 162.159.137.43:80
          - warn:
              when: "error"
              message: Unexpected error connecting to 162.159.137.43:80
          - pass:
              when: "connected"
              message: Successfully connected to 162.159.137.43:80
          - warn:
              message: Unexpected TCP connection status for 162.159.137.43:80
```

Previous functionality:

```
$ ./preflight preflight.yaml --interactive=false
[162.159.137.43] Running collector...

   --- PASS 162.159.137.43:80 TCP connection status
      --- Successfully connected to 162.159.137.43:80
   --- WARN: 162.159.137.43:80 TCP connection status
      --- Unexpected TCP connection status for 162.159.137.43:80
--- PASS   weave
PASS
```

New functionality:

```
$ ./preflight preflight.yaml --interactive=false
$ go run -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -installsuffix netgo ./cmd/preflight/main.go preflight.yaml --interactive=false
[162.159.137.43] Running collector...

   --- PASS 162.159.137.43:80 TCP connection status
      --- Successfully connected to 162.159.137.43:80
--- PASS   weave
PASS
```

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
