### PR TITLE
Add ability to fetch preflights from OCI registry to standard out

### DIFF
--- a/cmd/preflight/cli/oci_fetch.go
+++ b/cmd/preflight/cli/oci_fetch.go
@@ -14,7 +14,7 @@ func OciFetchCmd() *cobra.Command {
 		Short: "Fetch a preflight from an OCI registry and print it to standard out",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			uri := args[0]
-			data,err := oci.PullPreflightFromOCI(uri)
+			data, err := oci.PullPreflightFromOCI(uri)
 			if err != nil {
 				return err
 			}

--- a/cmd/preflight/cli/oci_fetch.go
+++ b/cmd/preflight/cli/oci_fetch.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/troubleshoot/pkg/oci"
+	"github.com/spf13/cobra"
+)
+
+func OciFetchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oci-fetch [URI]",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Fetch a preflight from an OCI registry and print it to standard out",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			uri := args[0]
+			data,err := oci.PullPreflightFromOCI(uri)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(data))
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -60,6 +60,7 @@ that a cluster meets the requirements to run an application.`,
 	cobra.OnInitialize(initConfig)
 
 	cmd.AddCommand(VersionCmd())
+	cmd.AddCommand(OciFetchCmd())
 	preflight.AddFlags(cmd.PersistentFlags())
 
 	k8sutil.AddFlags(cmd.Flags())


### PR DESCRIPTION
## Description, Motivation and Context

Preflights that live in OCI registries are hard to get at for an end user, this small command allows the preflights to be fetched and read before running or to be piped to another command for manipulation / templating. 

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
