### PR TITLE
Revert "feat: Add partition type info to block device collector"

### DIFF
--- a/pkg/analyze/host_block_devices.go
+++ b/pkg/analyze/host_block_devices.go
@@ -116,7 +116,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(getCollectedFileContents func(string) 
 func compareHostBlockDevicesConditionalToActual(conditional string, minimumAcceptableSize uint64, includeUnmountedPartitions bool, devices []collect.BlockDeviceInfo) (res bool, err error) {
 	parts := strings.Split(conditional, " ")
 	if len(parts) != 3 {
-		return false, fmt.Errorf("expected exactly 3 parts, got %d", len(parts))
+		return false, fmt.Errorf("Expected exactly 3 parts, got %d", len(parts))
 	}
 
 	rx, err := regexp.Compile(parts[0])
@@ -143,7 +143,7 @@ func compareHostBlockDevicesConditionalToActual(conditional string, minimumAccep
 		return count == desiredInt, nil
 	}
 
-	return false, fmt.Errorf("unexpected operator %q", parts[1])
+	return false, fmt.Errorf("Unexpected operator %q", parts[1])
 }
 
 func countEligibleBlockDevices(rx *regexp.Regexp, minimumAcceptableSize uint64, includeUnmountedPartitions bool, devices []collect.BlockDeviceInfo) int {

--- a/pkg/analyze/host_block_devices_test.go
+++ b/pkg/analyze/host_block_devices_test.go
@@ -158,7 +158,7 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 			},
 		},
 		{
-			name: ".* == 1, pass with unmounted partition",
+			name: ".* > 1, pass with unmounted partition",
 			devices: []collect.BlockDeviceInfo{
 				{
 					Name:       "sdb",
@@ -175,21 +175,13 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 					Major:            8,
 					Minor:            1,
 				},
-				{
-					Name:             "sdb2",
-					KernelName:       "sdb2",
-					ParentKernelName: "sdb",
-					Type:             "crypto_LUKS",
-					Major:            8,
-					Size:             1024 * 1024 * 1024 * 5,
-				},
 			},
 			hostAnalyzer: &troubleshootv1beta2.BlockDevicesAnalyze{
 				IncludeUnmountedPartitions: true,
 				Outcomes: []*troubleshootv1beta2.Outcome{
 					{
 						Pass: &troubleshootv1beta2.SingleOutcome{
-							When:    ".* == 1",
+							When:    ".* >= 1",
 							Message: "Block device or partition available",
 						},
 					},
@@ -263,8 +255,11 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
 			b, err := json.Marshal(test.devices)
-			require.NoError(t, err)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			getCollectedFileContents := func(filename string) ([]byte, error) {
 				return b, nil
@@ -272,9 +267,9 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 
 			result, err := (&AnalyzeHostBlockDevices{test.hostAnalyzer}).Analyze(getCollectedFileContents)
 			if test.expectErr {
-				assert.Error(t, err)
+				req.Error(err)
 			} else {
-				assert.NoError(t, err)
+				req.NoError(err)
 			}
 
 			assert.Equal(t, test.result, result)

--- a/pkg/collect/host_block_device.go
+++ b/pkg/collect/host_block_device.go
@@ -13,23 +13,22 @@ import (
 )
 
 type BlockDeviceInfo struct {
-	Name               string `json:"name"`
-	KernelName         string `json:"kernel_name"`
-	ParentKernelName   string `json:"parent_kernel_name"`
-	Type               string `json:"type"`
-	Major              int    `json:"major"`
-	Minor              int    `json:"minor"`
-	Size               uint64 `json:"size"`
-	FilesystemType     string `json:"filesystem_type"`
-	Mountpoint         string `json:"mountpoint"`
-	Serial             string `json:"serial"`
-	ReadOnly           bool   `json:"read_only"`
-	Removable          bool   `json:"removable"`
-	PartitionTableType string `json:"partition_table_type"`
+	Name             string `json:"name"`
+	KernelName       string `json:"kernel_name"`
+	ParentKernelName string `json:"parent_kernel_name"`
+	Type             string `json:"type"`
+	Major            int    `json:"major"`
+	Minor            int    `json:"minor"`
+	Size             uint64 `json:"size"`
+	FilesystemType   string `json:"filesystem_type"`
+	Mountpoint       string `json:"mountpoint"`
+	Serial           string `json:"serial"`
+	ReadOnly         bool   `json:"read_only"`
+	Removable        bool   `json:"removable"`
 }
 
-const lsblkColumns = "NAME,KNAME,PKNAME,TYPE,MAJ:MIN,SIZE,FSTYPE,MOUNTPOINT,SERIAL,RO,RM,PTTYPE"
-const lsblkFormat = `NAME=%q KNAME=%q PKNAME=%q TYPE=%q MAJ:MIN="%d:%d" SIZE="%d" FSTYPE=%q MOUNTPOINT=%q SERIAL=%q RO="%d" RM="%d0" PTTYPE=%q`
+const lsblkColumns = "NAME,KNAME,PKNAME,TYPE,MAJ:MIN,SIZE,FSTYPE,MOUNTPOINT,SERIAL,RO,RM"
+const lsblkFormat = `NAME=%q KNAME=%q PKNAME=%q TYPE=%q MAJ:MIN="%d:%d" SIZE="%d" FSTYPE=%q MOUNTPOINT=%q SERIAL=%q RO="%d" RM="%d0"`
 const HostBlockDevicesPath = `host-collectors/system/block_devices.json`
 
 type CollectHostBlockDevices struct {
@@ -46,11 +45,6 @@ func (c *CollectHostBlockDevices) IsExcluded() (bool, error) {
 }
 
 func (c *CollectHostBlockDevices) Collect(progressChan chan<- interface{}) (map[string][]byte, error) {
-	// TODO: Consider using lsblk --json --output <columns> instead.
-	// This simplifies the parsing logic and also represents a parent/child relationship
-	// between devices when there are partitions.
-	// NOTE: Remember to validate the output of lsblk json
-	// NOTE: Check what version of lsblk --json was introduced.
 	cmd := exec.Command("lsblk", "--noheadings", "--bytes", "--pairs", "-o", lsblkColumns)
 	stdout, err := cmd.Output()
 	if err != nil {
@@ -101,7 +95,6 @@ func parseLsblkOutput(output []byte) ([]BlockDeviceInfo, error) {
 			&bdi.Serial,
 			&ro,
 			&rm,
-			&bdi.PartitionTableType,
 		)
 		bdi.ReadOnly = ro == 1
 		bdi.Removable = rm == 1


### PR DESCRIPTION
Reverts replicatedhq/troubleshoot#1063

PTYPE is not supported on older kernels

```
$ sudo lsblk --bytes --pairs -o NAME,KNAME,PKNAME,TYPE,MAJ:MIN,SIZE,FSTYPE,MOUNTPOINT,SERIAL,RO,RM,PTTYPE
lsblk: unknown column: PTTYPE
$ cat /etc/centos-release
CentOS Linux release 7.9.2009 (Core)
```