### PR TITLE
fix(hostpreflight): tcploadbalancer analyzer should use first outcome

### DIFF
--- a/pkg/analyze/host_tcploadbalancer.go
+++ b/pkg/analyze/host_tcploadbalancer.go
@@ -42,9 +42,9 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 	}
 
 	var coll resultCollector
+	result := &AnalyzeResult{Title: a.Title()}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
-		result := &AnalyzeResult{Title: a.Title()}
 
 		if outcome.Fail != nil {
 			if outcome.Fail.When == "" {
@@ -53,6 +53,7 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				break
 			}
 
 			if string(actual.Status) == outcome.Fail.When {
@@ -61,6 +62,7 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 				result.URI = outcome.Fail.URI
 
 				coll.push(result)
+				break
 			}
 		} else if outcome.Warn != nil {
 			if outcome.Warn.When == "" {
@@ -69,6 +71,7 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				break
 			}
 
 			if string(actual.Status) == outcome.Warn.When {
@@ -77,6 +80,7 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 				result.URI = outcome.Warn.URI
 
 				coll.push(result)
+				break
 			}
 		} else if outcome.Pass != nil {
 			if outcome.Pass.When == "" {
@@ -85,6 +89,7 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				break
 			}
 
 			if string(actual.Status) == outcome.Pass.When {
@@ -93,6 +98,7 @@ func (a *AnalyzeHostTCPLoadBalancer) Analyze(getCollectedFileContents func(strin
 				result.URI = outcome.Pass.URI
 
 				coll.push(result)
+				break
 			}
 		}
 	}

--- a/pkg/analyze/host_tcploadbalancer_test.go
+++ b/pkg/analyze/host_tcploadbalancer_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAnalyzeTCPConnect(t *testing.T) {
+func TestAnalyzeTCPLoadBalancer(t *testing.T) {
 	tests := []struct {
 		name         string
 		info         *collect.NetworkStatusResult
-		hostAnalyzer *troubleshootv1beta2.TCPConnectAnalyze
+		hostAnalyzer *troubleshootv1beta2.TCPLoadBalancerAnalyze
 		result       []*AnalyzeResult
 		expectErr    bool
 	}{
@@ -23,7 +23,7 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 			info: &collect.NetworkStatusResult{
 				Status: collect.NetworkStatusConnectionRefused,
 			},
-			hostAnalyzer: &troubleshootv1beta2.TCPConnectAnalyze{
+			hostAnalyzer: &troubleshootv1beta2.TCPLoadBalancerAnalyze{
 				Outcomes: []*troubleshootv1beta2.Outcome{
 					{
 						Fail: &troubleshootv1beta2.SingleOutcome{
@@ -46,7 +46,7 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 			},
 			result: []*AnalyzeResult{
 				{
-					Title:   "TCP Connection Attempt",
+					Title:   "TCP Load Balancer",
 					IsFail:  true,
 					Message: "Connection was refused",
 				},
@@ -57,7 +57,7 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 			info: &collect.NetworkStatusResult{
 				Status: collect.NetworkStatusConnected,
 			},
-			hostAnalyzer: &troubleshootv1beta2.TCPConnectAnalyze{
+			hostAnalyzer: &troubleshootv1beta2.TCPLoadBalancerAnalyze{
 				Outcomes: []*troubleshootv1beta2.Outcome{
 					{
 						Fail: &troubleshootv1beta2.SingleOutcome{
@@ -80,7 +80,7 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 			},
 			result: []*AnalyzeResult{
 				{
-					Title:   "TCP Connection Attempt",
+					Title:   "TCP Load Balancer",
 					IsPass:  true,
 					Message: "Connection was successful",
 				},
@@ -99,7 +99,7 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 				return b, nil
 			}
 
-			result, err := (&AnalyzeHostTCPConnect{test.hostAnalyzer}).Analyze(getCollectedFileContents)
+			result, err := (&AnalyzeHostTCPLoadBalancer{test.hostAnalyzer}).Analyze(getCollectedFileContents)
 			if test.expectErr {
 				req.Error(err)
 			} else {


### PR DESCRIPTION
## Description, Motivation and Context

A tcpLoadBalancer host preflight check with a fallthrough outcome with no when condition is always true. This changes functionality to choose only the first matching outcome similar to other analyzers.

```
[PASS] Kubernetes API Server Load Balancer: Successfully connected to 10.138.15.220:6443 via load balancer
[WARN] Kubernetes API Server Load Balancer: Unexpected port status
```

```
    - tcpLoadBalancer:
        checkName: "Load Balancer Check"
        collectorName: "Load Balancer Check"
        outcomes:
          - fail:
              when: "invalid-address"
              message: The load balancer address is not valid.
          - warn:
              when: "connection-refused"
              message: Connection to load balancer was refused.
          - warn:
              when: "connection-timeout"
              message: Timed out connecting to load balancer. Check your firewall.
          - warn:
              when: "error"
              message: Unexpected connection status
          - warn:
              when: "address-in-use"
              message: Port 6443 is unavailable
          - pass:
              when: "connected"
              message: Successfully connected to load balancer
          - warn:
              message: Unexpected connection status
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
