### PR TITLE
fix: logs collector timeout prevent concurrent map iteration and map write

### DIFF
--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -52,102 +52,66 @@ func (c *CollectLogs) Collect(progressChan chan<- interface{}) (CollectorResult,
 // client for collectors or leave the implementation as is.
 // Ref: https://github.com/replicatedhq/troubleshoot/pull/821#discussion_r1026258904
 func (c *CollectLogs) CollectWithClient(progressChan chan<- interface{}, client kubernetes.Interface) (CollectorResult, error) {
-	out := NewResult()
+	output := NewResult()
 
 	ctx, cancel := context.WithTimeout(c.Context, constants.DEFAULT_LOGS_COLLECTOR_TIMEOUT)
 	defer cancel()
 
-	errCh := make(chan error, 1)
-	done := make(chan struct{}, 1)
-
-	// Collect logs in a go routine to allow timing out of long running operations
-	// If a timeout occurs, the passed in collector result will contain logs collected
-	// prior. We want this to be the case so as to have some logs in the support bundle
-	// even if not from all expected pods.
-	// TODO: In future all collectors will have a timeout. This will be implemented in the
-	// framework level (caller of Collect function). Remove this code when we get there.
-	go func(output CollectorResult) {
-		if c.SinceTime != nil {
-			if c.Collector.Limits == nil {
-				c.Collector.Limits = new(troubleshootv1beta2.LogLimits)
-			}
-			c.Collector.Limits.SinceTime = metav1.NewTime(*c.SinceTime)
+	if c.SinceTime != nil {
+		if c.Collector.Limits == nil {
+			c.Collector.Limits = new(troubleshootv1beta2.LogLimits)
 		}
-
-		pods, podsErrors := listPodsInSelectors(ctx, client, c.Collector.Namespace, c.Collector.Selector)
-		if len(podsErrors) > 0 {
-			// prevent concurrent map writes to the output map
-			if err := ctx.Err(); err != nil {
-				return
-			}
-			output.SaveResult(c.BundlePath, getLogsErrorsFileName(c.Collector), marshalErrors(podsErrors))
-		}
-
-		if len(pods) > 0 {
-			for _, pod := range pods {
-				if len(c.Collector.ContainerNames) == 0 {
-					// make a list of all the containers in the pod, so that we can get logs from all of them
-					containerNames := []string{}
-					for _, container := range pod.Spec.Containers {
-						containerNames = append(containerNames, container.Name)
-					}
-					for _, container := range pod.Spec.InitContainers {
-						containerNames = append(containerNames, container.Name)
-					}
-
-					for _, containerName := range containerNames {
-						podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
-						// prevent concurrent map writes to the output map
-						if err := ctx.Err(); err != nil {
-							return
-						}
-						if err != nil {
-							key := fmt.Sprintf("%s/%s-errors.json", c.Collector.Name, pod.Name)
-							if containerName != "" {
-								key = fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, containerName)
-							}
-							err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
-							if err != nil {
-								errCh <- err
-							}
-							continue
-						}
-						output.AddResult(podLogs)
-					}
-				} else {
-					for _, container := range c.Collector.ContainerNames {
-						containerLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, container, c.Collector.Limits, false, true)
-						// prevent concurrent map writes to the output map
-						if err := ctx.Err(); err != nil {
-							return
-						}
-						if err != nil {
-							key := fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, container)
-							err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
-							if err != nil {
-								errCh <- err
-							}
-							continue
-						}
-						output.AddResult(containerLogs)
-					}
-				}
-			}
-		}
-
-		// Send a signal to indicate that we are done collecting logs
-		done <- struct{}{}
-	}(out)
-
-	select {
-	case <-ctx.Done():
-		// When we timeout, return the logs we have collected so far
-		return out, fmt.Errorf("%s (%s) collector timeout exceeded", c.Title(), c.Collector.CollectorName)
-	case <-done:
-		return out, nil
-	case err := <-errCh:
-		return nil, err
+		c.Collector.Limits.SinceTime = metav1.NewTime(*c.SinceTime)
 	}
+
+	pods, podsErrors := listPodsInSelectors(ctx, client, c.Collector.Namespace, c.Collector.Selector)
+	if len(podsErrors) > 0 {
+		output.SaveResult(c.BundlePath, getLogsErrorsFileName(c.Collector), marshalErrors(podsErrors))
+	}
+
+	for _, pod := range pods {
+		if len(c.Collector.ContainerNames) == 0 {
+			// make a list of all the containers in the pod, so that we can get logs from all of them
+			containerNames := []string{}
+			for _, container := range pod.Spec.Containers {
+				containerNames = append(containerNames, container.Name)
+			}
+			for _, container := range pod.Spec.InitContainers {
+				containerNames = append(containerNames, container.Name)
+			}
+
+			for _, containerName := range containerNames {
+				podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
+				if err != nil {
+					key := fmt.Sprintf("%s/%s-errors.json", c.Collector.Name, pod.Name)
+					if containerName != "" {
+						key = fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, containerName)
+					}
+					err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
+					if err != nil {
+						klog.Errorf("Failed to save result for pod %s and container %s: %v", pod.Name, containerName, err)
+					}
+					continue
+				}
+				output.AddResult(podLogs)
+			}
+		} else {
+			for _, containerName := range c.Collector.ContainerNames {
+				containerLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
+				if err != nil {
+					key := fmt.Sprintf("%s/%s/%s-errors.json", c.Collector.Name, pod.Name, containerName)
+					err := output.SaveResult(c.BundlePath, key, marshalErrors([]string{err.Error()}))
+					if err != nil {
+						klog.Errorf("Failed to save result for pod %s and container %s: %v", pod.Name, containerName, err)
+					}
+					continue
+				}
+				output.AddResult(containerLogs)
+			}
+		}
+	}
+
+	return output, nil
 }
 
 func listPodsInSelectors(ctx context.Context, client kubernetes.Interface, namespace string, selector []string) ([]corev1.Pod, []string) {


### PR DESCRIPTION
## Description, Motivation and Context

Code was [recently added](https://github.com/replicatedhq/troubleshoot/commit/70af0ff3d072cc5f2155e9a3797b30356d847300) to collect as much log info as possible if there is a timeout. This spawns a goroutine that writes to a map which is returned by the function. If there is a timeout the goroutine is not canceled before the function returns and can still be appending to the map while the caller is reading from the map causing a fatal error: concurrent map iteration and map write.

This adds code to the goroutine to check if the context has been canceled before appending any more entries to the map.

```
fatal error: concurrent map iteration and map write

goroutine 1 [running]:
github.com/replicatedhq/troubleshoot/pkg/supportbundle.runCollectors({0x2e65ce8, 0xc000bd9e00}, {0xc00012d4a0?, 0x1e, 0x6?}, 0xc002307b78, {0xc000b65840, 0x3f}, {0x2a0bf60, 0x1, ...})
	/home/runner/work/troubleshoot/troubleshoot/pkg/supportbundle/collect.go:178 +0x1a9b
github.com/replicatedhq/troubleshoot/pkg/supportbundle.CollectSupportBundleFromSpec(0xc0006025e8, 0x80?, {0x2a0bf60, 0x1, 0x0, 0xc00057a480, {0x0, 0x0}, 0xc000061320, 0x0, ...})
	/home/runner/work/troubleshoot/troubleshoot/pkg/supportbundle/supportbundle.go:124 +0x7e9
github.com/replicatedhq/troubleshoot/cmd/troubleshoot/cli.runTroubleshoot(0x28bde3b?, {0xc000197b30, 0x1, 0x0?})
	/home/runner/work/troubleshoot/troubleshoot/cmd/troubleshoot/cli/run.go:209 +0xc92
github.com/replicatedhq/troubleshoot/cmd/troubleshoot/cli.RootCmd.func2(0xc000161200?, {0xc000197b30, 0x1, 0x1})
	/home/runner/work/troubleshoot/troubleshoot/cmd/troubleshoot/cli/root.go:47 +0x15c
github.com/spf13/cobra.(*Command).execute(0xc000161200, {0xc000050050, 0x1, 0x1})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000161200)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/replicatedhq/troubleshoot/cmd/troubleshoot/cli.InitAndExecute()
	/home/runner/work/troubleshoot/troubleshoot/cmd/troubleshoot/cli/root.go:98 +0x1e
main.main()
	/home/runner/work/troubleshoot/troubleshoot/cmd/troubleshoot/main.go:9 +0x17
...
goroutine 450 [runnable]:
k8s.io/client-go/kubernetes/typed/core/v1.(*CoreV1Client).Pods(0xc0004bff20?, {0xc001ec9540, 0x9})
	/home/runner/go/pkg/mod/k8s.io/client-go@v0.27.1/kubernetes/typed/core/v1/core_client.go:90 +0xc7
github.com/replicatedhq/troubleshoot/pkg/collect.savePodLogs({0x2e65cb0, 0xc000544fc0}, {0xc000b65840, 0x3f}, {0x2e89210, 0xc0009996c0}, 0xc000e5db90, {0xc000b6c200, 0x9}, {0xc001ec9941, ...}, ...)
	/home/runner/work/troubleshoot/troubleshoot/pkg/collect/logs.go:194 +0x4fa
github.com/replicatedhq/troubleshoot/pkg/collect.(*CollectLogs).CollectWithClient.func1(0xc0019d4de0?)
	/home/runner/work/troubleshoot/troubleshoot/pkg/collect/logs.go:95 +0x7c7
created by github.com/replicatedhq/troubleshoot/pkg/collect.(*CollectLogs).CollectWithClient
	/home/runner/work/troubleshoot/troubleshoot/pkg/collect/logs.go:69 +0x1fd
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
