### PR TITLE
fix (support-bundle): Ensure specs are merged correctly

### DIFF
--- a/pkg/specs/configmaps.go
+++ b/pkg/specs/configmaps.go
@@ -7,6 +7,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 func LoadFromConfigMap(namespace string, configMapName string, key string) ([]byte, error) {
@@ -30,6 +31,10 @@ func LoadFromConfigMap(namespace string, configMapName string, key string) ([]by
 		return nil, errors.Errorf("spec not found in configmap %s", configMapName)
 	}
 
+	klog.V(1).InfoS("Loaded spec from config map", "name",
+		foundConfigMap.Name, "namespace", foundConfigMap.Namespace, "data key", key,
+	)
+
 	return []byte(spec), nil
 }
 
@@ -46,6 +51,10 @@ func LoadFromConfigMapMatchingLabel(client kubernetes.Interface, labelSelector s
 		if !ok {
 			continue
 		}
+
+		klog.V(1).InfoS("Loaded spec from config map", "name", configMap.Name,
+			"namespace", configMap.Namespace, "data key", key, "label selector", labelSelector,
+		)
 		configMapMatchingKey = append(configMapMatchingKey, string(spec))
 	}
 

--- a/pkg/specs/secrets.go
+++ b/pkg/specs/secrets.go
@@ -7,6 +7,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 )
 
 func LoadFromSecret(namespace string, secretName string, key string) ([]byte, error) {
@@ -30,6 +31,9 @@ func LoadFromSecret(namespace string, secretName string, key string) ([]byte, er
 		return nil, errors.Errorf("spec not found in secret %s", secretName)
 	}
 
+	klog.V(1).InfoS("Loaded spec from secret", "name",
+		foundSecret.Name, "namespace", foundSecret.Namespace, "data key", key,
+	)
 	return spec, nil
 }
 
@@ -46,6 +50,10 @@ func LoadFromSecretMatchingLabel(client kubernetes.Interface, labelSelector stri
 		if !ok {
 			continue
 		}
+
+		klog.V(1).InfoS("Loaded spec from secret", "name", secret.Name,
+			"namespace", secret.Namespace, "data key", key, "label selector", labelSelector,
+		)
 		secretsMatchingKey = append(secretsMatchingKey, string(spec))
 	}
 

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -2,11 +2,24 @@
 
 set -euo pipefail
 
-tmpdir="$(mktemp -d)"
+readonly PRJ_ROOT=$(dirname $(dirname -- "$( readlink -f -- $0)"))
+tmpdir=""
+function cleanup() {
+    test -d "$tmpdir" && rm -r "$tmpdir" || :
+}
+
+function recreate_tmpdir() {
+    cleanup
+    tmpdir="$(mktemp -d)"
+}
+# Cleanup on exit
+trap cleanup EXIT
+
 bundle_archive_name="support-bundle.tar.gz"
 bundle_directory_name="support-bundle"
 
 echo "====== Generating support bundle from k8s cluster ======"
+recreate_tmpdir
 ./bin/support-bundle --debug --interactive=false examples/support-bundle/e2e.yaml --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"
@@ -43,23 +56,46 @@ if [ $EXIT_STATUS -ne 0 ]; then
 fi
 
 echo "======= Redact an existing support bundle ======"
-redact_tmpdir="$(mktemp -d)"
-redacted_archive_name="$redact_tmpdir/redacted-support-bundle.tar.gz"
+redacted_archive_name="$tmpdir/redacted-support-bundle.tar.gz"
 ./bin/support-bundle redact examples/redact/e2e.yaml --bundle=$tmpdir/$bundle_archive_name --output=$redacted_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle redact command failed"
     exit $?
 fi
 
-if ! tar -xvzf $redacted_archive_name --directory $redact_tmpdir; then
+if ! tar -xvzf $redacted_archive_name --directory $tmpdir; then
     echo "Failed to extract redacted support bundle archive"
     exit 1
 fi
 
-if ! grep "\*\*\*HIDDEN\*\*\*" "$redact_tmpdir/$bundle_directory_name/static-hi.log"; then
-    echo "$(cat $redact_tmpdir/$bundle_directory_name/static-hi.log)"
+if ! grep "\*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_directory_name/static-hi.log"; then
+    echo "$(cat $tmpdir/$bundle_directory_name/static-hi.log)"
     echo "Hidden content not found in redacted static-hi.log file"
     exit 1
 fi
 
-rm -rf "$tmpdir" "$redact_tmpdir"
+echo "======= Generating support bundle from k8s cluster using --load-cluster-specs ======"
+recreate_tmpdir
+kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
+./bin/support-bundle -v1 --interactive=false --load-cluster-specs --output=$tmpdir/$bundle_archive_name
+if [ $? -ne 0 ]; then
+    echo "support-bundle command failed"
+    exit $?
+fi
+
+if ! tar -xvzf $tmpdir/$bundle_archive_name --directory $tmpdir; then
+    echo "A valid support bundle archive was not generated"
+    exit 1
+fi
+
+if ! grep "labelled-support-bundle-1 \*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_directory_name/echo-hi-1"; then
+    echo "$(cat $tmpdir/$bundle_directory_name/echo-hi-1)"
+    echo "Hidden content not found in redacted echo-hi-1 file"
+    exit 1
+fi
+
+if ! grep "labelled-support-bundle-2 \*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_directory_name/echo-hi-2"; then
+    echo "$(cat $tmpdir/$bundle_directory_name/echo-hi-2)"
+    echo "Hidden content not found in redacted echo-hi-2 file"
+    exit 1
+fi

--- a/testdata/supportbundle/labelled-specs/0-ns.yaml
+++ b/testdata/supportbundle/labelled-specs/0-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: labelled-specs

--- a/testdata/supportbundle/labelled-specs/redact-spec-1.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: labelled-redactor-spec-1
+  labels:
+    troubleshoot.io/kind: support-bundle
+data:
+  redactor-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Redactor
+    metadata:
+      name: labelled-redactor-spec-1
+    spec:
+      redactors:
+        - name: redact-text-1
+          removals:
+            values:
+            -  REDACT FIRST TEXT PLEASE

--- a/testdata/supportbundle/labelled-specs/redact-spec-2.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: labelled-redactor-spec-2
+  labels:
+    troubleshoot.io/kind: support-bundle
+  namespace: labelled-specs
+stringData:
+  redactor-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Redactor
+    metadata:
+      name: labelled-redactor-spec-2
+    spec:
+      redactors:
+        - name: redact-text-2
+          removals:
+            values:
+            -  REDACT SECOND TEXT PLEASE

--- a/testdata/supportbundle/labelled-specs/sb-spec-1.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: labelled-support-bundle-1
+  labels:
+    troubleshoot.io/kind: support-bundle
+stringData:
+  support-bundle-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: labelled-support-bundle-1
+    spec:
+      collectors:
+        - data:
+            name: echo-hi-1
+            data: "I am labelled-support-bundle-1 REDACT FIRST TEXT PLEASE"

--- a/testdata/supportbundle/labelled-specs/sb-spec-2.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: labelled-support-bundle-2
+  labels:
+    troubleshoot.io/kind: support-bundle
+  namespace: labelled-specs
+data:
+  support-bundle-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: labelled-support-bundle-2
+    spec:
+      collectors:
+        - data:
+            name: echo-hi-2
+            data: "I am labelled-support-bundle-2 REDACT SECOND TEXT PLEASE"


### PR DESCRIPTION
## Description, Motivation and Context

When the support-bundle cli is used with --load-cluster-specs, not all discovered specs are merged into the spec used to collect data.

<!--- If it relates to an open issue, please link to the issue here.
e.g.

-->

Fixes: #1179

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
