### PR TITLE
feat(analyzer): fix clusterResource analyzer  always uses the first object found

### DIFF
--- a/pkg/analyze/kube_resource.go
+++ b/pkg/analyze/kube_resource.go
@@ -94,11 +94,11 @@ func FindResource(kind string, clusterScoped bool, namespace string, name string
 	}
 	itemslice := items.([]interface{})
 	for _, item := range itemslice {
-		name, err := iutils.GetAtPath(item, "metadata.name")
+		resourceName, err := iutils.GetAtPath(item, "metadata.name")
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to find resource with name: %s", name)
 		}
-		if name == name {
+		if resourceName == name {
 			return item, nil
 		}
 	}

--- a/pkg/analyze/kube_resource_test.go
+++ b/pkg/analyze/kube_resource_test.go
@@ -10,12 +10,14 @@ import (
 
 func Test_clusterResource(t *testing.T) {
 	tests := []struct {
-		name     string
-		isError  bool
-		analyzer troubleshootv1beta2.ClusterResource
+		name           string
+		isError        bool
+		resourceExists bool
+		analyzer       troubleshootv1beta2.ClusterResource
 	}{
 		{
-			name: "namespaced resource",
+			name:           "namespaced resource",
+			resourceExists: true,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
 				Kind:          "Deployment",
@@ -24,7 +26,8 @@ func Test_clusterResource(t *testing.T) {
 			},
 		},
 		{
-			name: "check default fallthrough",
+			name:           "check default fallthrough",
+			resourceExists: true,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
 				Kind:          "Deployment",
@@ -32,12 +35,23 @@ func Test_clusterResource(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster scoped resource",
+			name:           "cluster scoped resource",
+			resourceExists: true,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
 				Kind:          "Node",
 				ClusterScoped: true,
 				Name:          "repldev-marc",
+			},
+		},
+		{
+			name:           "not existed resource",
+			resourceExists: false,
+			analyzer: troubleshootv1beta2.ClusterResource{
+				CollectorName: "Check namespaced resource",
+				Kind:          "Node",
+				ClusterScoped: true,
+				Name:          "not-existed-resource",
 			},
 		},
 	}
@@ -49,9 +63,9 @@ func Test_clusterResource(t *testing.T) {
 			fcp := fileContentProvider{rootDir: rootDir}
 
 			analyzer := &test.analyzer
-			_, err := FindResource(analyzer.Kind, analyzer.ClusterScoped, analyzer.Namespace, analyzer.Name, fcp.getFileContents)
+			item, err := FindResource(analyzer.Kind, analyzer.ClusterScoped, analyzer.Namespace, analyzer.Name, fcp.getFileContents)
+			assert.Equal(t, test.resourceExists, item != nil)
 			assert.Nil(t, err)
-
 		})
 	}
 }

--- a/pkg/analyze/kube_resource_test.go
+++ b/pkg/analyze/kube_resource_test.go
@@ -45,13 +45,13 @@ func Test_clusterResource(t *testing.T) {
 			},
 		},
 		{
-			name:           "not existed resource",
+			name:           "resource does not exist",
 			resourceExists: false,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
 				Kind:          "Node",
 				ClusterScoped: true,
-				Name:          "not-existed-resource",
+				Name:          "resource-does-not-exist",
 			},
 		},
 	}


### PR DESCRIPTION


## Description, Motivation and Context

- fix a variable name collision
- update tests to test no existed resource

Fixes: #1184


## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
