### PR TITLE
Update preflight e2e test

### DIFF
--- a/examples/preflight/e2e.yaml
+++ b/examples/preflight/e2e.yaml
@@ -7,10 +7,13 @@ spec:
     - data:
         name: config/replicas.txt
         data: "5"
-    - run:
+    - runPod:
         collectorName: "static-hi"
-        image: 'alpine:3'
-        command: ["echo", "hi static!"]
+        podSpec:
+          containers:
+          - name: static-hi
+            image: alpine:3
+            command: ["echo", "hi static!"]
   analyzers:
     - clusterVersion:
         outcomes:


### PR DESCRIPTION
Replace the `run` collector (deprecated) with `runPod`.

## Description, Motivation and Context

The `run` collector is deprecated.  The preflight e2e test should use the replacement `runPod` collector.

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Related: https://github.com/replicatedhq/troubleshoot/issues/1177