### PR TITLE
fix(collector): solving pod stuck in terminating with CNI issue

### DIFF
--- a/examples/preflight/e2e.yaml
+++ b/examples/preflight/e2e.yaml
@@ -8,7 +8,15 @@ spec:
         name: config/replicas.txt
         data: "5"
     - runPod:
-        collectorName: "static-hi"
+        collectorName: "static-hi-1"
+        podSpec:
+          containers:
+          - name: static-hi
+            image: alpine:3
+            command: ["echo", "hi static!"]
+    ## This collector is intentionally duplicated to test same pod should be terminated after success
+    - runPod:
+        collectorName: "static-hi-2"
         podSpec:
           containers:
           - name: static-hi
@@ -47,7 +55,16 @@ spec:
               message: You have at least 5 replicas
     - textAnalyze:
         checkName: Said hi!
-        fileName: /static-hi.log
+        fileName: /static-hi-1.log
+        regex: 'hi static'
+        outcomes:
+          - fail:
+              message: Didn't say hi.
+          - pass:
+              message: Said hi!
+    - textAnalyze:
+        checkName: Said hi!
+        fileName: /static-hi-2.log
         regex: 'hi static'
         outcomes:
           - fail:

--- a/pkg/collect/copy_from_host.go
+++ b/pkg/collect/copy_from_host.go
@@ -222,6 +222,7 @@ func copyFromHostCreateDaemonSet(ctx context.Context, client kubernetes.Interfac
 		klog.V(2).Infof("Daemonset %s has been scheduled for deletion", createdDS.Name)
 		if err := client.AppsV1().DaemonSets(namespace).Delete(context.Background(), createdDS.Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("Failed to delete daemonset %s: %v", createdDS.Name, err)
+			return
 		}
 
 		var labelSelector []string
@@ -264,7 +265,9 @@ func copyFromHostCreateDaemonSet(ctx context.Context, client kubernetes.Interfac
 				})
 				if err != nil {
 					klog.Errorf("Failed to wait for pod %s deletion: %v", pod.Name, err)
+					return
 				}
+				klog.V(2).Infof("Daemonset pod %s in %s namespace has been deleted", pod.Name, pod.Namespace)
 			}
 		}
 	})

--- a/pkg/collect/copy_from_host.go
+++ b/pkg/collect/copy_from_host.go
@@ -219,57 +219,7 @@ func copyFromHostCreateDaemonSet(ctx context.Context, client kubernetes.Interfac
 		return "", cleanup, errors.Wrap(err, "create daemonset")
 	}
 	cleanupFuncs = append(cleanupFuncs, func() {
-		klog.V(2).Infof("Daemonset %s has been scheduled for deletion", createdDS.Name)
-		if err := client.AppsV1().DaemonSets(namespace).Delete(context.Background(), createdDS.Name, metav1.DeleteOptions{}); err != nil {
-			klog.Errorf("Failed to delete daemonset %s: %v", createdDS.Name, err)
-			return
-		}
-
-		var labelSelector []string
-		for k, v := range labels {
-			labelSelector = append(labelSelector, fmt.Sprintf("%s=%s", k, v))
-		}
-
-		dsPods := &corev1.PodList{}
-		klog.V(2).Infof("Continuously poll each second for Pod deletion of DaemontSet %s for maximum %d seconds", ds.Name, constants.MAX_TIME_TO_WAIT_FOR_POD_DELETION/time.Second)
-
-		err := wait.PollUntilContextTimeout(ctx, time.Second, constants.MAX_TIME_TO_WAIT_FOR_POD_DELETION, true, func(ctx context.Context) (bool, error) {
-			pods, listErr := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-				LabelSelector: strings.Join(labelSelector, ","),
-			})
-
-			if listErr != nil {
-				klog.Errorf("Failed to list pods created by %s daemonset: %v", ds.Name, listErr)
-			}
-			// If there are no pods remaining, return true to stop the polling
-			if len(pods.Items) == 0 {
-				return true, nil
-			}
-			// If there is an error from context (e.g., context deadline exceeded), return the error.
-			if ctx.Err() != nil {
-				return false, ctx.Err()
-			}
-			// If there are still pods remaining and there was no context error, save the list of pods,
-			dsPods = pods
-			return false, nil
-		})
-
-		// If there was an error from the polling (e.g., the context deadline was exceeded before all pods were deleted),
-		// delete each remaining pod with a zero-second grace period
-		if err != nil {
-			zeroGracePeriod := int64(0)
-			for _, pod := range dsPods.Items {
-				klog.V(2).Infof("Pod %s forcefully deleted after reaching the maximum wait time of %d seconds", pod.Name, constants.MAX_TIME_TO_WAIT_FOR_POD_DELETION/time.Second)
-				err := client.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{
-					GracePeriodSeconds: &zeroGracePeriod,
-				})
-				if err != nil {
-					klog.Errorf("Failed to wait for pod %s deletion: %v", pod.Name, err)
-					return
-				}
-				klog.V(2).Infof("Daemonset pod %s in %s namespace has been deleted", pod.Name, pod.Namespace)
-			}
-		}
+		deleteDaemonSet(client, ctx, createdDS, namespace, labels)
 	})
 
 	// This timeout is different from collector timeout.
@@ -419,4 +369,58 @@ func copyFilesFromHost(ctx context.Context, dstPath string, clientConfig *restcl
 	}
 
 	return result, stderr.Bytes(), nil
+}
+
+func deleteDaemonSet(client kubernetes.Interface, ctx context.Context, createdDS *appsv1.DaemonSet, namespace string, labels map[string]string) {
+	klog.V(2).Infof("Daemonset %s has been scheduled for deletion", createdDS.Name)
+	if err := client.AppsV1().DaemonSets(namespace).Delete(context.Background(), createdDS.Name, metav1.DeleteOptions{}); err != nil {
+		klog.Errorf("Failed to delete daemonset %s: %v", createdDS.Name, err)
+		return
+	}
+
+	var labelSelector []string
+	for k, v := range labels {
+		labelSelector = append(labelSelector, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	dsPods := &corev1.PodList{}
+	klog.V(2).Infof("Continuously poll each second for Pod deletion of DaemontSet %s for maximum %d seconds", createdDS.Name, constants.MAX_TIME_TO_WAIT_FOR_POD_DELETION/time.Second)
+
+	err := wait.PollUntilContextTimeout(ctx, time.Second, constants.MAX_TIME_TO_WAIT_FOR_POD_DELETION, true, func(ctx context.Context) (bool, error) {
+		pods, listErr := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: strings.Join(labelSelector, ","),
+		})
+
+		if listErr != nil {
+			klog.Errorf("Failed to list pods created by %s daemonset: %v", createdDS.Name, listErr)
+		}
+		// If there are no pods remaining, return true to stop the polling
+		if len(pods.Items) == 0 {
+			return true, nil
+		}
+		// If there is an error from context (e.g., context deadline exceeded), return the error.
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		// If there are still pods remaining and there was no context error, save the list of pods,
+		dsPods = pods
+		return false, nil
+	})
+
+	// If there was an error from the polling (e.g., the context deadline was exceeded before all pods were deleted),
+	// delete each remaining pod with a zero-second grace period
+	if err != nil {
+		zeroGracePeriod := int64(0)
+		for _, pod := range dsPods.Items {
+			klog.V(2).Infof("Pod %s forcefully deleted after reaching the maximum wait time of %d seconds", pod.Name, constants.MAX_TIME_TO_WAIT_FOR_POD_DELETION/time.Second)
+			err := client.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{
+				GracePeriodSeconds: &zeroGracePeriod,
+			})
+			if err != nil {
+				klog.Errorf("Failed to wait for pod %s deletion: %v", pod.Name, err)
+				return
+			}
+			klog.V(2).Infof("Daemonset pod %s in %s namespace has been deleted", pod.Name, pod.Namespace)
+		}
+	}
 }

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -59,6 +59,7 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (CollectorResul
 	defer func() {
 		if err := client.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("Failed to delete pod %s: %v", pod.Name, err)
+			return
 		}
 		klog.V(2).Infof("Pod %s has been scheduled for deletion", pod.Name)
 
@@ -85,7 +86,9 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (CollectorResul
 				GracePeriodSeconds: &zeroGracePeriod,
 			}); err != nil {
 				klog.Errorf("Failed to wait for pod %s deletion: %v", pod.Name, err)
+				return
 			}
+			klog.V(2).Infof("Pod %s in %s namespace has been deleted", pod.Name, pod.Namespace)
 		}
 	}()
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -13,7 +13,8 @@ const (
 	VERSION_FILENAME = "version.yaml"
 	// DEFAULT_LOGS_COLLECTOR_TIMEOUT is the default timeout for logs collector.
 	DEFAULT_LOGS_COLLECTOR_TIMEOUT = 60 * time.Second
-
+	// MAX_TIME_TO_WAIT_FOR_POD_DELETION is the maximum time to wait for pod deletion.
+	MAX_TIME_TO_WAIT_FOR_POD_DELETION = 60 * time.Second
 	// Tracing constants
 	LIB_TRACER_NAME             = "github.com/replicatedhq/troubleshoot"
 	TROUBLESHOOT_ROOT_SPAN_NAME = "ReplicatedTroubleshootRootSpan"


### PR DESCRIPTION
## Description, Motivation and Context

- this pr is targeted on two collectors `runPod` and `copyFromHost` 
- Make sure the run pod and daemonset have been deleted before the troubleshoot.sh finished running
- Poll every second to check if the Pod has been deleted. The maximum grace period is 1 Minute.
- If it reached 1 Minute,  all the pods created by those two collectors will be force deleted
- add klog.v(2) for reporting process


Fixes: 
#1188
#1186

Previous PR:
https://github.com/replicatedhq/troubleshoot/pull/1172
https://github.com/replicatedhq/troubleshoot/pull/1194

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
