### PR TITLE
fix(collector): removed unused name in certificates collector

### DIFF
--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -99,8 +99,6 @@ spec:
                           type: array
                         exclude:
                           type: BoolString
-                        name:
-                          type: string
                         secrets:
                           items:
                             properties:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -1594,8 +1594,6 @@ spec:
                           type: array
                         exclude:
                           type: BoolString
-                        name:
-                          type: string
                         secrets:
                           items:
                             properties:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -1625,8 +1625,6 @@ spec:
                           type: array
                         exclude:
                           type: BoolString
-                        name:
-                          type: string
                         secrets:
                           items:
                             properties:

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -218,7 +218,6 @@ type RegistryImages struct {
 
 type Certificates struct {
 	CollectorMeta `json:",inline" yaml:",inline"`
-	Name          string              `json:"name,omitempty" yaml:"name,omitempty"`
 	Secrets       []CertificateSource `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 	ConfigMaps    []CertificateSource `json:"configMaps,omitempty" yaml:"configMaps,omitempty"`
 }

--- a/pkg/collect/certificates_test.go
+++ b/pkg/collect/certificates_test.go
@@ -143,7 +143,6 @@ func TestCertParser(t *testing.T) {
 						CollectorMeta: troubleshootv1beta2.CollectorMeta{
 							CollectorName: "collectorname",
 						},
-						Name: "expired certificate",
 						Secrets: []troubleshootv1beta2.CertificateSource{
 							{
 								Name:       "expiredCert",
@@ -183,7 +182,6 @@ func TestCertParser(t *testing.T) {
 						CollectorMeta: troubleshootv1beta2.CollectorMeta{
 							CollectorName: "collectorname",
 						},
-						Name: "multiple certificate",
 						Secrets: []troubleshootv1beta2.CertificateSource{
 							{
 								Name:       "multiCert",
@@ -232,7 +230,6 @@ func TestCertParser(t *testing.T) {
 						CollectorMeta: troubleshootv1beta2.CollectorMeta{
 							CollectorName: "collectorname",
 						},
-						Name: "valid certificate",
 						Secrets: []troubleshootv1beta2.CertificateSource{
 							{
 								Name:       "validCert",
@@ -277,7 +274,6 @@ func TestCertParser(t *testing.T) {
 						CollectorMeta: troubleshootv1beta2.CollectorMeta{
 							CollectorName: "collectorname",
 						},
-						Name: "non valid certificate",
 						Secrets: []troubleshootv1beta2.CertificateSource{
 							{
 								Name:       "nonCert",

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -180,7 +180,6 @@ func getCollectorName(c interface{}) string {
 		name = v.Collector.Name
 	case *CollectCertificates:
 		collector = "certificates"
-		name = v.Collector.Name
 	default:
 		collector = "<none>"
 	}

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -114,9 +114,6 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
-                  "name": {
-                    "type": "string"
-                  },
                   "secrets": {
                     "type": "array",
                     "items": {

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -2417,9 +2417,6 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
-                  "name": {
-                    "type": "string"
-                  },
                   "secrets": {
                     "type": "array",
                     "items": {

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -2463,9 +2463,6 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
-                  "name": {
-                    "type": "string"
-                  },
                   "secrets": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## Description, Motivation and Context

- the name in certificates collector is not used
- reduce the confusion

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Related PR
https://github.com/replicatedhq/troubleshoot.sh/pull/499

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
