### PR TITLE
chore: add make target to build all binaries together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ preflight-e2e-test:
 support-bundle-e2e-test:
 	./test/validate-support-bundle-e2e.sh
 
+# Build all binaries in parallel ( -j )
+build:
+	@echo "Build cli binaries"
+	$(MAKE) -j support-bundle preflight analyze collect
+
 .PHONY: support-bundle
 support-bundle:
 	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle github.com/replicatedhq/troubleshoot/cmd/troubleshoot


### PR DESCRIPTION
## Description, Motivation and Context

Add `make build` target that builds all troubleshoot binaries in parallel using `-j` make flag that lets `make` run all make sub-targets as separate jobs

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
