### PR TITLE
chore: remove unnecessary logrus dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/replicatedhq/termui/v3 v3.1.1-0.20200811145416-f40076d26851
 	github.com/segmentio/ksuid v1.0.4
 	github.com/shirou/gopsutil/v3 v3.23.5
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
@@ -70,6 +69,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sylabs/sif/v2 v2.11.1 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect

--- a/pkg/longhorn/types/setting.go
+++ b/pkg/longhorn/types/setting.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/replicatedhq/troubleshoot/pkg/longhorn/util"
 )
@@ -941,7 +941,7 @@ func GetCustomizedDefaultSettings() (map[string]string, error) {
 
 		// `yaml.Unmarshal()` can return a partial result. We shouldn't allow it
 		if err := yaml.Unmarshal(data, &defaultSettings); err != nil {
-			logrus.Errorf("Failed to unmarshal customized default settings from yaml data %v, will give up using them: %v", string(data), err)
+			klog.Errorf("Failed to unmarshal customized default settings from yaml data %v, will give up using them: %v", string(data), err)
 			defaultSettings = map[string]string{}
 		}
 	}
@@ -951,7 +951,7 @@ func GetCustomizedDefaultSettings() (map[string]string, error) {
 		value = strings.Trim(value, " ")
 		definition, exist := SettingDefinitions[SettingName(name)]
 		if !exist {
-			logrus.Errorf("Customized settings are invalid, will give up using them: undefined setting %v", name)
+			klog.Errorf("Customized settings are invalid, will give up using them: undefined setting %v", name)
 			defaultSettings = map[string]string{}
 			break
 		}
@@ -963,14 +963,14 @@ func GetCustomizedDefaultSettings() (map[string]string, error) {
 		if definition.Type == SettingTypeBool {
 			result, err := strconv.ParseBool(value)
 			if err != nil {
-				logrus.Errorf("Invalid value %v for the boolean setting %v: %v", value, name, err)
+				klog.Errorf("Invalid value %v for the boolean setting %v: %v", value, name, err)
 				defaultSettings = map[string]string{}
 				break
 			}
 			value = strconv.FormatBool(result)
 		}
 		if err := ValidateInitSetting(name, value); err != nil {
-			logrus.Errorf("Customized settings are invalid, will give up using them: the value of customized setting %v is invalid: %v", name, err)
+			klog.Errorf("Customized settings are invalid, will give up using them: the value of customized setting %v is invalid: %v", name, err)
 			defaultSettings = map[string]string{}
 			break
 		}
@@ -986,7 +986,7 @@ func GetCustomizedDefaultSettings() (map[string]string, error) {
 		guaranteedReplicaManagerCPU = defaultSettings[string(SettingNameGuaranteedReplicaManagerCPU)]
 	}
 	if err := ValidateCPUReservationValues(guaranteedEngineManagerCPU, guaranteedReplicaManagerCPU); err != nil {
-		logrus.Errorf("Customized settings GuaranteedEngineManagerCPU and GuaranteedReplicaManagerCPU are invalid, will give up using them: %v", err)
+		klog.Errorf("Customized settings GuaranteedEngineManagerCPU and GuaranteedReplicaManagerCPU are invalid, will give up using them: %v", err)
 		defaultSettings = map[string]string{}
 	}
 
@@ -994,7 +994,7 @@ func GetCustomizedDefaultSettings() (map[string]string, error) {
 }
 
 func OverwriteBuiltInSettingsWithCustomizedValues() error {
-	logrus.Infof("Start overwriting built-in settings with customized values")
+	klog.V(2).Info("Start overwriting built-in settings with customized values")
 	customizedDefaultSettings, err := GetCustomizedDefaultSettings()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description, Motivation and Context

The troubleshoot project uses `klog` logging library. There is room for only one library unfortunately. Sorry `logrus` :)

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
