### PR TITLE
Add code to collect cluster endpoint data with cluster-resources collector

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -352,6 +352,13 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_CLUSTER_ROLE_BINDINGS)), bytes.NewBuffer(clusterRoleBindings))
 	output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_CLUSTER_ROLE_BINDINGS)), marshalErrors(clusterRoleBindingsErrors))
 
+	// endpoints
+	endpoints, endpointsErrors := endpoints(ctx, client, namespaceNames)
+	for k, v := range endpoints {
+		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_ENDPOINTS, k), bytes.NewBuffer(v))
+	}
+	output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_ENDPOINTS)), marshalErrors(endpointsErrors))
+
 	return output, nil
 }
 
@@ -1887,4 +1894,39 @@ func clusterRoleBindings(ctx context.Context, client *kubernetes.Clientset) ([]b
 		return nil, []string{err.Error()}
 	}
 	return b, nil
+}
+
+func endpoints(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
+	endpointsByNamespace := make(map[string][]byte)
+	errorsByNamespace := make(map[string]string)
+
+	for _, namespace := range namespaces {
+		endpoints, err := client.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			errorsByNamespace[namespace] = err.Error()
+			continue
+		}
+
+		gvk, err := apiutil.GVKForObject(endpoints, scheme.Scheme)
+		if err == nil {
+			endpoints.GetObjectKind().SetGroupVersionKind(gvk)
+		}
+
+		for i, o := range endpoints.Items {
+			gvk, err := apiutil.GVKForObject(&o, scheme.Scheme)
+			if err == nil {
+				endpoints.Items[i].GetObjectKind().SetGroupVersionKind(gvk)
+			}
+		}
+
+		b, err := json.MarshalIndent(endpoints, "", "  ")
+		if err != nil {
+			errorsByNamespace[namespace] = err.Error()
+			continue
+		}
+
+		endpointsByNamespace[namespace+".json"] = b
+	}
+
+	return endpointsByNamespace, errorsByNamespace
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,6 +52,7 @@ const (
 	CLUSTER_RESOURCES_CLUSTER_ROLES               = "clusterroles"
 	CLUSTER_RESOURCES_CLUSTER_ROLE_BINDINGS       = "clusterrolebindings"
 	CLUSTER_RESOURCES_PRIORITY_CLASS              = "priorityclasses"
+	CLUSTER_RESOURCES_ENDPOINTS                   = "endpoints"
 
 	// Custom exit codes
 	EXIT_CODE_CATCH_ALL   = 1


### PR DESCRIPTION
## Description, Motivation and Context

Collect cluster endpoint data with cluster-resources collector.  Will no longer have to request customer to provide endpoint data when troubleshooting issues.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
https://github.com/replicatedhq/troubleshoot/issues/1046
-->

## Checklist

- [X] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] The commit message(s) are informative and highlight any breaking changes
- [X] Any documentation required has been added/updated.
         troubleshoot.sh PR: https://github.com/replicatedhq/troubleshoot.sh/pull/508

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
