### PR TITLE
feat(collector): checking existing service account before create running pod

### DIFF
--- a/pkg/collect/run.go
+++ b/pkg/collect/run.go
@@ -43,6 +43,10 @@ func (c *CollectRun) Collect(progressChan chan<- interface{}) (CollectorResult, 
 		serviceAccountName = c.Collector.ServiceAccountName
 	}
 
+	if err := checkForExistingServiceAccount(c.Client, namespace, serviceAccountName); err != nil {
+		return nil, err
+	}
+
 	runPodSpec := &troubleshootv1beta2.RunPod{
 		CollectorMeta: troubleshootv1beta2.CollectorMeta{
 			CollectorName: c.Collector.CollectorName,

--- a/pkg/collect/runner.go
+++ b/pkg/collect/runner.go
@@ -155,6 +155,10 @@ func createCollectorPod(client kubernetes.Interface, scheme *runtime.Scheme, own
 		return nil, err
 	}
 
+	if err := checkForExistingServiceAccount(client, namespace, serviceAccountName); err != nil {
+		return nil, err
+	}
+
 	imageName := "replicated/troubleshoot:latest"
 	imagePullPolicy := corev1.PullAlways
 

--- a/pkg/collect/util.go
+++ b/pkg/collect/util.go
@@ -227,3 +227,12 @@ func getTLSParamsFromSecret(ctx context.Context, client kubernetes.Interface, se
 
 	return caCert, clientCert, clientKey, nil
 }
+
+func checkForExistingServiceAccount(client kubernetes.Interface, namespace string, serviceAccountName string) error {
+	_, err := client.CoreV1().ServiceAccounts(namespace).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
+
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get service account %s", serviceAccountName)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description, Motivation and Context
- check the service account before creating the running pod
- if the service account didn't exist, create the service account first

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Related to PR: https://github.com/replicatedhq/troubleshoot/pull/1196#issuecomment-1579883857
Fixes: #1223 
## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
