### PR TITLE
explicitly test TCPConnectAnalyze unconditional fallthrough behavior

### DIFF
--- a/pkg/analyze/host_tcp_connect_test.go
+++ b/pkg/analyze/host_tcp_connect_test.go
@@ -86,6 +86,40 @@ func TestAnalyzeTCPConnect(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unknown status",
+			info: &collect.NetworkStatusResult{
+				Status: "test value",
+			},
+			hostAnalyzer: &troubleshootv1beta2.TCPConnectAnalyze{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "connection-refused",
+							Message: "Connection was refused",
+						},
+					},
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "connected",
+							Message: "Connection was successful",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "Unexpected TCP connection status",
+						},
+					},
+				},
+			},
+			result: []*AnalyzeResult{
+				{
+					Title:   "TCP Connection Attempt",
+					IsWarn:  true,
+					Message: "Unexpected TCP connection status",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

This adds a unit test that explicitly exercises the fallthrough behavior for the TCPConnectAnalyze function when there is no condition specified.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
