### PR TITLE
fix(message): fix message display issue

### DIFF
--- a/cmd/troubleshoot/cli/interactive_results.go
+++ b/cmd/troubleshoot/cli/interactive_results.go
@@ -7,11 +7,13 @@ import (
 	"path"
 	"time"
 
+	"github.com/mitchellh/go-wordwrap"
 	"github.com/pkg/errors"
 	ui "github.com/replicatedhq/termui/v3"
 	"github.com/replicatedhq/termui/v3/widgets"
 	"github.com/replicatedhq/troubleshoot/internal/util"
 	analyzerunner "github.com/replicatedhq/troubleshoot/pkg/analyze"
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
 )
 
 var (
@@ -178,7 +180,10 @@ func drawDetails(analysisResult *analyzerunner.AnalyzeResult) {
 
 	currentTop := 4
 	title := widgets.NewParagraph()
-	title.Text = analysisResult.Title
+	// WrapText is set to false to prevent internal wordwrap which is not accounting for the padding
+	title.WrapText = false
+	// For long title that lead to wrapping text, the terminal width is divided by 2 and deducted by MESSAGE_TEXT_PADDING to account for the padding
+	title.Text = wordwrap.WrapString(analysisResult.Title, uint(termWidth/2-constants.MESSAGE_TEXT_PADDING))
 	title.Border = false
 	if analysisResult.IsPass {
 		title.TextStyle = ui.NewStyle(ui.ColorGreen, ui.ColorClear, ui.ModifierBold)
@@ -187,34 +192,26 @@ func drawDetails(analysisResult *analyzerunner.AnalyzeResult) {
 	} else if analysisResult.IsFail {
 		title.TextStyle = ui.NewStyle(ui.ColorRed, ui.ColorClear, ui.ModifierBold)
 	}
-	height := estimateNumberOfLines(title.Text, termWidth/2)
+	height := util.EstimateNumberOfLines(title.Text)
 	title.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
 	ui.Render(title)
 	currentTop = currentTop + height + 1
 
 	message := widgets.NewParagraph()
-	message.Text = analysisResult.Message
+	// WrapText is set to false to prevent internal wordwrap which is not accounting for the padding
+	message.WrapText = false
+	// For long text that lead to wrapping text, the terminal width is divided by 2 and deducted by MESSAGE_TEXT_PADDING to account for the padding
+	message.Text = wordwrap.WrapString(analysisResult.Message, uint(termWidth/2-constants.MESSAGE_TEXT_PADDING))
+	if analysisResult.URI != "" {
+		// Add URL to the message with wordwrap
+		// Add emply lines as separator
+		urlText := wordwrap.WrapString(fmt.Sprintf("For more information: %s", analysisResult.URI), uint(termWidth/2-constants.MESSAGE_TEXT_PADDING))
+		message.Text = message.Text + "\n\n" + urlText
+	}
+	height = util.EstimateNumberOfLines(message.Text) + constants.MESSAGE_TEXT_LINES_MARGIN_TO_BOTTOM
 	message.Border = false
-	height = estimateNumberOfLines(message.Text, termWidth/2) + 2
 	message.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
 	ui.Render(message)
-	currentTop = currentTop + height + 1
-
-	if analysisResult.URI != "" {
-		uri := widgets.NewParagraph()
-		uri.Text = fmt.Sprintf("For more information: %s", analysisResult.URI)
-		uri.Border = false
-		// For long urls that lead to wrapping text, make the rectangle bigger by
-		// increasing the calculated height by 2
-		height = estimateNumberOfLines(uri.Text, termWidth/2) + 2
-		uri.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
-		ui.Render(uri)
-	}
-}
-
-func estimateNumberOfLines(text string, width int) int {
-	lines := len(text)/width + 1
-	return lines
 }
 
 func showSaved(filename string) {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -44,3 +44,11 @@ func AppName(name string) string {
 func SplitYAML(doc string) []string {
 	return strings.Split(doc, "\n---\n")
 }
+
+func EstimateNumberOfLines(text string) int {
+	n := strings.Count(text, "\n")
+	if len(text) > 0 && !strings.HasSuffix(text, "\n") {
+		n++
+	}
+	return n
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -70,4 +70,8 @@ const (
 
 	// Troubleshoot spec constants
 	Troubleshootv1beta2Kind = "troubleshoot.sh/v1beta2"
+
+	// TermUI Display Constants
+	MESSAGE_TEXT_PADDING                = 4
+	MESSAGE_TEXT_LINES_MARGIN_TO_BOTTOM = 4
 )

--- a/pkg/preflight/interactive_results.go
+++ b/pkg/preflight/interactive_results.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/go-wordwrap"
@@ -198,23 +199,24 @@ func drawDetails(analysisResult *analyzerunner.AnalyzeResult) {
 	message := widgets.NewParagraph()
 	message.WrapText = false
 	message.Text = wordwrap.WrapString(analysisResult.Message, uint(termWidth/2-constants.MESSAGE_TEXT_PADDING))
-	height = estimateNumberOfLines(message.Text, termWidth/2-constants.MESSAGE_TEXT_PADDING) + constants.MESSAGE_TEXT_LINES_MARGIN_TO_BOTTOM
+
+	if analysisResult.URI != "" {
+		urlText := wordwrap.WrapString(fmt.Sprintf("For more information: %s", analysisResult.URI), uint(termWidth/2-constants.MESSAGE_TEXT_PADDING))
+		message.Text = message.Text + "\n\n" + urlText
+	}
+	numberOfLines := linesStringCount(message.Text)
+	height = numberOfLines + constants.MESSAGE_TEXT_LINES_MARGIN_TO_BOTTOM
 	message.Border = false
 	message.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
 	ui.Render(message)
-	currentTop = currentTop + height + 1
+}
 
-	if analysisResult.URI != "" {
-		uri := widgets.NewParagraph()
-		uri.WrapText = false
-		uri.Text = fmt.Sprintf("For more information: %s", analysisResult.URI)
-		uri.Text = wordwrap.WrapString(uri.Text, uint(termWidth/2-constants.MESSAGE_TEXT_PADDING))
-		uri.Border = false
-		height = estimateNumberOfLines(uri.Text, termWidth/2) + constants.MESSAGE_TEXT_LINES_MARGIN_TO_BOTTOM
-		uri.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
-		ui.Render(uri)
-		currentTop = currentTop + height + 1
+func linesStringCount(s string) int {
+	n := strings.Count(s, "\n")
+	if len(s) > 0 && !strings.HasSuffix(s, "\n") {
+		n++
 	}
+	return n
 }
 
 func estimateNumberOfLines(text string, width int) int {

--- a/pkg/preflight/interactive_results.go
+++ b/pkg/preflight/interactive_results.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -174,6 +175,26 @@ func drawPreflightTable(analyzeResults []*analyzerunner.AnalyzeResult) {
 	ui.Render(table)
 }
 
+func wrapString(text string, lineWidth int) (string, int) {
+	words := strings.Fields(strings.TrimSpace(text))
+	if len(words) == 0 {
+		return text, 1
+	}
+	wrapped := words[0]
+	spaceLeft := lineWidth - len(wrapped)
+	for _, word := range words[1:] {
+		if len(word)+4 > spaceLeft {
+			wrapped += "\n" + word
+			spaceLeft = lineWidth - len(word)
+		} else {
+			wrapped += " " + word
+			spaceLeft -= 1 + len(word)
+		}
+	}
+	return wrapped, strings.Count(wrapped, "\n") + 4
+
+}
+
 func drawDetails(analysisResult *analyzerunner.AnalyzeResult) {
 	termWidth, _ := ui.TerminalDimensions()
 
@@ -194,9 +215,9 @@ func drawDetails(analysisResult *analyzerunner.AnalyzeResult) {
 	currentTop = currentTop + height + 1
 
 	message := widgets.NewParagraph()
-	message.Text = analysisResult.Message
+	message.WrapText = false
+	message.Text, height = wrapString(analysisResult.Message, termWidth/2)
 	message.Border = false
-	height = estimateNumberOfLines(message.Text, termWidth/2) + 2
 	message.SetRect(termWidth/2, currentTop, termWidth, currentTop+height)
 	ui.Render(message)
 	currentTop = currentTop + height + 1


### PR DESCRIPTION
## Description, Motivation and Context

- disable the wordwrap of termui, according to https://github.com/gizak/termui/issues/296. There is a bug.
- use internal [wordwrap](https://github.com/replicatedhq/termui/blob/f40076d26851cfd03eca89fed73cb708aab13296/v3/utils.go#L159C2-L159C2) function from termui, no need extra function and test
- word wrap for all title, url and messages deducted by MESSAGE_TEXT_PADDING to account for the padding
- return the calculation of the line based on the number of "\n"
- add padding-bottom line 4
- restructured the display of message url

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes: #1237

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
