### PR TITLE
get cluster-resources even if negotiating RBAC fails

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil/discovery"
@@ -100,6 +101,7 @@ EMPTY_NAMESPACE_FOUND:
 }
 
 func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (CollectorResult, error) {
+	klog.V(4).Infof("CollectClusterResources.Collect")
 	client, err := kubernetes.NewForConfig(c.ClientConfig)
 	if err != nil {
 		return nil, err
@@ -118,16 +120,19 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	var namespaceNames []string
 	if len(c.Collector.Namespaces) > 0 {
 		namespaces, namespaceErrors := getNamespaces(ctx, client, c.Collector.Namespaces)
+		klog.V(4).Infof("checking for namespaces access: %s", string(namespaces))
 		namespaceNames = c.Collector.Namespaces
 		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NAMESPACES)), bytes.NewBuffer(namespaces))
 		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_NAMESPACES)), marshalErrors(namespaceErrors))
 	} else if c.Namespace != "" {
 		namespace, namespaceErrors := getNamespace(ctx, client, c.Namespace)
+		klog.V(4).Infof("checking for namespace access: %s", string(namespace))
 		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NAMESPACES)), bytes.NewBuffer(namespace))
 		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_NAMESPACES)), marshalErrors(namespaceErrors))
 		namespaceNames = append(namespaceNames, c.Namespace)
 	} else {
 		namespaces, namespaceList, namespaceErrors := getAllNamespaces(ctx, client)
+		klog.V(4).Infof("checking for all namespaces access: %s", string(namespaces))
 		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NAMESPACES)), bytes.NewBuffer(namespaces))
 		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_NAMESPACES)), marshalErrors(namespaceErrors))
 		if namespaceList != nil {
@@ -139,6 +144,8 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	}
 
 	reviewStatuses, reviewStatusErrors := getSelfSubjectRulesReviews(ctx, client, namespaceNames)
+	s, _ := json.MarshalIndent(reviewStatuses, "", "  ")
+	klog.V(4).Infof("checking for self subject rules reviews: %s", s)
 
 	// auth cani
 	authCanI := authCanI(reviewStatuses, namespaceNames)
@@ -1661,6 +1668,7 @@ func events(ctx context.Context, client *kubernetes.Clientset, namespaces []stri
 func canCollectNamespaceResources(status *authorizationv1.SubjectRulesReviewStatus) bool {
 	// This is all very approximate
 
+	klog.V(4).Infof("canCollectNamespaceResources: %+v", status)
 	for _, resource := range status.ResourceRules {
 		hasGet := false
 		for _, verb := range resource.Verbs {
@@ -1668,6 +1676,7 @@ func canCollectNamespaceResources(status *authorizationv1.SubjectRulesReviewStat
 				hasGet = true
 				break
 			}
+			klog.V(4).Infof("resource: %+v hasGet: %t", resource, hasGet)
 		}
 
 		hasAPI := false
@@ -1676,6 +1685,7 @@ func canCollectNamespaceResources(status *authorizationv1.SubjectRulesReviewStat
 				hasAPI = true
 				break
 			}
+			klog.V(4).Infof("group: %+v hasGet: %t", group, hasAPI)
 		}
 
 		hasPods := false
@@ -1684,6 +1694,7 @@ func canCollectNamespaceResources(status *authorizationv1.SubjectRulesReviewStat
 				hasPods = true
 				break
 			}
+			klog.V(4).Infof("resource: %+v hasPods: %t", resource, hasPods)
 		}
 
 		if hasGet && hasAPI && hasPods {

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -144,8 +144,6 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	}
 
 	reviewStatuses, reviewStatusErrors := getSelfSubjectRulesReviews(ctx, client, namespaceNames)
-	s, _ := json.MarshalIndent(reviewStatuses, "", "  ")
-	klog.V(4).Infof("checking for self subject rules reviews: %s", s)
 
 	// auth cani
 	authCanI := authCanI(reviewStatuses, namespaceNames)
@@ -163,6 +161,7 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 			}
 		}
 		namespaceNames = filteredNamespaces
+		klog.V(4).Infof("filtered to namespaceNames %s", namespaceNames)
 	}
 
 	// pods
@@ -1605,6 +1604,10 @@ func getSelfSubjectRulesReviews(ctx context.Context, client *kubernetes.Clientse
 			continue
 		}
 
+		if response.Status.Incomplete == true {
+			errorsByNamespace[namespace] = response.Status.EvaluationError
+		}
+
 		statusByNamespace[namespace] = response.Status.DeepCopy()
 	}
 
@@ -1667,6 +1670,11 @@ func events(ctx context.Context, client *kubernetes.Clientset, namespaces []stri
 
 func canCollectNamespaceResources(status *authorizationv1.SubjectRulesReviewStatus) bool {
 	// This is all very approximate
+
+	if status.Incomplete && (status.EvaluationError == constants.SELFSUBJECTRULESREVIEW_ERROR_AUTHORIZATION_WEBHOOK_UNSUPPORTED) {
+		klog.V(4).Infof("could not negotiate RBAC because of an unsupported authorizer webhook; try to get resources from this namespace anyway.")
+		return true
+	}
 
 	klog.V(4).Infof("canCollectNamespaceResources: %+v", status)
 	for _, resource := range status.ResourceRules {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -55,6 +55,9 @@ const (
 	CLUSTER_RESOURCES_PRIORITY_CLASS              = "priorityclasses"
 	CLUSTER_RESOURCES_ENDPOINTS                   = "endpoints"
 
+	// SelfSubjectRulesReview evaluation responses
+	SELFSUBJECTRULESREVIEW_ERROR_AUTHORIZATION_WEBHOOK_UNSUPPORTED = "webhook authorizer does not support user rule resolution"
+
 	// Custom exit codes
 	EXIT_CODE_CATCH_ALL   = 1
 	EXIT_CODE_SPEC_ISSUES = 2


### PR DESCRIPTION
## Description, Motivation and Context

#1167 

https://github.com/kubernetes/kubernetes/issues/65744 leads some clusters using authorization webhooks to fail to report a users' authorizations correctly, so cluster-resources collector skips over some namespaces.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
