### PR TITLE
JSONPath support for json compare analyzer

### DIFF
--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -732,6 +732,8 @@ spec:
                           type: BoolString
                         fileName:
                           type: string
+                        jsonPath:
+                          type: string
                         outcomes:
                           items:
                             properties:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -732,6 +732,8 @@ spec:
                           type: BoolString
                         fileName:
                           type: string
+                        jsonPath:
+                          type: string
                         outcomes:
                           items:
                             properties:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -763,6 +763,8 @@ spec:
                           type: BoolString
                         fileName:
                           type: string
+                        jsonPath:
+                          type: string
                         outcomes:
                           items:
                             properties:

--- a/pkg/analyze/json_compare_test.go
+++ b/pkg/analyze/json_compare_test.go
@@ -541,6 +541,144 @@ func Test_jsonCompare(t *testing.T) {
 			},
 			fileContents: []byte(``),
 		},
+		{
+			name: "jsonpath comparison",
+			analyzer: troubleshootv1beta2.JsonCompare{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "pass",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+						},
+					},
+				},
+				CollectorName: "jsonpath-compare-1",
+				FileName:      "jsonpath-compare-1.json",
+				JsonPath:      "{$.morestuff[0]}",
+				Value: `{
+					"foo": {
+						"bar": 123
+					}
+				}`,
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  true,
+				IsWarn:  false,
+				IsFail:  false,
+				Title:   "jsonpath-compare-1",
+				Message: "pass",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+			},
+			fileContents: []byte(`{
+				"foo": "bar",
+				"stuff": {
+					"foo": "bar",
+					"bar": true
+				},
+				"morestuff": [
+					{
+						"foo": {
+							"bar": 123
+						}
+					}
+				]
+			}`),
+		},
+		{
+			name: "jsonpath comparison, but fail on match",
+			analyzer: troubleshootv1beta2.JsonCompare{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "pass",
+							When:    "false",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+							When:    "true",
+						},
+					},
+				},
+				CollectorName: "jsonpath-compare-1-1",
+				FileName:      "jsonpath-compare-1-1.json",
+				JsonPath:      "{$.morestuff[0].foo.bar}",
+				Value:         `123`,
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  false,
+				IsWarn:  false,
+				IsFail:  true,
+				Title:   "jsonpath-compare-1-1",
+				Message: "fail",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+			},
+			fileContents: []byte(`{
+				"foo": "bar",
+				"stuff": {
+					"foo": "bar",
+					"bar": true
+				},
+				"morestuff": [
+					{
+						"foo": {
+							"bar": 123
+						}
+					}
+				]
+			}`),
+		},
+		{
+			name: "jsonpath comparison, multiple values",
+			analyzer: troubleshootv1beta2.JsonCompare{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "pass",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+						},
+					},
+				},
+				CollectorName: "jsonpath-compare-2",
+				FileName:      "jsonpath-compare-2.json",
+				JsonPath:      "{$..bar}",
+				Value:         `[true, 123]`,
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  true,
+				IsWarn:  false,
+				IsFail:  false,
+				Title:   "jsonpath-compare-2",
+				Message: "pass",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+			},
+			fileContents: []byte(`{
+				"foo": "bar",
+				"stuff": {
+					"foo": "bar",
+					"bar": true
+				},
+				"morestuff": [
+					{
+						"foo": {
+							"bar": 123
+						}
+					}
+				]
+			}`),
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -161,6 +161,7 @@ type JsonCompare struct {
 	CollectorName string     `json:"collectorName,omitempty" yaml:"collectorName,omitempty"`
 	FileName      string     `json:"fileName,omitempty" yaml:"fileName,omitempty"`
 	Path          string     `json:"path,omitempty" yaml:"path,omitempty"`
+	JsonPath      string     `json:"jsonPath,omitempty" yaml:"jsonPath,omitempty"`
 	Value         string     `json:"value,omitempty" yaml:"value,omitempty"`
 	Outcomes      []*Outcome `json:"outcomes" yaml:"outcomes"`
 }

--- a/schemas/analyzer-troubleshoot-v1beta2.json
+++ b/schemas/analyzer-troubleshoot-v1beta2.json
@@ -1092,6 +1092,9 @@
                   "fileName": {
                     "type": "string"
                   },
+                  "jsonPath": {
+                    "type": "string"
+                  },
                   "outcomes": {
                     "type": "array",
                     "items": {

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -1092,6 +1092,9 @@
                   "fileName": {
                     "type": "string"
                   },
+                  "jsonPath": {
+                    "type": "string"
+                  },
                   "outcomes": {
                     "type": "array",
                     "items": {

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -1138,6 +1138,9 @@
                   "fileName": {
                     "type": "string"
                   },
+                  "jsonPath": {
+                    "type": "string"
+                  },
                   "outcomes": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
This adds JSONPath support to the json compare analyzer using k8s.io/client-go/util/jsonpath implementation.

To preserve backwards compatibility a new attribute, `JsonPath, is added to the compare analyzer as opposed to changing how `Path` works. Only one should be set, but preference is given to `Path`, again to maintain backwards compatibility.

As a convience for users, if the result of running the JSONPath expression returns a single value, that value is unwrapped from its enclosing array and used as the comparison with `Value`. This isn't strictly compatible with how JSONPath works (all results are wrapped in an array), but it's easier for end users who are expecting a single result from their JSONPath expression.

## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
