### PR TITLE
feat(analyzer): add detailed message for unhealthy pod

### DIFF
--- a/pkg/analyze/cluster_pod_statuses.go
+++ b/pkg/analyze/cluster_pod_statuses.go
@@ -77,7 +77,7 @@ func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChi
 
 	for _, pod := range pods {
 		if pod.Status.Reason == "" {
-			pod.Status.Reason = k8sutil.GetPodStatusReason(&pod)
+			pod.Status.Reason, pod.Status.Message = k8sutil.GetPodStatusReason(&pod)
 		}
 
 		for _, outcome := range analyzer.Outcomes {
@@ -149,7 +149,7 @@ func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChi
 			}
 
 			if r.Message == "" {
-				r.Message = "Pod {{ .Namespace }}/{{ .Name }} status is {{ .Status.Reason }}"
+				r.Message = "Pod {{ .Namespace }}/{{ .Name }} status is {{ .Status.Reason }} with messages. {{ .Status.Message }}"
 			}
 
 			tmpl := template.New("pod")

--- a/pkg/analyze/cluster_pod_statuses.go
+++ b/pkg/analyze/cluster_pod_statuses.go
@@ -33,7 +33,7 @@ func (a *AnalyzeClusterPodStatuses) IsExcluded() (bool, error) {
 }
 
 func (a *AnalyzeClusterPodStatuses) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
-	results, err := clusterPodStatuses(a.analyzer, findFiles)
+	results, err := clusterPodStatuses(a.analyzer, findFiles, findFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (a *AnalyzeClusterPodStatuses) Analyze(getFile getCollectedFileContents, fi
 	return results, nil
 }
 
-func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChildCollectedFileContents getChildCollectedFileContents) ([]*AnalyzeResult, error) {
+func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChildCollectedFileContents getChildCollectedFileContents, getChildCollectedFileContentsEvents getChildCollectedFileContents) ([]*AnalyzeResult, error) {
 	excludeFiles := []string{}
 	collected, err := getChildCollectedFileContents(filepath.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_PODS, "*.json"), excludeFiles)
 	if err != nil {
@@ -83,7 +83,7 @@ func clusterPodStatuses(analyzer *troubleshootv1beta2.ClusterPodStatuses, getChi
 
 		if pod.Status.Message == "" {
 			messages := []string{}
-			collectedEvents, err := getChildCollectedFileContents(filepath.Join(constants.CLUSTER_RESOURCES_DIR, "events", fmt.Sprintf("%s.json", pod.Namespace)), excludeFiles)
+			collectedEvents, err := getChildCollectedFileContentsEvents(filepath.Join(constants.CLUSTER_RESOURCES_DIR, "events", fmt.Sprintf("%s.json", pod.Namespace)), excludeFiles)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to read collected events")
 			}

--- a/pkg/analyze/cluster_pod_statuses_test.go
+++ b/pkg/analyze/cluster_pod_statuses_test.go
@@ -448,6 +448,222 @@ func Test_ClusterPodStatuses(t *testing.T) {
 				"cluster-resources/events/message-container-creating-failed-mount.json": []byte(messageContainerCreatingFailedMountEvents),
 			},
 		},
+		{
+			name: "show_message_of_pod_crashloop_backoff",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_message_of_pod_crashloop_backoff",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-pod-crashloop-backoff"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_message_of_pod_crashloop_backoff",
+					Message: "A Pod, init-demo, is unhealthy with a status of: CrashLoopBackOff. Message is: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-pod-crashloop-backoff",
+						Name:       "init-demo",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-pod-crashloop-backoff.json": []byte(messagePodCrashLoopBackOff),
+			},
+		},
+		{
+			name: "show_message_of_init_pod_crashloop_backoff",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_message_of_init_pod_crashloop_backoff",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-pod-init-crashloop-backoff"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_message_of_init_pod_crashloop_backoff",
+					Message: "A Pod, init-demo2, is unhealthy with a status of: Init:RunContainerError. Message is: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-pod-init-crashloop-backoff",
+						Name:       "init-demo2",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-pod-init-crashloop-backoff.json": []byte(messagePodInitCrashLoopBackOff),
+			},
+			eventFiles: map[string][]byte{
+				"cluster-resources/events/message-pod-init-crashloop-backoff.json": []byte(messagePodInitCrashLoopBackOffEvents),
+			},
+		},
+		{
+			name: "show_message_of_pending_pod_resource",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_message_of_pending_pod_resource",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-pending-pod-resources"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_message_of_pending_pod_resource",
+					Message: "A Pod, pending-pod-resources-5fddcf7688-djjfc, is unhealthy with a status of: Pending. Message is: 0/1 nodes are available: 1 Insufficient nvidia.com/gpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-pending-pod-resources",
+						Name:       "pending-pod-resources-5fddcf7688-djjfc",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-pending-pod-resources.json": []byte(messagePendingPodResources),
+			},
+		},
+		{
+			name: "show_message_of_oom_killed_pod",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_message_of_oom_killed_pod",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-oomkill-pod"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_message_of_oom_killed_pod",
+					Message: "A Pod, oom-kill-job3-gbb89, is unhealthy with a status of: OOMKilled. Message is: ExitCode:137",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-oomkill-pod",
+						Name:       "oom-kill-job3-gbb89",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-oomkill-pod.json": []byte(messageOOMKillPod),
+			},
+		},
+		{
+			name: "show_message_of_image_pull_fail",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_message_of_image_pull_fail",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-image-pull-fail"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_message_of_image_pull_fail",
+					Message: "A Pod, no-image-deployment-849c4c4958-rxqmt, is unhealthy with a status of: ErrImagePull. Message is: Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": x509: certificate is not valid for any names, but wanted to match noimage.com. Error: ErrImagePull. Error: ImagePullBackOff",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-image-pull-fail",
+						Name:       "no-image-deployment-849c4c4958-rxqmt",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-image-pull-fail.json": []byte(messageImagePullFail),
+			},
+			eventFiles: map[string][]byte{
+				"cluster-resources/events/message-image-pull-fail.json": []byte(messageImagePullFailEvents),
+			},
+		},
+		{
+			name: "show_none_message_of_no_events_pod",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_none_message_of_no_events_pod",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-image-pull-fail"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_none_message_of_no_events_pod",
+					Message: "A Pod, no-image-deployment-849c4c4958-rxqmt, is unhealthy with a status of: ErrImagePull. Message is: None",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-image-pull-fail",
+						Name:       "no-image-deployment-849c4c4958-rxqmt",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-image-pull-fail.json": []byte(messageImagePullFail),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/analyze/cluster_pod_statuses_test.go
+++ b/pkg/analyze/cluster_pod_statuses_test.go
@@ -374,6 +374,41 @@ func Test_ClusterPodStatuses(t *testing.T) {
 				"cluster-resources/pods/other-unhealthy.json":   []byte(otherPodsUnhealthy),
 			},
 		},
+		{
+			name: "show_message_of_pending_pods_with_wrong_node_affinity",
+			analyzer: troubleshootv1beta2.ClusterPodStatuses{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "show_message_of_pending_pods_with_wrong_node_affinity",
+				},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							When:    "!= Healthy",
+							Message: "A Pod, {{ .Name }}, is unhealthy with a status of: {{ .Status.Reason }}. Message is: {{ .Status.Message }}",
+						},
+					},
+				},
+				Namespaces: []string{"message-pending-node-affinity"},
+			},
+			expectResult: []*AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "show_message_of_pending_pods_with_wrong_node_affinity",
+					Message: "A Pod, kotsadm-b6cb54c8f-zgzrn, is unhealthy with a status of: Pending. Message is: 0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.",
+					InvolvedObject: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  "message-pending-node-affinity",
+						Name:       "kotsadm-b6cb54c8f-zgzrn",
+					},
+				},
+			},
+			files: map[string][]byte{
+				"cluster-resources/pods/message-pending-node-affinity.json": []byte(messagePendingNodeAffinity),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/analyze/data_test.go
+++ b/pkg/analyze/data_test.go
@@ -45,3 +45,6 @@ var defaultPodsUnhealthy string
 
 //go:embed files/pods/other-unhealthy.json
 var otherPodsUnhealthy string
+
+//go:embed files/pods/message-pending-node-affinity.json
+var messagePendingNodeAffinity string

--- a/pkg/analyze/data_test.go
+++ b/pkg/analyze/data_test.go
@@ -54,3 +54,24 @@ var messageContainerCreatingFailedMount string
 
 //go:embed files/events/message-container-creating-failed-mount.json
 var messageContainerCreatingFailedMountEvents string
+
+//go:embed files/pods/message-pod-crashloop-backoff.json
+var messagePodCrashLoopBackOff string
+
+//go:embed files/pods/message-pod-init-crashloop-backoff.json
+var messagePodInitCrashLoopBackOff string
+
+//go:embed files/events/message-pod-init-crashloop-backoff.json
+var messagePodInitCrashLoopBackOffEvents string
+
+//go:embed files/pods/message-pending-pod-resources.json
+var messagePendingPodResources string
+
+//go:embed files/pods/message-oomkill-pod.json
+var messageOOMKillPod string
+
+//go:embed files/pods/message-image-pull-fail.json
+var messageImagePullFail string
+
+//go:embed files/events/message-image-pull-fail.json
+var messageImagePullFailEvents string

--- a/pkg/analyze/data_test.go
+++ b/pkg/analyze/data_test.go
@@ -48,3 +48,9 @@ var otherPodsUnhealthy string
 
 //go:embed files/pods/message-pending-node-affinity.json
 var messagePendingNodeAffinity string
+
+//go:embed files/pods/message-container-creating-failed-mount.json
+var messageContainerCreatingFailedMount string
+
+//go:embed files/events/message-container-creating-failed-mount.json
+var messageContainerCreatingFailedMountEvents string

--- a/pkg/analyze/files/events/message-container-creating-failed-mount.json
+++ b/pkg/analyze/files/events/message-container-creating-failed-mount.json
@@ -1,0 +1,4064 @@
+{
+  "kind": "EventList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "954529"
+  },
+  "items": [
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-7828f.17706aa0ee99e24f",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "8ff136be-d0ba-4a62-8a88-459ee38d7448",
+        "resourceVersion": "953924",
+        "creationTimestamp": "2023-07-10T05:31:39Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:31:39Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-7828f",
+        "uid": "8ffb51a6-6a35-456a-a566-cafb05f7d36a",
+        "apiVersion": "v1",
+        "resourceVersion": "953918"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/crashpod-f9b59484-7828f to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:31:39.694297Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-7828f.17706aa121b35e80",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "5004a54d-032b-4516-ab32-c2778413354b",
+        "resourceVersion": "953927",
+        "creationTimestamp": "2023-07-10T05:31:40Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:31:40Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-7828f",
+        "uid": "8ffb51a6-6a35-456a-a566-cafb05f7d36a",
+        "apiVersion": "v1",
+        "resourceVersion": "953921",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"bash\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:31:40Z",
+      "lastTimestamp": "2023-07-10T05:31:40Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-7828f.17706aa23ecb9d4e",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "8c8f0c95-37eb-4686-a7a0-498ee44b93eb",
+        "resourceVersion": "953932",
+        "creationTimestamp": "2023-07-10T05:31:45Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:31:45Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-7828f",
+        "uid": "8ffb51a6-6a35-456a-a566-cafb05f7d36a",
+        "apiVersion": "v1",
+        "resourceVersion": "953921",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"bash\" in 4.783086211s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:31:45Z",
+      "lastTimestamp": "2023-07-10T05:31:45Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-7828f.17706aa2424d5703",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ebb9a55e-ca23-41bc-b165-64475ba5aa02",
+        "resourceVersion": "953933",
+        "creationTimestamp": "2023-07-10T05:31:45Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:31:45Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-7828f",
+        "uid": "8ffb51a6-6a35-456a-a566-cafb05f7d36a",
+        "apiVersion": "v1",
+        "resourceVersion": "953921",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Created",
+      "message": "Created container crashpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:31:45Z",
+      "lastTimestamp": "2023-07-10T05:31:45Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-7828f.17706aa2460b4264",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "0f6cf357-a264-4bde-8326-492cd73bede8",
+        "resourceVersion": "953934",
+        "creationTimestamp": "2023-07-10T05:31:45Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:31:45Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-7828f",
+        "uid": "8ffb51a6-6a35-456a-a566-cafb05f7d36a",
+        "apiVersion": "v1",
+        "resourceVersion": "953921",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Started",
+      "message": "Started container crashpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:31:45Z",
+      "lastTimestamp": "2023-07-10T05:31:45Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-7828f.17706ac181da17e4",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ac641bcb-e4db-43e6-a058-63c9544549b3",
+        "resourceVersion": "954039",
+        "creationTimestamp": "2023-07-10T05:33:59Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:33:59Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-7828f",
+        "uid": "8ffb51a6-6a35-456a-a566-cafb05f7d36a",
+        "apiVersion": "v1",
+        "resourceVersion": "953921",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Killing",
+      "message": "Stopping container crashpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:33:59Z",
+      "lastTimestamp": "2023-07-10T05:33:59Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706ac183555f6e",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "c99310af-7ba2-430a-912c-65b94ff21258",
+        "resourceVersion": "954045",
+        "creationTimestamp": "2023-07-10T05:33:59Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:33:59Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1",
+        "resourceVersion": "954040"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/crashpod-f9b59484-fpzht to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:33:59.628571Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706ac1a1e6134b",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "8c88abfa-17ec-49d3-839d-326cdedc1842",
+        "resourceVersion": "954050",
+        "creationTimestamp": "2023-07-10T05:34:00Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:00Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1",
+        "resourceVersion": "954041",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"bash\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:00Z",
+      "lastTimestamp": "2023-07-10T05:34:00Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706ac22d668ff2",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "9653b3e5-808c-42ba-8637-3983cd311ced",
+        "resourceVersion": "954055",
+        "creationTimestamp": "2023-07-10T05:34:02Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:02Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1",
+        "resourceVersion": "954041",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"bash\" in 2.340432126s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:02Z",
+      "lastTimestamp": "2023-07-10T05:34:02Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706ac23017099f",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "10f18f1c-1671-45a9-b09c-cf85ccb7e236",
+        "resourceVersion": "954056",
+        "creationTimestamp": "2023-07-10T05:34:02Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:02Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1",
+        "resourceVersion": "954041",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Created",
+      "message": "Created container crashpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:02Z",
+      "lastTimestamp": "2023-07-10T05:34:02Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706ac233e51a76",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ed128e56-7703-4b65-be07-8a7473897bed",
+        "resourceVersion": "954057",
+        "creationTimestamp": "2023-07-10T05:34:02Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:02Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1",
+        "resourceVersion": "954041",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Started",
+      "message": "Started container crashpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:02Z",
+      "lastTimestamp": "2023-07-10T05:34:02Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706ac375375567",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "0524a17d-5f1e-4510-a983-6992afce4df8",
+        "resourceVersion": "954104",
+        "creationTimestamp": "2023-07-10T05:34:07Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:39Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1",
+        "resourceVersion": "954041",
+        "fieldPath": "spec.containers{crashpod}"
+      },
+      "reason": "Killing",
+      "message": "Stopping container crashpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:07Z",
+      "lastTimestamp": "2023-07-10T05:34:39Z",
+      "count": 2,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484-fpzht.17706acab9cf0e83",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "4175abb9-31cc-452b-9459-9453ea45ed68",
+        "resourceVersion": "954105",
+        "creationTimestamp": "2023-07-10T05:34:39Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:39Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484-fpzht",
+        "uid": "ad623dde-ad9b-42c4-97b8-34f2cb89905b",
+        "apiVersion": "v1"
+      },
+      "reason": "FailedKillPod",
+      "message": "error killing pod: failed to \"KillContainer\" for \"crashpod\" with KillContainerError: \"rpc error: code = Unknown desc = Error response from daemon: No such container: cff6df8c234e52aed25ba1f3b507e37368da5fc2d6f6390a46908344c5de8976\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:39Z",
+      "lastTimestamp": "2023-07-10T05:34:39Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484.17706aa0ee666ab1",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "b2035e95-02fa-47bf-bf22-bc96763b4346",
+        "resourceVersion": "953919",
+        "creationTimestamp": "2023-07-10T05:31:39Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:31:39Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484",
+        "uid": "9f9ca1c4-e9ee-405e-9757-efab12b0d20f",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953915"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: crashpod-f9b59484-7828f",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:31:39Z",
+      "lastTimestamp": "2023-07-10T05:31:39Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod-f9b59484.17706ac182dd75ad",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "da205e0c-2e92-49ac-8626-68557677bcb2",
+        "resourceVersion": "954042",
+        "creationTimestamp": "2023-07-10T05:33:59Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:33:59Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod-f9b59484",
+        "uid": "9f9ca1c4-e9ee-405e-9757-efab12b0d20f",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953937"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: crashpod-f9b59484-fpzht",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:33:59Z",
+      "lastTimestamp": "2023-07-10T05:33:59Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "crashpod.17706aa0ee252ff6",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "4e83447c-044a-4c11-91f0-94c3de755810",
+        "resourceVersion": "953917",
+        "creationTimestamp": "2023-07-10T05:31:39Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:31:39Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "crashpod",
+        "uid": "9a3826fd-d86f-449d-8551-ed09bba2376a",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953914"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set crashpod-f9b59484 to 1",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:31:39Z",
+      "lastTimestamp": "2023-07-10T05:31:39Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.177069ccd065ca1e",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "74e26478-620c-407a-a1b4-6fced3d979f0",
+        "resourceVersion": "953045",
+        "creationTimestamp": "2023-07-10T05:16:28Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:16:28Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "74804a80-0e4a-4e7a-8524-e28675305d24",
+        "apiVersion": "v1",
+        "resourceVersion": "953043"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/failing-liveness-pod to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:16:28.654504Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.177069ccef31bf16",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "d83e2e21-a2c0-4fdd-81d3-47e8d002a8b8",
+        "resourceVersion": "953047",
+        "creationTimestamp": "2023-07-10T05:16:29Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:16:29Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "74804a80-0e4a-4e7a-8524-e28675305d24",
+        "apiVersion": "v1",
+        "resourceVersion": "953044",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"busybox\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:16:29Z",
+      "lastTimestamp": "2023-07-10T05:16:29Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.177069ce09403b9c",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ff27c082-724b-4704-86d9-c9f801b4d1e6",
+        "resourceVersion": "953051",
+        "creationTimestamp": "2023-07-10T05:16:33Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:16:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "74804a80-0e4a-4e7a-8524-e28675305d24",
+        "apiVersion": "v1",
+        "resourceVersion": "953044",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"busybox\" in 4.732098003s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:16:33Z",
+      "lastTimestamp": "2023-07-10T05:16:33Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.177069ce0ae63048",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "70dc7835-c11f-40c7-8343-eec4f28f7b30",
+        "resourceVersion": "953052",
+        "creationTimestamp": "2023-07-10T05:16:33Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:16:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "74804a80-0e4a-4e7a-8524-e28675305d24",
+        "apiVersion": "v1",
+        "resourceVersion": "953044",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Created",
+      "message": "Created container my-container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:16:33Z",
+      "lastTimestamp": "2023-07-10T05:16:33Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.177069ce0e0501ad",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "dd8d4af1-c685-44cd-89d7-f04f207428ca",
+        "resourceVersion": "953053",
+        "creationTimestamp": "2023-07-10T05:16:33Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:16:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "74804a80-0e4a-4e7a-8524-e28675305d24",
+        "apiVersion": "v1",
+        "resourceVersion": "953044",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Started",
+      "message": "Started container my-container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:16:33Z",
+      "lastTimestamp": "2023-07-10T05:16:33Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.177069cf3b8778b6",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "5e5b0c1b-4ced-40ba-8872-f4e2b0aa86cc",
+        "resourceVersion": "953300",
+        "creationTimestamp": "2023-07-10T05:16:39Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:21:34Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "74804a80-0e4a-4e7a-8524-e28675305d24",
+        "apiVersion": "v1",
+        "resourceVersion": "953044",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Unhealthy",
+      "message": "Liveness probe failed: ",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:16:39Z",
+      "lastTimestamp": "2023-07-10T05:21:34Z",
+      "count": 60,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a3988219750",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "f4634210-ab01-4fa9-82e3-e01dafe05b6b",
+        "resourceVersion": "953432",
+        "creationTimestamp": "2023-07-10T05:24:15Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:24:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953430"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/failing-liveness-pod to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:24:15.593510Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a39a6fd3b42",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "df39b622-ea74-4efc-98d7-c1bcbda84c75",
+        "resourceVersion": "953567",
+        "creationTimestamp": "2023-07-10T05:24:16Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:26:46Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"busybox\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:24:16Z",
+      "lastTimestamp": "2023-07-10T05:26:46Z",
+      "count": 4,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a3a29b227d8",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "d9e511dd-2b81-40f9-a0d4-77d4b5ae757e",
+        "resourceVersion": "953438",
+        "creationTimestamp": "2023-07-10T05:24:18Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:24:18Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"busybox\" in 2.192877584s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:24:18Z",
+      "lastTimestamp": "2023-07-10T05:24:18Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a3a2b701853",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "f680f272-ff0a-4e9b-99a6-1644a7b8430b",
+        "resourceVersion": "953527",
+        "creationTimestamp": "2023-07-10T05:24:18Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:25:58Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Created",
+      "message": "Created container my-container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:24:18Z",
+      "lastTimestamp": "2023-07-10T05:25:58Z",
+      "count": 3,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a3a2eb92af1",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "78df4ff9-02b9-45c6-aa64-b9c3506be57f",
+        "resourceVersion": "953528",
+        "creationTimestamp": "2023-07-10T05:24:18Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:25:58Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Started",
+      "message": "Started container my-container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:24:18Z",
+      "lastTimestamp": "2023-07-10T05:25:58Z",
+      "count": 3,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a3bf2588d79",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "11603266-5ad4-4986-abdb-0a402259f4e0",
+        "resourceVersion": "953544",
+        "creationTimestamp": "2023-07-10T05:24:25Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:26:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Unhealthy",
+      "message": "Liveness probe failed: ",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:24:25Z",
+      "lastTimestamp": "2023-07-10T05:26:15Z",
+      "count": 9,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a3e476dc552",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "bf5e8fec-c2a7-4051-b492-01a64ba02f63",
+        "resourceVersion": "953545",
+        "creationTimestamp": "2023-07-10T05:24:35Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:26:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Killing",
+      "message": "Container my-container failed liveness probe, will be restarted",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:24:35Z",
+      "lastTimestamp": "2023-07-10T05:26:15Z",
+      "count": 3,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a45c3eb585f",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "273a047a-9bfc-4983-b6b5-070a888b99c2",
+        "resourceVersion": "953481",
+        "creationTimestamp": "2023-07-10T05:25:08Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:25:08Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"busybox\" in 2.044691792s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:25:08Z",
+      "lastTimestamp": "2023-07-10T05:25:08Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "failing-liveness-pod.17706a516ea9e99a",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "975f9d76-aa07-4e38-87b7-5340aafac12a",
+        "resourceVersion": "953526",
+        "creationTimestamp": "2023-07-10T05:25:58Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:25:58Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "failing-liveness-pod",
+        "uid": "c6e243c6-21c3-4d14-96f6-49f6a5dc3efc",
+        "apiVersion": "v1",
+        "resourceVersion": "953431",
+        "fieldPath": "spec.containers{my-container}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"busybox\" in 2.17109096s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:25:58Z",
+      "lastTimestamp": "2023-07-10T05:25:58Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2.177058503f8168a2",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "94cd1ce0-8958-4b37-a5c4-bb284dc72cd0",
+        "resourceVersion": "952992",
+        "creationTimestamp": "2023-07-09T23:56:01Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:15:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "init-demo2",
+        "uid": "47e732ac-7a2f-4a01-afbd-943309bbc91f",
+        "apiVersion": "v1",
+        "resourceVersion": "938905",
+        "fieldPath": "spec.initContainers{install}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-09T23:56:01Z",
+      "lastTimestamp": "2023-07-10T05:15:47Z",
+      "count": 1464,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-47b9z.177064b23b5112ef",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "672611ac-5bb0-4384-b61c-a956a058acd9",
+        "resourceVersion": "952870",
+        "creationTimestamp": "2023-07-10T03:42:56Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:13:02Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-47b9z",
+        "uid": "7b5beabd-9840-4577-9f3e-7ebbcaf8397a",
+        "apiVersion": "v1",
+        "resourceVersion": "948723",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T03:42:56Z",
+      "lastTimestamp": "2023-07-10T05:13:02Z",
+      "count": 392,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6ae700baa0",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "9bdd2912-9e20-49e9-9060-b4e2acff3dfd",
+        "resourceVersion": "953638",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953629"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/no-image-deployment-849c4c4958-7fp5q to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:27:47.638594Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6b1a250e35",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ede0b430-7570-4bec-ba69-cf35e63a25da",
+        "resourceVersion": "953775",
+        "creationTimestamp": "2023-07-10T05:27:48Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:10Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953635",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:48Z",
+      "lastTimestamp": "2023-07-10T05:29:10Z",
+      "count": 4,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6b734d070f",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "cf1d7703-950f-4a48-892b-a8ae739474a1",
+        "resourceVersion": "953776",
+        "creationTimestamp": "2023-07-10T05:27:49Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:10Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953635",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:49Z",
+      "lastTimestamp": "2023-07-10T05:29:10Z",
+      "count": 3,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6b734d7bec",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "9f4056f5-92a8-4cf9-b744-06994d7b1910",
+        "resourceVersion": "953777",
+        "creationTimestamp": "2023-07-10T05:27:50Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:10Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953635",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ErrImagePull",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:49Z",
+      "lastTimestamp": "2023-07-10T05:29:10Z",
+      "count": 4,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6b95de2f48",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "8ed7d58a-8c27-4be0-8682-6bf804729c57",
+        "resourceVersion": "953989",
+        "creationTimestamp": "2023-07-10T05:27:50Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:32:56Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953635",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:50Z",
+      "lastTimestamp": "2023-07-10T05:32:56Z",
+      "count": 20,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6b95de858b",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "4f54d657-d7b8-4392-a61a-c630e89b425a",
+        "resourceVersion": "953811",
+        "creationTimestamp": "2023-07-10T05:27:50Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:37Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953635",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ImagePullBackOff",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:50Z",
+      "lastTimestamp": "2023-07-10T05:29:37Z",
+      "count": 6,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-7fp5q.17706a6f09e18946",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "6ce33714-2072-4065-bfe6-d177187e8b58",
+        "resourceVersion": "953683",
+        "creationTimestamp": "2023-07-10T05:28:05Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:28:05Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-7fp5q",
+        "uid": "7c99c7bc-cc4f-4497-85bd-0720586f167f",
+        "apiVersion": "v1",
+        "resourceVersion": "953635",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Head \"https://noimage.com/v2/no-such-image/manifests/latest\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:28:05Z",
+      "lastTimestamp": "2023-07-10T05:28:05Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-bz5zn.177064b23b52ca8c",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "77618bef-8cf2-482d-b7b3-e7650a5d1bd3",
+        "resourceVersion": "952863",
+        "creationTimestamp": "2023-07-10T03:42:56Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:12:55Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-bz5zn",
+        "uid": "51c5d742-19e8-4273-9c92-2ee9a2b8752e",
+        "apiVersion": "v1",
+        "resourceVersion": "948725",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T03:42:56Z",
+      "lastTimestamp": "2023-07-10T05:12:55Z",
+      "count": 394,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-fnzhh.177064b186411058",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "34ed97be-29e5-4311-a253-cddc5ceb26c5",
+        "resourceVersion": "952865",
+        "creationTimestamp": "2023-07-10T03:42:53Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:12:56Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-fnzhh",
+        "uid": "52b60b8d-4bd7-4e86-811d-63a2683157fc",
+        "apiVersion": "v1",
+        "resourceVersion": "948726",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T03:42:53Z",
+      "lastTimestamp": "2023-07-10T05:12:56Z",
+      "count": 391,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a6ae70280ba",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "931651a9-61db-413e-a961-90ad076cdfc9",
+        "resourceVersion": "953636",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953627"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/no-image-deployment-849c4c4958-l595s to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:27:47.638713Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a6b1a2c0b1b",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "7b2c1097-52a9-4823-bc82-c8e4b87a299b",
+        "resourceVersion": "953792",
+        "creationTimestamp": "2023-07-10T05:27:48Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:24Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:48Z",
+      "lastTimestamp": "2023-07-10T05:29:24Z",
+      "count": 4,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a6bc21072c8",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ac158a44-59c7-425e-93f7-5acf90457f6a",
+        "resourceVersion": "953731",
+        "creationTimestamp": "2023-07-10T05:27:51Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:28:40Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Head \"https://noimage.com/v2/no-such-image/manifests/latest\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:51Z",
+      "lastTimestamp": "2023-07-10T05:28:40Z",
+      "count": 2,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a6bc210c811",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "9924f756-8608-4450-8fed-60b5728bcefc",
+        "resourceVersion": "953797",
+        "creationTimestamp": "2023-07-10T05:27:51Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:24Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ErrImagePull",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:51Z",
+      "lastTimestamp": "2023-07-10T05:29:24Z",
+      "count": 4,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a6bd2f6b8a9",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "236e5715-5d21-4265-b3ae-38dc0a061349",
+        "resourceVersion": "953987",
+        "creationTimestamp": "2023-07-10T05:27:51Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:32:54Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:51Z",
+      "lastTimestamp": "2023-07-10T05:32:54Z",
+      "count": 19,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a6bd2f6f50b",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "a0daac25-a949-4f05-bea8-6a322489d8b5",
+        "resourceVersion": "953825",
+        "creationTimestamp": "2023-07-10T05:27:51Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:48Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ImagePullBackOff",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:51Z",
+      "lastTimestamp": "2023-07-10T05:29:48Z",
+      "count": 6,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a7160e939af",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "a5767296-fb90-4b42-8e6f-8dabc8fda753",
+        "resourceVersion": "953691",
+        "creationTimestamp": "2023-07-10T05:28:15Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:28:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": net/http: TLS handshake timeout",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:28:15Z",
+      "lastTimestamp": "2023-07-10T05:28:15Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-l595s.17706a817ff17267",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "4cb93636-9808-4a26-874b-0ba4d55580b7",
+        "resourceVersion": "953796",
+        "creationTimestamp": "2023-07-10T05:29:24Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:24Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-l595s",
+        "uid": "95a810a9-3977-432a-87a0-46f23123cd39",
+        "apiVersion": "v1",
+        "resourceVersion": "953634",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:29:24Z",
+      "lastTimestamp": "2023-07-10T05:29:24Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a6ae6ce5acb",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "27855127-e406-477a-a978-4b67e1880837",
+        "resourceVersion": "953631",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953625"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/no-image-deployment-849c4c4958-lm8qp to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:27:47.635287Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a6b195ceb2e",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "14c6fe3c-abd7-4e17-88be-5f457ab1a3e6",
+        "resourceVersion": "953785",
+        "creationTimestamp": "2023-07-10T05:27:48Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:21Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953628",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:48Z",
+      "lastTimestamp": "2023-07-10T05:29:21Z",
+      "count": 4,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a6b51c87b1a",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "1d89c69d-5535-4160-8114-916d4fb402e9",
+        "resourceVersion": "953675",
+        "creationTimestamp": "2023-07-10T05:27:49Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:28:02Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953628",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:49Z",
+      "lastTimestamp": "2023-07-10T05:28:02Z",
+      "count": 2,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a6b51c8c211",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "03eababe-91da-49da-872b-b730832c0952",
+        "resourceVersion": "953789",
+        "creationTimestamp": "2023-07-10T05:27:49Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:22Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953628",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ErrImagePull",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:49Z",
+      "lastTimestamp": "2023-07-10T05:29:22Z",
+      "count": 4,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a6b59993fe1",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "c507843a-4066-4a60-ad90-52dcb4109808",
+        "resourceVersion": "953983",
+        "creationTimestamp": "2023-07-10T05:27:49Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:32:50Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953628",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:49Z",
+      "lastTimestamp": "2023-07-10T05:32:50Z",
+      "count": 19,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a6b59997b20",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "f6715b68-8da8-4123-a8f4-07557a27783e",
+        "resourceVersion": "953815",
+        "creationTimestamp": "2023-07-10T05:27:49Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:38Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953628",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ImagePullBackOff",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:27:49Z",
+      "lastTimestamp": "2023-07-10T05:29:38Z",
+      "count": 6,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-lm8qp.17706a751d187e18",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "a8b5639b-e2fa-4b19-93f5-6f7e8e99e970",
+        "resourceVersion": "953788",
+        "creationTimestamp": "2023-07-10T05:28:31Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:29:22Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958-lm8qp",
+        "uid": "ce305073-9ae5-45cf-a7c9-7dfb544c9f12",
+        "apiVersion": "v1",
+        "resourceVersion": "953628",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Head \"https://noimage.com/v2/no-such-image/manifests/latest\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:28:31Z",
+      "lastTimestamp": "2023-07-10T05:29:22Z",
+      "count": 2,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958.17706a6ae6799e15",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "97b652a0-2bf4-4a58-b009-20c38d5fbef6",
+        "resourceVersion": "953626",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958",
+        "uid": "a6859997-f30e-4fd9-9eed-c5d91d04534f",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953622"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: no-image-deployment-849c4c4958-lm8qp",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:27:47Z",
+      "lastTimestamp": "2023-07-10T05:27:47Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958.17706a6ae6c94d56",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "3db8132c-adfd-4941-8340-35078dc45b6d",
+        "resourceVersion": "953632",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958",
+        "uid": "a6859997-f30e-4fd9-9eed-c5d91d04534f",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953622"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: no-image-deployment-849c4c4958-7fp5q",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:27:47Z",
+      "lastTimestamp": "2023-07-10T05:27:47Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958.17706a6ae6cb1a6f",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "756d0d1c-a096-462d-bba1-5ee67e9ddca5",
+        "resourceVersion": "953637",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment-849c4c4958",
+        "uid": "a6859997-f30e-4fd9-9eed-c5d91d04534f",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953622"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: no-image-deployment-849c4c4958-l595s",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:27:47Z",
+      "lastTimestamp": "2023-07-10T05:27:47Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment.17706a6ae648250b",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "8d453b00-15eb-4487-95fc-1d6a205507fa",
+        "resourceVersion": "953624",
+        "creationTimestamp": "2023-07-10T05:27:47Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:27:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "no-image-deployment",
+        "uid": "4867c20b-d8fd-49f7-9008-f3d50d8020ee",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953621"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set no-image-deployment-849c4c4958 to 3",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:27:47Z",
+      "lastTimestamp": "2023-07-10T05:27:47Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-59zjj.17706a2fa28dfbb4",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "9cde6c40-7651-4fc6-891e-c9451f66bc4e",
+        "resourceVersion": "953392",
+        "creationTimestamp": "2023-07-10T05:23:33Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:23:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688-59zjj",
+        "uid": "a2e15d20-a683-4e67-9959-b3e9d89f32a4",
+        "apiVersion": "v1",
+        "resourceVersion": "953389"
+      },
+      "reason": "FailedScheduling",
+      "message": "0/1 nodes are available: 1 Insufficient nvidia.com/gpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-10T05:23:33.087153Z",
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-59zjj.17706a302948ac68",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "f7c10a30-796f-4324-bc84-93375426db48",
+        "resourceVersion": "953402",
+        "creationTimestamp": "2023-07-10T05:23:35Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:23:35Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688-59zjj",
+        "uid": "a2e15d20-a683-4e67-9959-b3e9d89f32a4",
+        "apiVersion": "v1",
+        "resourceVersion": "953393"
+      },
+      "reason": "FailedScheduling",
+      "message": "0/1 nodes are available: 1 Insufficient nvidia.com/gpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-10T05:23:35.347536Z",
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-59zjj.17706a60d6c71599",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "a87b373e-ff70-4f1f-b6e5-ae405884fb97",
+        "resourceVersion": "953587",
+        "creationTimestamp": "2023-07-10T05:27:04Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:27:04Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688-59zjj",
+        "uid": "a2e15d20-a683-4e67-9959-b3e9d89f32a4",
+        "apiVersion": "v1",
+        "resourceVersion": "953585"
+      },
+      "reason": "FailedScheduling",
+      "message": "skip schedule deleting pod: default/pending-pod-resources-5fddcf7688-59zjj",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-10T05:27:04.416707Z",
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-wzvfz.177069f667efe27c",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "276f8fc7-499b-406c-a423-8418c4e5658a",
+        "resourceVersion": "953206",
+        "creationTimestamp": "2023-07-10T05:19:27Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:19:27Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688-wzvfz",
+        "uid": "1cd6b98c-2f73-48c0-b2d1-24549b0005b7",
+        "apiVersion": "v1",
+        "resourceVersion": "953203"
+      },
+      "reason": "FailedScheduling",
+      "message": "0/1 nodes are available: 1 Insufficient nvidia.com/gpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-10T05:19:27.290575Z",
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-wzvfz.17706a2fa190fcc7",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ab85c0f5-c969-483a-8893-97851cfa1704",
+        "resourceVersion": "953387",
+        "creationTimestamp": "2023-07-10T05:23:33Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:23:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688-wzvfz",
+        "uid": "1cd6b98c-2f73-48c0-b2d1-24549b0005b7",
+        "apiVersion": "v1",
+        "resourceVersion": "953386"
+      },
+      "reason": "FailedScheduling",
+      "message": "skip schedule deleting pod: default/pending-pod-resources-5fddcf7688-wzvfz",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-10T05:23:33.070562Z",
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688.177069f667e49edb",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "5038e57a-80f7-414c-9e8c-540b17f568ce",
+        "resourceVersion": "953204",
+        "creationTimestamp": "2023-07-10T05:19:27Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:19:27Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688",
+        "uid": "7c18a253-bcaf-43a2-9b0e-02e1a44c4c7d",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953199"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: pending-pod-resources-5fddcf7688-wzvfz",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:19:27Z",
+      "lastTimestamp": "2023-07-10T05:19:27Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688.17706a2fa283031c",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "ad6c3d31-f701-4d87-9540-21c89d310793",
+        "resourceVersion": "953390",
+        "creationTimestamp": "2023-07-10T05:23:33Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:23:33Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources-5fddcf7688",
+        "uid": "7c18a253-bcaf-43a2-9b0e-02e1a44c4c7d",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953208"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: pending-pod-resources-5fddcf7688-59zjj",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:23:33Z",
+      "lastTimestamp": "2023-07-10T05:23:33Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources.177069f667697706",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "3cf88958-3fe2-4e58-92a5-71ea46491dad",
+        "resourceVersion": "953201",
+        "creationTimestamp": "2023-07-10T05:19:27Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:19:27Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "pending-pod-resources",
+        "uid": "a69d2ee0-43c5-4476-83e5-1c4eb2347963",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "953198"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set pending-pod-resources-5fddcf7688 to 1",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2023-07-10T05:19:27Z",
+      "lastTimestamp": "2023-07-10T05:19:27Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "testpod.17706ac58f77c55a",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "d02568ed-92a2-46ee-9e28-bb70319f9f24",
+        "resourceVersion": "954076",
+        "creationTimestamp": "2023-07-10T05:34:17Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-10T05:34:17Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "testpod",
+        "uid": "e6a00439-6a9a-4b1e-bef0-7cc6253e2a41",
+        "apiVersion": "v1",
+        "resourceVersion": "954074"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/testpod to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-10T05:34:17.012024Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "testpod.17706ac5b111318c",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "78b1746d-d38c-4949-8f94-90e9475afa34",
+        "resourceVersion": "954079",
+        "creationTimestamp": "2023-07-10T05:34:17Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:17Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "testpod",
+        "uid": "e6a00439-6a9a-4b1e-bef0-7cc6253e2a41",
+        "apiVersion": "v1",
+        "resourceVersion": "954075",
+        "fieldPath": "spec.containers{testpod}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"busybox:1.28\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:17Z",
+      "lastTimestamp": "2023-07-10T05:34:17Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "testpod.17706ac5b1f3b968",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "b0885d47-7073-4918-86a1-4b8f9d4513d3",
+        "resourceVersion": "954080",
+        "creationTimestamp": "2023-07-10T05:34:17Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:17Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "testpod",
+        "uid": "e6a00439-6a9a-4b1e-bef0-7cc6253e2a41",
+        "apiVersion": "v1",
+        "resourceVersion": "954075",
+        "fieldPath": "spec.containers{testpod}"
+      },
+      "reason": "Created",
+      "message": "Created container testpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:17Z",
+      "lastTimestamp": "2023-07-10T05:34:17Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "testpod.17706ac5b4ffe4e1",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "0b99bf01-d10b-4d04-810d-4b3c1061f693",
+        "resourceVersion": "954081",
+        "creationTimestamp": "2023-07-10T05:34:17Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:17Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "testpod",
+        "uid": "e6a00439-6a9a-4b1e-bef0-7cc6253e2a41",
+        "apiVersion": "v1",
+        "resourceVersion": "954075",
+        "fieldPath": "spec.containers{testpod}"
+      },
+      "reason": "Started",
+      "message": "Started container testpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:17Z",
+      "lastTimestamp": "2023-07-10T05:34:17Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "testpod.17706acda007ff0e",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "9dde92d7-b051-4007-8dae-0066312f7b57",
+        "resourceVersion": "954117",
+        "creationTimestamp": "2023-07-10T05:34:51Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:34:51Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "testpod",
+        "uid": "e6a00439-6a9a-4b1e-bef0-7cc6253e2a41",
+        "apiVersion": "v1",
+        "resourceVersion": "954075",
+        "fieldPath": "spec.containers{testpod}"
+      },
+      "reason": "Killing",
+      "message": "Stopping container testpod",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-10T05:34:51Z",
+      "lastTimestamp": "2023-07-10T05:34:51Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm.177058280d4c0493",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "380bec72-7cfd-4a00-85ff-8725c9fc28f9",
+        "resourceVersion": "954314",
+        "creationTimestamp": "2023-07-09T23:53:09Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:39:03Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm",
+        "uid": "55ca5d14-2541-42a9-9eb1-5eb53133e178",
+        "apiVersion": "v1",
+        "resourceVersion": "938779"
+      },
+      "reason": "FailedMount",
+      "message": "MountVolume.SetUp failed for volume \"host\" : hostPath type check failed: /var/lib/collectd is not a directory",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-09T23:53:09Z",
+      "lastTimestamp": "2023-07-10T05:39:03Z",
+      "count": 178,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm.17705863d9fdab48",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "bab0a7d9-61a5-43a1-813c-ed2d050aee34",
+        "resourceVersion": "954514",
+        "creationTimestamp": "2023-07-09T23:57:26Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-10T05:43:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-container-creating-failed-mount",
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm",
+        "uid": "55ca5d14-2541-42a9-9eb1-5eb53133e178",
+        "apiVersion": "v1",
+        "resourceVersion": "938779"
+      },
+      "reason": "FailedMount",
+      "message": "Unable to attach or mount volumes: unmounted volumes=[host], unattached volumes=[host kube-api-access-xddvj]: timed out waiting for the condition",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-09T23:57:26Z",
+      "lastTimestamp": "2023-07-10T05:43:47Z",
+      "count": 109,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    }
+  ]
+}

--- a/pkg/analyze/files/events/message-image-pull-fail.json
+++ b/pkg/analyze/files/events/message-image-pull-fail.json
@@ -1,0 +1,913 @@
+{
+  "kind": "EventList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "986840"
+  },
+  "items": [
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt.1770b96096f009dd",
+        "namespace": "message-image-pull-fail",
+        "uid": "3b134296-43f6-4228-9c98-aeb622fb0a9a",
+        "resourceVersion": "986732",
+        "creationTimestamp": "2023-07-11T05:34:44Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-11T05:34:44Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "apiVersion": "v1",
+        "resourceVersion": "986727"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/no-image-deployment-849c4c4958-rxqmt to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-11T05:34:44.764227Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt.1770b960b6f1e0ea",
+        "namespace": "message-image-pull-fail",
+        "uid": "e5ea1f55-0d14-4443-8f79-d5b6ef692f61",
+        "resourceVersion": "986820",
+        "creationTimestamp": "2023-07-11T05:34:45Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:36:11Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "apiVersion": "v1",
+        "resourceVersion": "986730",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T05:34:45Z",
+      "lastTimestamp": "2023-07-11T05:36:11Z",
+      "count": 4,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt.1770b960f12b4918",
+        "namespace": "message-image-pull-fail",
+        "uid": "4ed0acd0-b3a2-477c-bb33-0e14512f5dd8",
+        "resourceVersion": "986821",
+        "creationTimestamp": "2023-07-11T05:34:46Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:36:12Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "apiVersion": "v1",
+        "resourceVersion": "986730",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Failed to pull image \"noimage.com/no-such-image\": rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": x509: certificate is not valid for any names, but wanted to match noimage.com",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T05:34:46Z",
+      "lastTimestamp": "2023-07-11T05:36:12Z",
+      "count": 4,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt.1770b960f12bd46b",
+        "namespace": "message-image-pull-fail",
+        "uid": "4a66c16a-b2ee-4345-8de6-028936861f03",
+        "resourceVersion": "986822",
+        "creationTimestamp": "2023-07-11T05:34:46Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:36:12Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "apiVersion": "v1",
+        "resourceVersion": "986730",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ErrImagePull",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T05:34:46Z",
+      "lastTimestamp": "2023-07-11T05:36:12Z",
+      "count": 4,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt.1770b960fa64918a",
+        "namespace": "message-image-pull-fail",
+        "uid": "0b4b988c-faf5-447a-bb2e-367b627152dc",
+        "resourceVersion": "986833",
+        "creationTimestamp": "2023-07-11T05:34:46Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:36:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "apiVersion": "v1",
+        "resourceVersion": "986730",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off pulling image \"noimage.com/no-such-image\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T05:34:46Z",
+      "lastTimestamp": "2023-07-11T05:36:25Z",
+      "count": 5,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt.1770b960fa64bb88",
+        "namespace": "message-image-pull-fail",
+        "uid": "eae7cb57-316e-4dc7-8e3a-45c01ca369a5",
+        "resourceVersion": "986835",
+        "creationTimestamp": "2023-07-11T05:34:46Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:36:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "apiVersion": "v1",
+        "resourceVersion": "986730",
+        "fieldPath": "spec.containers{demo-deployment-container}"
+      },
+      "reason": "Failed",
+      "message": "Error: ImagePullBackOff",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T05:34:46Z",
+      "lastTimestamp": "2023-07-11T05:36:25Z",
+      "count": 5,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958.1770b96096c622fa",
+        "namespace": "message-image-pull-fail",
+        "uid": "55bc2a37-2ff2-4a17-a29d-c3eab878e353",
+        "resourceVersion": "986728",
+        "creationTimestamp": "2023-07-11T05:34:44Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:34:44Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment-849c4c4958",
+        "uid": "d992c1a5-d2c4-4065-ac5b-3bb893f9000a",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "986723"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: no-image-deployment-849c4c4958-rxqmt",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2023-07-11T05:34:44Z",
+      "lastTimestamp": "2023-07-11T05:34:44Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment.1770b96096492cbe",
+        "namespace": "message-image-pull-fail",
+        "uid": "3feddf40-caa5-45f9-9d8b-bc24796d508f",
+        "resourceVersion": "986725",
+        "creationTimestamp": "2023-07-11T05:34:44Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:34:44Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Deployment",
+        "namespace": "message-image-pull-fail",
+        "name": "no-image-deployment",
+        "uid": "abe37ef6-38c5-4f29-a956-f79def48c342",
+        "apiVersion": "apps/v1",
+        "resourceVersion": "986722"
+      },
+      "reason": "ScalingReplicaSet",
+      "message": "Scaled up replica set no-image-deployment-849c4c4958 to 1",
+      "source": {
+        "component": "deployment-controller"
+      },
+      "firstTimestamp": "2023-07-11T05:34:44Z",
+      "lastTimestamp": "2023-07-11T05:34:44Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3-gbb89.1770b6922c75433d",
+        "namespace": "message-image-pull-fail",
+        "uid": "3cfa33ed-cedc-4fa3-a9b7-aa657048784a",
+        "resourceVersion": "984536",
+        "creationTimestamp": "2023-07-11T04:43:19Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-11T04:43:19Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3-gbb89",
+        "uid": "c8d3f094-b80c-4ff8-aff7-f0e624f1bf3a",
+        "apiVersion": "v1",
+        "resourceVersion": "984532"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/oom-kill-job3-gbb89 to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-11T04:43:19.191283Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3-gbb89.1770b6924d361854",
+        "namespace": "message-image-pull-fail",
+        "uid": "695da2fb-7e2f-4c20-b60a-9a4cd3b1b60e",
+        "resourceVersion": "984539",
+        "creationTimestamp": "2023-07-11T04:43:19Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:19Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3-gbb89",
+        "uid": "c8d3f094-b80c-4ff8-aff7-f0e624f1bf3a",
+        "apiVersion": "v1",
+        "resourceVersion": "984533",
+        "fieldPath": "spec.containers{memory-eater}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:43:19Z",
+      "lastTimestamp": "2023-07-11T04:43:19Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3-gbb89.1770b6939d446433",
+        "namespace": "message-image-pull-fail",
+        "uid": "b7ddf622-f531-4822-bdb2-46f6e27218ae",
+        "resourceVersion": "984544",
+        "creationTimestamp": "2023-07-11T04:43:25Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3-gbb89",
+        "uid": "c8d3f094-b80c-4ff8-aff7-f0e624f1bf3a",
+        "apiVersion": "v1",
+        "resourceVersion": "984533",
+        "fieldPath": "spec.containers{memory-eater}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0\" in 5.638046961s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:43:25Z",
+      "lastTimestamp": "2023-07-11T04:43:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3-gbb89.1770b6939f884130",
+        "namespace": "message-image-pull-fail",
+        "uid": "84e0a635-a3b8-4cdc-b439-a71454e7d7d5",
+        "resourceVersion": "984545",
+        "creationTimestamp": "2023-07-11T04:43:25Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3-gbb89",
+        "uid": "c8d3f094-b80c-4ff8-aff7-f0e624f1bf3a",
+        "apiVersion": "v1",
+        "resourceVersion": "984533",
+        "fieldPath": "spec.containers{memory-eater}"
+      },
+      "reason": "Created",
+      "message": "Created container memory-eater",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:43:25Z",
+      "lastTimestamp": "2023-07-11T04:43:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3-gbb89.1770b693a39538e4",
+        "namespace": "message-image-pull-fail",
+        "uid": "a15333ad-0390-4325-8880-34ef36508831",
+        "resourceVersion": "984546",
+        "creationTimestamp": "2023-07-11T04:43:25Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3-gbb89",
+        "uid": "c8d3f094-b80c-4ff8-aff7-f0e624f1bf3a",
+        "apiVersion": "v1",
+        "resourceVersion": "984533",
+        "fieldPath": "spec.containers{memory-eater}"
+      },
+      "reason": "Started",
+      "message": "Started container memory-eater",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:43:25Z",
+      "lastTimestamp": "2023-07-11T04:43:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3.1770b6922c53f55c",
+        "namespace": "message-image-pull-fail",
+        "uid": "db095cdc-df52-490d-a308-9b283f99eaa6",
+        "resourceVersion": "984534",
+        "creationTimestamp": "2023-07-11T04:43:19Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:19Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Job",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3",
+        "uid": "a85295e8-54e4-40a4-aeb0-b47c19f1a69f",
+        "apiVersion": "batch/v1",
+        "resourceVersion": "984531"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: oom-kill-job3-gbb89",
+      "source": {
+        "component": "job-controller"
+      },
+      "firstTimestamp": "2023-07-11T04:43:19Z",
+      "lastTimestamp": "2023-07-11T04:43:19Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3.1770b6944e3d254b",
+        "namespace": "message-image-pull-fail",
+        "uid": "fb3ea640-2484-44d5-b65d-698d8e5bd3db",
+        "resourceVersion": "984553",
+        "creationTimestamp": "2023-07-11T04:43:28Z",
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:28Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Job",
+        "namespace": "message-image-pull-fail",
+        "name": "oom-kill-job3",
+        "uid": "a85295e8-54e4-40a4-aeb0-b47c19f1a69f",
+        "apiVersion": "batch/v1",
+        "resourceVersion": "984551"
+      },
+      "reason": "BackoffLimitExceeded",
+      "message": "Job has reached the specified backoff limit",
+      "source": {
+        "component": "job-controller"
+      },
+      "firstTimestamp": "2023-07-11T04:43:28Z",
+      "lastTimestamp": "2023-07-11T04:43:28Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-djjfc.1770b59c8b866b56",
+        "namespace": "message-image-pull-fail",
+        "uid": "64330c31-0f5e-46f3-8fb6-ffdac523bb77",
+        "resourceVersion": "984662",
+        "creationTimestamp": "2023-07-11T04:25:44Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-11T04:46:01Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:series": {
+                ".": {},
+                "f:count": {},
+                "f:lastObservedTime": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "pending-pod-resources-5fddcf7688-djjfc",
+        "uid": "e4d4c4cc-2c41-4ab7-b41c-9c8b28ded451",
+        "apiVersion": "v1",
+        "resourceVersion": "983556"
+      },
+      "reason": "FailedScheduling",
+      "message": "0/1 nodes are available: 1 Insufficient nvidia.com/gpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-11T04:25:44.224298Z",
+      "series": {
+        "count": 3,
+        "lastObservedTime": "2023-07-11T04:40:44.264058Z"
+      },
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-djjfc.1770b68fb368b5a6",
+        "namespace": "message-image-pull-fail",
+        "uid": "369454df-c891-4e76-96b9-ebdaabe2a6a6",
+        "resourceVersion": "984523",
+        "creationTimestamp": "2023-07-11T04:43:08Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-11T04:43:08Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-image-pull-fail",
+        "name": "pending-pod-resources-5fddcf7688-djjfc",
+        "uid": "e4d4c4cc-2c41-4ab7-b41c-9c8b28ded451",
+        "apiVersion": "v1",
+        "resourceVersion": "984521"
+      },
+      "reason": "FailedScheduling",
+      "message": "skip schedule deleting pod: default/pending-pod-resources-5fddcf7688-djjfc",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Warning",
+      "eventTime": "2023-07-11T04:43:08.570490Z",
+      "action": "Scheduling",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    }
+  ]
+}

--- a/pkg/analyze/files/events/message-pod-init-crashloop-backoff.json
+++ b/pkg/analyze/files/events/message-pod-init-crashloop-backoff.json
@@ -1,0 +1,928 @@
+{
+  "kind": "EventList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "982712"
+  },
+  "items": [
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2a98cf7b53c",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "cfdfe0af-6dc5-4c6c-a3be-f1532d424ab4",
+        "resourceVersion": "981383",
+        "creationTimestamp": "2023-07-11T03:31:41Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-11T03:31:41Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981381"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/init-demo to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-11T03:31:41.548190Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2a9adf25515",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "091c0f14-75df-47e6-af31-309d8a0b0b86",
+        "resourceVersion": "981479",
+        "creationTimestamp": "2023-07-11T03:31:42Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:33:12Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Pulling",
+      "message": "Pulling image \"nginx\"",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:31:42Z",
+      "lastTimestamp": "2023-07-11T03:33:12Z",
+      "count": 5,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2aa4adc35a4",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "740be04d-5aa8-4bce-ace3-ec61e4d229e0",
+        "resourceVersion": "981389",
+        "creationTimestamp": "2023-07-11T03:31:44Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:31:44Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"nginx\" in 2.633289584s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:31:44Z",
+      "lastTimestamp": "2023-07-11T03:31:44Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2aa4cbb718f",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "a158f7ff-6b95-45db-ac28-2d02ba1d8ca0",
+        "resourceVersion": "981483",
+        "creationTimestamp": "2023-07-11T03:31:44Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:33:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Created",
+      "message": "Created container nginx",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:31:44Z",
+      "lastTimestamp": "2023-07-11T03:33:15Z",
+      "count": 5,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2aa50edfd38",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "0fc24955-49dd-4c16-8c7b-c4a3316b1f9d",
+        "resourceVersion": "981484",
+        "creationTimestamp": "2023-07-11T03:31:44Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:33:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Failed",
+      "message": "Error: failed to start container \"nginx\": Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:31:44Z",
+      "lastTimestamp": "2023-07-11T03:33:15Z",
+      "count": 5,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2aae7fb3f76",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "3c489943-7de7-4a1b-a108-1e9d55a2d6a7",
+        "resourceVersion": "981396",
+        "creationTimestamp": "2023-07-11T03:31:47Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:31:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"nginx\" in 1.952280959s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:31:47Z",
+      "lastTimestamp": "2023-07-11T03:31:47Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2ae5cec9549",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "793ce261-4cb0-4b2a-9c97-fe1924e534e3",
+        "resourceVersion": "981413",
+        "creationTimestamp": "2023-07-11T03:32:02Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:32:02Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"nginx\" in 2.228363585s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:32:02Z",
+      "lastTimestamp": "2023-07-11T03:32:02Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2b1917b81fa",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "2dbed976-4a5d-42f8-8cd7-8778f2382b7a",
+        "resourceVersion": "982495",
+        "creationTimestamp": "2023-07-11T03:32:15Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:56:47Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:32:15Z",
+      "lastTimestamp": "2023-07-11T03:56:47Z",
+      "count": 111,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2b3b6fab35b",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "f3d43cf2-f8b7-428a-b834-4826603b414c",
+        "resourceVersion": "981439",
+        "creationTimestamp": "2023-07-11T03:32:25Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:32:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"nginx\" in 2.117272501s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:32:25Z",
+      "lastTimestamp": "2023-07-11T03:32:25Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo.1770b2bf5bb3f082",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "f9f3da46-c519-43b0-9721-07113e30e2e3",
+        "resourceVersion": "981482",
+        "creationTimestamp": "2023-07-11T03:33:15Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:33:15Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "apiVersion": "v1",
+        "resourceVersion": "981382",
+        "fieldPath": "spec.containers{nginx}"
+      },
+      "reason": "Pulled",
+      "message": "Successfully pulled image \"nginx\" in 2.219218792s",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T03:33:15Z",
+      "lastTimestamp": "2023-07-11T03:33:15Z",
+      "count": 1,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2.1770b446b3f016ce",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "12009dc6-123f-488f-9b1f-412930c8d28d",
+        "resourceVersion": "982692",
+        "creationTimestamp": "2023-07-11T04:01:16Z",
+        "managedFields": [
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "events.k8s.io/v1",
+            "time": "2023-07-11T04:01:16Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:action": {},
+              "f:eventTime": {},
+              "f:note": {},
+              "f:reason": {},
+              "f:regarding": {},
+              "f:reportingController": {},
+              "f:reportingInstance": {},
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo2",
+        "uid": "5a560e83-c634-4c91-b308-510ee692ed6a",
+        "apiVersion": "v1",
+        "resourceVersion": "982690"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned default/init-demo2 to minikube",
+      "source": {},
+      "firstTimestamp": null,
+      "lastTimestamp": null,
+      "type": "Normal",
+      "eventTime": "2023-07-11T04:01:16.023486Z",
+      "action": "Binding",
+      "reportingComponent": "default-scheduler",
+      "reportingInstance": "default-scheduler-minikube"
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2.1770b446d40953ed",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "a5ffd925-1612-4178-b5ce-02e981500ee5",
+        "resourceVersion": "982698",
+        "creationTimestamp": "2023-07-11T04:01:16Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:01:16Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo2",
+        "uid": "5a560e83-c634-4c91-b308-510ee692ed6a",
+        "apiVersion": "v1",
+        "resourceVersion": "982691",
+        "fieldPath": "spec.initContainers{install}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"busybox:1.28\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:01:16Z",
+      "lastTimestamp": "2023-07-11T04:01:16Z",
+      "count": 2,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2.1770b446d5539074",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "f431bae6-64fb-47ba-81ee-ab4f32122024",
+        "resourceVersion": "982700",
+        "creationTimestamp": "2023-07-11T04:01:16Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:01:16Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo2",
+        "uid": "5a560e83-c634-4c91-b308-510ee692ed6a",
+        "apiVersion": "v1",
+        "resourceVersion": "982691",
+        "fieldPath": "spec.initContainers{install}"
+      },
+      "reason": "Created",
+      "message": "Created container install",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:01:16Z",
+      "lastTimestamp": "2023-07-11T04:01:16Z",
+      "count": 2,
+      "type": "Normal",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2.1770b446d9b392f2",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "9e237187-eb36-4f2d-a139-3c5c450a75e9",
+        "resourceVersion": "982701",
+        "creationTimestamp": "2023-07-11T04:01:16Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:01:17Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo2",
+        "uid": "5a560e83-c634-4c91-b308-510ee692ed6a",
+        "apiVersion": "v1",
+        "resourceVersion": "982691",
+        "fieldPath": "spec.initContainers{install}"
+      },
+      "reason": "Failed",
+      "message": "Error: failed to start container \"install\": Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:01:16Z",
+      "lastTimestamp": "2023-07-11T04:01:17Z",
+      "count": 2,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2.1770b448549c898a",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "44c503f2-0bd9-46ad-81be-9c2626d3bdf3",
+        "resourceVersion": "982706",
+        "creationTimestamp": "2023-07-11T04:01:23Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:01:23Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "init-demo2",
+        "uid": "5a560e83-c634-4c91-b308-510ee692ed6a",
+        "apiVersion": "v1",
+        "resourceVersion": "982691",
+        "fieldPath": "spec.initContainers{install}"
+      },
+      "reason": "BackOff",
+      "message": "Back-off restarting failed container",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-11T04:01:23Z",
+      "lastTimestamp": "2023-07-11T04:01:23Z",
+      "count": 1,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm.177058280d4c0493",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "380bec72-7cfd-4a00-85ff-8725c9fc28f9",
+        "resourceVersion": "981372",
+        "creationTimestamp": "2023-07-09T23:53:09Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:31:29Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm",
+        "uid": "55ca5d14-2541-42a9-9eb1-5eb53133e178",
+        "apiVersion": "v1",
+        "resourceVersion": "938779"
+      },
+      "reason": "FailedMount",
+      "message": "MountVolume.SetUp failed for volume \"host\" : hostPath type check failed: /var/lib/collectd is not a directory",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-09T23:53:09Z",
+      "lastTimestamp": "2023-07-11T03:31:29Z",
+      "count": 490,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    },
+    {
+      "kind": "Event",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm.17705863d9fdab48",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "bab0a7d9-61a5-43a1-813c-ed2d050aee34",
+        "resourceVersion": "981185",
+        "creationTimestamp": "2023-07-09T23:57:26Z",
+        "managedFields": [
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:27:03Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:count": {},
+              "f:firstTimestamp": {},
+              "f:involvedObject": {},
+              "f:lastTimestamp": {},
+              "f:message": {},
+              "f:reason": {},
+              "f:source": {
+                "f:component": {},
+                "f:host": {}
+              },
+              "f:type": {}
+            }
+          }
+        ]
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm",
+        "uid": "55ca5d14-2541-42a9-9eb1-5eb53133e178",
+        "apiVersion": "v1",
+        "resourceVersion": "938779"
+      },
+      "reason": "FailedMount",
+      "message": "Unable to attach or mount volumes: unmounted volumes=[host], unattached volumes=[host kube-api-access-xddvj]: timed out waiting for the condition",
+      "source": {
+        "component": "kubelet",
+        "host": "minikube"
+      },
+      "firstTimestamp": "2023-07-09T23:57:26Z",
+      "lastTimestamp": "2023-07-11T03:27:03Z",
+      "count": 324,
+      "type": "Warning",
+      "eventTime": null,
+      "reportingComponent": "",
+      "reportingInstance": ""
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-container-creating-failed-mount.json
+++ b/pkg/analyze/files/pods/message-container-creating-failed-mount.json
@@ -1,0 +1,355 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "954528"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "troubleshoot-copyfromhost-4m79m-psdjm",
+        "generateName": "troubleshoot-copyfromhost-4m79m-",
+        "namespace": "message-container-creating-failed-mount",
+        "uid": "55ca5d14-2541-42a9-9eb1-5eb53133e178",
+        "resourceVersion": "938782",
+        "creationTimestamp": "2023-07-09T23:53:09Z",
+        "labels": {
+          "app.kubernetes.io/managed-by": "troubleshoot.sh",
+          "controller-revision-hash": "54b4f4f449",
+          "pod-template-generation": "1",
+          "troubleshoot.sh/collector": "copyfromhost",
+          "troubleshoot.sh/copyfromhost-id": "2SAoFNhXU68STgniojM3fJcNQig"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "name": "troubleshoot-copyfromhost-4m79m",
+            "uid": "ed30f463-4614-41b3-b2b6-52f65e50b1d3",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-09T23:53:09Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:generateName": {},
+                "f:labels": {
+                  ".": {},
+                  "f:app.kubernetes.io/managed-by": {},
+                  "f:controller-revision-hash": {},
+                  "f:pod-template-generation": {},
+                  "f:troubleshoot.sh/collector": {},
+                  "f:troubleshoot.sh/copyfromhost-id": {}
+                },
+                "f:ownerReferences": {
+                  ".": {},
+                  "k:{\"uid\":\"ed30f463-4614-41b3-b2b6-52f65e50b1d3\"}": {}
+                }
+              },
+              "f:spec": {
+                "f:affinity": {
+                  ".": {},
+                  "f:nodeAffinity": {
+                    ".": {},
+                    "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                  }
+                },
+                "f:containers": {
+                  "k:{\"name\":\"collector\"}": {
+                    ".": {},
+                    "f:args": {},
+                    "f:command": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/host\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {},
+                "f:tolerations": {},
+                "f:volumes": {
+                  ".": {},
+                  "k:{\"name\":\"host\"}": {
+                    ".": {},
+                    "f:hostPath": {
+                      ".": {},
+                      "f:path": {},
+                      "f:type": {}
+                    },
+                    "f:name": {}
+                  }
+                }
+              }
+            }
+          },
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-09T23:53:09Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  "k:{\"type\":\"ContainersReady\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Initialized\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Ready\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                },
+                "f:containerStatuses": {},
+                "f:hostIP": {},
+                "f:startTime": {}
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "host",
+            "hostPath": {
+              "path": "/var/lib/collectd",
+              "type": "Directory"
+            }
+          },
+          {
+            "name": "kube-api-access-xddvj",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "collector",
+            "image": "alpine",
+            "command": [
+              "sleep"
+            ],
+            "args": [
+              "1000000"
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "host",
+                "mountPath": "/host"
+              },
+              {
+                "name": "kube-api-access-xddvj",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchFields": [
+                    {
+                      "key": "metadata.name",
+                      "operator": "In",
+                      "values": [
+                        "minikube"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node-role.kubernetes.io/master",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node-role.kubernetes.io/control-plane",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute"
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute"
+          },
+          {
+            "key": "node.kubernetes.io/disk-pressure",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/memory-pressure",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/pid-pressure",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "key": "node.kubernetes.io/unschedulable",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-09T23:53:09Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-09T23:53:09Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [collector]"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-09T23:53:09Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [collector]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-09T23:53:09Z"
+          }
+        ],
+        "hostIP": "192.168.49.2",
+        "startTime": "2023-07-09T23:53:09Z",
+        "containerStatuses": [
+          {
+            "name": "collector",
+            "state": {
+              "waiting": {
+                "reason": "ContainerCreating"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "alpine",
+            "imageID": "",
+            "started": false
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-image-pull-fail.json
+++ b/pkg/analyze/files/pods/message-image-pull-fail.json
@@ -1,0 +1,272 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "986839"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "no-image-deployment-849c4c4958-rxqmt",
+        "generateName": "no-image-deployment-849c4c4958-",
+        "namespace": "message-image-pull-fail",
+        "uid": "209076ce-26d6-4836-981b-8c05cb0081eb",
+        "resourceVersion": "986834",
+        "creationTimestamp": "2023-07-11T05:34:44Z",
+        "labels": {
+          "app": "no-image-deployment",
+          "pod-template-hash": "849c4c4958",
+          "visualize": "true"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "no-image-deployment-849c4c4958",
+            "uid": "d992c1a5-d2c4-4065-ac5b-3bb893f9000a",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:34:44Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:generateName": {},
+                "f:labels": {
+                  ".": {},
+                  "f:app": {},
+                  "f:pod-template-hash": {},
+                  "f:visualize": {}
+                },
+                "f:ownerReferences": {
+                  ".": {},
+                  "k:{\"uid\":\"d992c1a5-d2c4-4065-ac5b-3bb893f9000a\"}": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"demo-deployment-container\"}": {
+                    ".": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {}
+              }
+            }
+          },
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T05:36:25Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  "k:{\"type\":\"ContainersReady\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Initialized\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Ready\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                },
+                "f:containerStatuses": {},
+                "f:hostIP": {},
+                "f:podIP": {},
+                "f:podIPs": {
+                  ".": {},
+                  "k:{\"ip\":\"172.17.0.3\"}": {
+                    ".": {},
+                    "f:ip": {}
+                  }
+                },
+                "f:startTime": {}
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "kube-api-access-5p7hr",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "demo-deployment-container",
+            "image": "noimage.com/no-such-image",
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "kube-api-access-5p7hr",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T05:34:44Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T05:34:44Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [demo-deployment-container]"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T05:34:44Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [demo-deployment-container]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T05:34:44Z"
+          }
+        ],
+        "hostIP": "192.168.49.2",
+        "podIP": "172.17.0.3",
+        "podIPs": [
+          {
+            "ip": "172.17.0.3"
+          }
+        ],
+        "startTime": "2023-07-11T05:34:44Z",
+        "containerStatuses": [
+          {
+            "name": "demo-deployment-container",
+            "state": {
+              "waiting": {
+                "reason": "ErrImagePull",
+                "message": "rpc error: code = Unknown desc = Error response from daemon: Get \"https://noimage.com/v2/\": x509: certificate is not valid for any names, but wanted to match noimage.com"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "noimage.com/no-such-image",
+            "imageID": "",
+            "started": false
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-oomkill-pod.json
+++ b/pkg/analyze/files/pods/message-oomkill-pod.json
@@ -1,0 +1,296 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "985854"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "oom-kill-job3-gbb89",
+        "generateName": "oom-kill-job3-",
+        "namespace": "message-oomkill-pod",
+        "uid": "c8d3f094-b80c-4ff8-aff7-f0e624f1bf3a",
+        "resourceVersion": "984552",
+        "creationTimestamp": "2023-07-11T04:43:19Z",
+        "labels": {
+          "controller-uid": "a85295e8-54e4-40a4-aeb0-b47c19f1a69f",
+          "job-name": "oom-kill-job3"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "oom-kill-job3",
+            "uid": "a85295e8-54e4-40a4-aeb0-b47c19f1a69f",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:19Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:generateName": {},
+                "f:labels": {
+                  ".": {},
+                  "f:controller-uid": {},
+                  "f:job-name": {}
+                },
+                "f:ownerReferences": {
+                  ".": {},
+                  "k:{\"uid\":\"a85295e8-54e4-40a4-aeb0-b47c19f1a69f\"}": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"memory-eater\"}": {
+                    ".": {},
+                    "f:args": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:memory": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:memory": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {}
+              }
+            }
+          },
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:43:28Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  "k:{\"type\":\"ContainersReady\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Initialized\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Ready\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                },
+                "f:containerStatuses": {},
+                "f:hostIP": {},
+                "f:phase": {},
+                "f:podIP": {},
+                "f:podIPs": {
+                  ".": {},
+                  "k:{\"ip\":\"172.17.0.3\"}": {
+                    ".": {},
+                    "f:ip": {}
+                  }
+                },
+                "f:startTime": {}
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "kube-api-access-rbt47",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "memory-eater",
+            "image": "us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0",
+            "args": [
+              "75Mi",
+              "0",
+              "30Mi",
+              "80",
+              "1"
+            ],
+            "resources": {
+              "limits": {
+                "memory": "100Mi"
+              },
+              "requests": {
+                "memory": "100Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "kube-api-access-rbt47",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Never",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Failed",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:43:19Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:43:19Z",
+            "reason": "PodFailed"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:43:19Z",
+            "reason": "PodFailed"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:43:19Z"
+          }
+        ],
+        "hostIP": "192.168.49.2",
+        "podIP": "172.17.0.3",
+        "podIPs": [
+          {
+            "ip": "172.17.0.3"
+          }
+        ],
+        "startTime": "2023-07-11T04:43:19Z",
+        "containerStatuses": [
+          {
+            "name": "memory-eater",
+            "state": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "OOMKilled",
+                "startedAt": "2023-07-11T04:43:25Z",
+                "finishedAt": "2023-07-11T04:43:25Z",
+                "containerID": "docker://84d3d308bb9a5765e637884194e718d297046f156a377cf6145a9397d5e469b7"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0",
+            "imageID": "docker-pullable://us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater@sha256:b99901aacc6c87f86a767b3a0b02cdc926aae62bb4a5e7361d895f26f4773562",
+            "containerID": "docker://84d3d308bb9a5765e637884194e718d297046f156a377cf6145a9397d5e469b7",
+            "started": false
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-pending-node-affinity.json
+++ b/pkg/analyze/files/pods/message-pending-node-affinity.json
@@ -1,0 +1,1080 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "954528"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "kotsadm-b6cb54c8f-zgzrn",
+        "generateName": "kotsadm-b6cb54c8f-",
+        "namespace": "message-pending-node-affinity",
+        "uid": "6947a9d5-f99e-4efc-81ce-2ee36083f307",
+        "resourceVersion": "904719",
+        "creationTimestamp": "2023-07-07T05:22:09Z",
+        "labels": {
+          "app": "kotsadm",
+          "kots.io/backup": "velero",
+          "kots.io/kotsadm": "true",
+          "pod-template-hash": "b6cb54c8f"
+        },
+        "annotations": {
+          "backup.velero.io/backup-volumes": "backup",
+          "pre.hook.backup.velero.io/command": "[\"/backup.sh\"]",
+          "pre.hook.backup.velero.io/timeout": "10m"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "kotsadm-b6cb54c8f",
+            "uid": "6dad9479-a0c9-45af-9212-273ded35e6a1",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-07T05:22:09Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:backup.velero.io/backup-volumes": {},
+                  "f:pre.hook.backup.velero.io/command": {},
+                  "f:pre.hook.backup.velero.io/timeout": {}
+                },
+                "f:generateName": {},
+                "f:labels": {
+                  ".": {},
+                  "f:app": {},
+                  "f:kots.io/backup": {},
+                  "f:kots.io/kotsadm": {},
+                  "f:pod-template-hash": {}
+                },
+                "f:ownerReferences": {
+                  ".": {},
+                  "k:{\"uid\":\"6dad9479-a0c9-45af-9212-273ded35e6a1\"}": {}
+                }
+              },
+              "f:spec": {
+                "f:affinity": {
+                  ".": {},
+                  "f:nodeAffinity": {
+                    ".": {},
+                    "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                  }
+                },
+                "f:containers": {
+                  "k:{\"name\":\"kotsadm\"}": {
+                    ".": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"API_ADVERTISE_ENDPOINT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"API_ENCRYPTION_KEY\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"API_ENDPOINT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"AUTO_CREATE_CLUSTER_TOKEN\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"HTTPS_PROXY\"}": {
+                        ".": {},
+                        "f:name": {}
+                      },
+                      "k:{\"name\":\"HTTP_PROXY\"}": {
+                        ".": {},
+                        "f:name": {}
+                      },
+                      "k:{\"name\":\"KOTS_INSTALL_ID\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"NO_PROXY\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"POD_NAMESPACE\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:fieldRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"POD_OWNER_KIND\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"POSTGRES_SCHEMA_DIR\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"POSTGRES_URI\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"RQLITE_PASSWORD\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"RQLITE_URI\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"S3_ACCESS_KEY_ID\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"S3_BUCKET_ENDPOINT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"S3_BUCKET_NAME\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"S3_ENDPOINT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"S3_SECRET_ACCESS_KEY\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"SESSION_KEY\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"SHARED_PASSWORD_BCRYPT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:ports": {
+                      ".": {},
+                      "k:{\"containerPort\":3000,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:name": {},
+                        "f:protocol": {}
+                      }
+                    },
+                    "f:readinessProbe": {
+                      ".": {},
+                      "f:failureThreshold": {},
+                      "f:httpGet": {
+                        ".": {},
+                        "f:path": {},
+                        "f:port": {},
+                        "f:scheme": {}
+                      },
+                      "f:initialDelaySeconds": {},
+                      "f:periodSeconds": {},
+                      "f:successThreshold": {},
+                      "f:timeoutSeconds": {}
+                    },
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/backup\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      },
+                      "k:{\"mountPath\":\"/tmp\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:initContainers": {
+                  ".": {},
+                  "k:{\"name\":\"restore-db\"}": {
+                    ".": {},
+                    "f:command": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"RQLITE_PASSWORD\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/backup\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      },
+                      "k:{\"mountPath\":\"/tmp\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  },
+                  "k:{\"name\":\"restore-s3\"}": {
+                    ".": {},
+                    "f:command": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"S3_ACCESS_KEY_ID\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      },
+                      "k:{\"name\":\"S3_BUCKET_ENDPOINT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"S3_BUCKET_NAME\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"S3_ENDPOINT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"S3_SECRET_ACCESS_KEY\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/backup\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  },
+                  "k:{\"name\":\"schemahero-apply\"}": {
+                    ".": {},
+                    "f:args": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"SCHEMAHERO_DDL\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"SCHEMAHERO_DRIVER\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"SCHEMAHERO_URI\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/migrations\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  },
+                  "k:{\"name\":\"schemahero-plan\"}": {
+                    ".": {},
+                    "f:args": {},
+                    "f:env": {
+                      ".": {},
+                      "k:{\"name\":\"SCHEMAHERO_DRIVER\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"SCHEMAHERO_OUT\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"SCHEMAHERO_SPEC_FILE\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:value": {}
+                      },
+                      "k:{\"name\":\"SCHEMAHERO_URI\"}": {
+                        ".": {},
+                        "f:name": {},
+                        "f:valueFrom": {
+                          ".": {},
+                          "f:secretKeyRef": {}
+                        }
+                      }
+                    },
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/migrations\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  }
+                },
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {
+                  ".": {},
+                  "f:fsGroup": {},
+                  "f:runAsUser": {}
+                },
+                "f:serviceAccount": {},
+                "f:serviceAccountName": {},
+                "f:terminationGracePeriodSeconds": {},
+                "f:volumes": {
+                  ".": {},
+                  "k:{\"name\":\"backup\"}": {
+                    ".": {},
+                    "f:emptyDir": {},
+                    "f:name": {}
+                  },
+                  "k:{\"name\":\"migrations\"}": {
+                    ".": {},
+                    "f:emptyDir": {
+                      ".": {},
+                      "f:medium": {}
+                    },
+                    "f:name": {}
+                  },
+                  "k:{\"name\":\"tmp\"}": {
+                    ".": {},
+                    "f:emptyDir": {},
+                    "f:name": {}
+                  }
+                }
+              }
+            }
+          },
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-07T05:22:09Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  ".": {},
+                  "k:{\"type\":\"PodScheduled\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                }
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "migrations",
+            "emptyDir": {
+              "medium": "Memory"
+            }
+          },
+          {
+            "name": "backup",
+            "emptyDir": {}
+          },
+          {
+            "name": "tmp",
+            "emptyDir": {}
+          },
+          {
+            "name": "kube-api-access-q4hz4",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "initContainers": [
+          {
+            "name": "schemahero-plan",
+            "image": "kotsadm/kotsadm-migrations:v1.100.3",
+            "args": [
+              "plan"
+            ],
+            "env": [
+              {
+                "name": "SCHEMAHERO_DRIVER",
+                "value": "rqlite"
+              },
+              {
+                "name": "SCHEMAHERO_SPEC_FILE",
+                "value": "/tables"
+              },
+              {
+                "name": "SCHEMAHERO_OUT",
+                "value": "/migrations/plan.yaml"
+              },
+              {
+                "name": "SCHEMAHERO_URI",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-rqlite",
+                    "key": "uri"
+                  }
+                }
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "100Mi"
+              },
+              "requests": {
+                "cpu": "50m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "migrations",
+                "mountPath": "/migrations"
+              },
+              {
+                "name": "kube-api-access-q4hz4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          },
+          {
+            "name": "schemahero-apply",
+            "image": "kotsadm/kotsadm-migrations:v1.100.3",
+            "args": [
+              "apply"
+            ],
+            "env": [
+              {
+                "name": "SCHEMAHERO_DRIVER",
+                "value": "rqlite"
+              },
+              {
+                "name": "SCHEMAHERO_DDL",
+                "value": "/migrations/plan.yaml"
+              },
+              {
+                "name": "SCHEMAHERO_URI",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-rqlite",
+                    "key": "uri"
+                  }
+                }
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "100m",
+                "memory": "100Mi"
+              },
+              "requests": {
+                "cpu": "50m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "migrations",
+                "mountPath": "/migrations"
+              },
+              {
+                "name": "kube-api-access-q4hz4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          },
+          {
+            "name": "restore-db",
+            "image": "kotsadm/kotsadm:v1.100.3",
+            "command": [
+              "/restore-db.sh"
+            ],
+            "env": [
+              {
+                "name": "RQLITE_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-rqlite",
+                    "key": "password"
+                  }
+                }
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "2Gi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "100Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "backup",
+                "mountPath": "/backup"
+              },
+              {
+                "name": "tmp",
+                "mountPath": "/tmp"
+              },
+              {
+                "name": "kube-api-access-q4hz4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          },
+          {
+            "name": "restore-s3",
+            "image": "kotsadm/kotsadm:v1.100.3",
+            "command": [
+              "/restore-s3.sh"
+            ],
+            "env": [
+              {
+                "name": "S3_ENDPOINT",
+                "value": "http://kotsadm-minio:9000"
+              },
+              {
+                "name": "S3_BUCKET_NAME",
+                "value": "kotsadm"
+              },
+              {
+                "name": "S3_ACCESS_KEY_ID",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-minio",
+                    "key": "accesskey"
+                  }
+                }
+              },
+              {
+                "name": "S3_SECRET_ACCESS_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-minio",
+                    "key": "secretkey"
+                  }
+                }
+              },
+              {
+                "name": "S3_BUCKET_ENDPOINT",
+                "value": "true"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "2Gi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "100Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "backup",
+                "mountPath": "/backup"
+              },
+              {
+                "name": "kube-api-access-q4hz4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "containers": [
+          {
+            "name": "kotsadm",
+            "image": "kotsadm/kotsadm:v1.100.3",
+            "ports": [
+              {
+                "name": "http",
+                "containerPort": 3000,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "SHARED_PASSWORD_BCRYPT",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-password",
+                    "key": "passwordBcrypt"
+                  }
+                }
+              },
+              {
+                "name": "AUTO_CREATE_CLUSTER_TOKEN",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-cluster-token",
+                    "key": "kotsadm-cluster-token"
+                  }
+                }
+              },
+              {
+                "name": "SESSION_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-session",
+                    "key": "key"
+                  }
+                }
+              },
+              {
+                "name": "RQLITE_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-rqlite",
+                    "key": "password"
+                  }
+                }
+              },
+              {
+                "name": "RQLITE_URI",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-rqlite",
+                    "key": "uri"
+                  }
+                }
+              },
+              {
+                "name": "POSTGRES_URI",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-postgres",
+                    "key": "uri",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "POSTGRES_SCHEMA_DIR",
+                "value": "/postgres/tables"
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              },
+              {
+                "name": "POD_OWNER_KIND",
+                "value": "deployment"
+              },
+              {
+                "name": "API_ENCRYPTION_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-encryption",
+                    "key": "encryptionKey"
+                  }
+                }
+              },
+              {
+                "name": "API_ENDPOINT",
+                "value": "http://kotsadm.test.svc.cluster.local:3000"
+              },
+              {
+                "name": "API_ADVERTISE_ENDPOINT",
+                "value": "http://localhost:8800"
+              },
+              {
+                "name": "S3_ENDPOINT",
+                "value": "http://kotsadm-minio:9000"
+              },
+              {
+                "name": "S3_BUCKET_NAME",
+                "value": "kotsadm"
+              },
+              {
+                "name": "S3_ACCESS_KEY_ID",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-minio",
+                    "key": "accesskey"
+                  }
+                }
+              },
+              {
+                "name": "S3_SECRET_ACCESS_KEY",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "kotsadm-minio",
+                    "key": "secretkey"
+                  }
+                }
+              },
+              {
+                "name": "S3_BUCKET_ENDPOINT",
+                "value": "true"
+              },
+              {
+                "name": "HTTP_PROXY"
+              },
+              {
+                "name": "HTTPS_PROXY"
+              },
+              {
+                "name": "NO_PROXY",
+                "value": "kotsadm-rqlite,kotsadm-postgres,kotsadm-minio,kotsadm-api-node"
+              },
+              {
+                "name": "KOTS_INSTALL_ID",
+                "value": "2SEMUZ2Va7cvFsWzphGRuMxhcN6"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "2Gi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "100Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "backup",
+                "mountPath": "/backup"
+              },
+              {
+                "name": "tmp",
+                "mountPath": "/tmp"
+              },
+              {
+                "name": "kube-api-access-q4hz4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/healthz",
+                "port": 3000,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 1,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "kotsadm",
+        "serviceAccount": "kotsadm",
+        "securityContext": {
+          "runAsUser": 1001,
+          "fsGroup": 1001
+        },
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "kubernetes.io/os",
+                      "operator": "In",
+                      "values": [
+                        "linux"
+                      ]
+                    },
+                    {
+                      "key": "kubernetes.io/arch",
+                      "operator": "NotIn",
+                      "values": [
+                        "arm64"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "PodScheduled",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-07T05:22:09Z",
+            "reason": "Unschedulable",
+            "message": "0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-pending-pod-resources.json
+++ b/pkg/analyze/files/pods/message-pending-pod-resources.json
@@ -1,0 +1,223 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "984246"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "pending-pod-resources-5fddcf7688-djjfc",
+        "generateName": "pending-pod-resources-5fddcf7688-",
+        "namespace": "message-pending-pod-resources",
+        "uid": "e4d4c4cc-2c41-4ab7-b41c-9c8b28ded451",
+        "resourceVersion": "983556",
+        "creationTimestamp": "2023-07-11T04:20:29Z",
+        "labels": {
+          "app": "pending-pod-resources",
+          "pod-template-hash": "5fddcf7688"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "pending-pod-resources-5fddcf7688",
+            "uid": "f57de73f-8492-4118-b4da-b0f9d7408c9b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ],
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:20:29Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:generateName": {},
+                "f:labels": {
+                  ".": {},
+                  "f:app": {},
+                  "f:pod-template-hash": {}
+                },
+                "f:ownerReferences": {
+                  ".": {},
+                  "k:{\"uid\":\"f57de73f-8492-4118-b4da-b0f9d7408c9b\"}": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"nginx\"}": {
+                    ".": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {
+                      ".": {},
+                      "f:limits": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {},
+                        "f:nvidia.com/gpu": {}
+                      },
+                      "f:requests": {
+                        ".": {},
+                        "f:cpu": {},
+                        "f:memory": {},
+                        "f:nvidia.com/gpu": {}
+                      }
+                    },
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {}
+              }
+            }
+          },
+          {
+            "manager": "kube-scheduler",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:20:29Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  ".": {},
+                  "k:{\"type\":\"PodScheduled\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                }
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "kube-api-access-sjnlv",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx",
+            "resources": {
+              "limits": {
+                "cpu": "3",
+                "memory": "5Gi",
+                "nvidia.com/gpu": "5"
+              },
+              "requests": {
+                "cpu": "3",
+                "memory": "5Gi",
+                "nvidia.com/gpu": "5"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "kube-api-access-sjnlv",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "PodScheduled",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:20:29Z",
+            "reason": "Unschedulable",
+            "message": "0/1 nodes are available: 1 Insufficient nvidia.com/gpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod."
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-pod-crashloop-backoff.json
+++ b/pkg/analyze/files/pods/message-pod-crashloop-backoff.json
@@ -1,0 +1,284 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "981519"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo",
+        "namespace": "message-pod-crashloop-backoff",
+        "uid": "8d27f35a-4b45-4752-a5db-7985ea8b38bf",
+        "resourceVersion": "981491",
+        "creationTimestamp": "2023-07-11T03:31:41Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"init-demo\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"wge\",\"-O\",\"/work-dir/index.html\",\"https://home.robusta.dev\"],\"image\":\"nginx\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}\n"
+        },
+        "managedFields": [
+          {
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:31:41Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"nginx\"}": {
+                    ".": {},
+                    "f:command": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:ports": {
+                      ".": {},
+                      "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:protocol": {}
+                      }
+                    },
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {}
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {}
+              }
+            }
+          },
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T03:33:23Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  "k:{\"type\":\"ContainersReady\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Initialized\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Ready\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                },
+                "f:containerStatuses": {},
+                "f:hostIP": {},
+                "f:phase": {},
+                "f:podIP": {},
+                "f:podIPs": {
+                  ".": {},
+                  "k:{\"ip\":\"172.17.0.3\"}": {
+                    ".": {},
+                    "f:ip": {}
+                  }
+                },
+                "f:startTime": {}
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "kube-api-access-htb9q",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx",
+            "command": [
+              "wge",
+              "-O",
+              "/work-dir/index.html",
+              "https://home.robusta.dev"
+            ],
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "kube-api-access-htb9q",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T03:31:41Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T03:31:41Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [nginx]"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T03:31:41Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [nginx]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T03:31:41Z"
+          }
+        ],
+        "hostIP": "192.168.49.2",
+        "podIP": "172.17.0.3",
+        "podIPs": [
+          {
+            "ip": "172.17.0.3"
+          }
+        ],
+        "startTime": "2023-07-11T03:31:41Z",
+        "containerStatuses": [
+          {
+            "name": "nginx",
+            "state": {
+              "waiting": {
+                "reason": "CrashLoopBackOff",
+                "message": "back-off 1m20s restarting failed container=nginx pod=init-demo_default(8d27f35a-4b45-4752-a5db-7985ea8b38bf)"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 127,
+                "reason": "ContainerCannotRun",
+                "message": "failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown",
+                "startedAt": "2023-07-11T03:33:15Z",
+                "finishedAt": "2023-07-11T03:33:15Z",
+                "containerID": "docker://c04bcccbdc5eee8f0fc1b88c85c9b31e79f963dbee75fda97c022938222c8d90"
+              }
+            },
+            "ready": false,
+            "restartCount": 4,
+            "image": "nginx:latest",
+            "imageID": "docker-pullable://nginx@sha256:08bc36ad52474e528cc1ea3426b5e3f4bad8a130318e3140d6cfe29c8892c7ef",
+            "containerID": "docker://c04bcccbdc5eee8f0fc1b88c85c9b31e79f963dbee75fda97c022938222c8d90",
+            "started": false
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/files/pods/message-pod-init-crashloop-backoff.json
+++ b/pkg/analyze/files/pods/message-pod-init-crashloop-backoff.json
@@ -1,0 +1,368 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "982711"
+  },
+  "items": [
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "init-demo2",
+        "namespace": "message-pod-init-crashloop-backoff",
+        "uid": "5a560e83-c634-4c91-b308-510ee692ed6a",
+        "resourceVersion": "982707",
+        "creationTimestamp": "2023-07-11T04:01:16Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"init-demo2\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"volumeMounts\":[{\"mountPath\":\"/usr/share/nginx/html\",\"name\":\"workdir\"}]}],\"dnsPolicy\":\"Default\",\"initContainers\":[{\"command\":[\"wge\",\"-O\",\"/work-dir/index.html\",\"https://home.robusta.dev\"],\"image\":\"busybox:1.28\",\"name\":\"install\",\"volumeMounts\":[{\"mountPath\":\"/work-dir\",\"name\":\"workdir\"}]}],\"volumes\":[{\"emptyDir\":{},\"name\":\"workdir\"}]}}\n"
+        },
+        "managedFields": [
+          {
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:01:16Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                }
+              },
+              "f:spec": {
+                "f:containers": {
+                  "k:{\"name\":\"nginx\"}": {
+                    ".": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:ports": {
+                      ".": {},
+                      "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                        ".": {},
+                        "f:containerPort": {},
+                        "f:protocol": {}
+                      }
+                    },
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/usr/share/nginx/html\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  }
+                },
+                "f:dnsPolicy": {},
+                "f:enableServiceLinks": {},
+                "f:initContainers": {
+                  ".": {},
+                  "k:{\"name\":\"install\"}": {
+                    ".": {},
+                    "f:command": {},
+                    "f:image": {},
+                    "f:imagePullPolicy": {},
+                    "f:name": {},
+                    "f:resources": {},
+                    "f:terminationMessagePath": {},
+                    "f:terminationMessagePolicy": {},
+                    "f:volumeMounts": {
+                      ".": {},
+                      "k:{\"mountPath\":\"/work-dir\"}": {
+                        ".": {},
+                        "f:mountPath": {},
+                        "f:name": {}
+                      }
+                    }
+                  }
+                },
+                "f:restartPolicy": {},
+                "f:schedulerName": {},
+                "f:securityContext": {},
+                "f:terminationGracePeriodSeconds": {},
+                "f:volumes": {
+                  ".": {},
+                  "k:{\"name\":\"workdir\"}": {
+                    ".": {},
+                    "f:emptyDir": {},
+                    "f:name": {}
+                  }
+                }
+              }
+            }
+          },
+          {
+            "manager": "kubelet",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-07-11T04:01:23Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:status": {
+                "f:conditions": {
+                  "k:{\"type\":\"ContainersReady\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Initialized\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  },
+                  "k:{\"type\":\"Ready\"}": {
+                    ".": {},
+                    "f:lastProbeTime": {},
+                    "f:lastTransitionTime": {},
+                    "f:message": {},
+                    "f:reason": {},
+                    "f:status": {},
+                    "f:type": {}
+                  }
+                },
+                "f:containerStatuses": {},
+                "f:hostIP": {},
+                "f:initContainerStatuses": {},
+                "f:podIP": {},
+                "f:podIPs": {
+                  ".": {},
+                  "k:{\"ip\":\"172.17.0.3\"}": {
+                    ".": {},
+                    "f:ip": {}
+                  }
+                },
+                "f:startTime": {}
+              }
+            },
+            "subresource": "status"
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "workdir",
+            "emptyDir": {}
+          },
+          {
+            "name": "kube-api-access-w4mrq",
+            "projected": {
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "expirationSeconds": 3607,
+                    "path": "token"
+                  }
+                },
+                {
+                  "configMap": {
+                    "name": "kube-root-ca.crt",
+                    "items": [
+                      {
+                        "key": "ca.crt",
+                        "path": "ca.crt"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "downwardAPI": {
+                    "items": [
+                      {
+                        "path": "namespace",
+                        "fieldRef": {
+                          "apiVersion": "v1",
+                          "fieldPath": "metadata.namespace"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "defaultMode": 420
+            }
+          }
+        ],
+        "initContainers": [
+          {
+            "name": "install",
+            "image": "busybox:1.28",
+            "command": [
+              "wge",
+              "-O",
+              "/work-dir/index.html",
+              "https://home.robusta.dev"
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "workdir",
+                "mountPath": "/work-dir"
+              },
+              {
+                "name": "kube-api-access-w4mrq",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "workdir",
+                "mountPath": "/usr/share/nginx/html"
+              },
+              {
+                "name": "kube-api-access-w4mrq",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "Default",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {},
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true,
+        "preemptionPolicy": "PreemptLowerPriority"
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:01:16Z",
+            "reason": "ContainersNotInitialized",
+            "message": "containers with incomplete status: [install]"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:01:16Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [nginx]"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:01:16Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [nginx]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2023-07-11T04:01:16Z"
+          }
+        ],
+        "hostIP": "192.168.49.2",
+        "podIP": "172.17.0.3",
+        "podIPs": [
+          {
+            "ip": "172.17.0.3"
+          }
+        ],
+        "startTime": "2023-07-11T04:01:16Z",
+        "initContainerStatuses": [
+          {
+            "name": "install",
+            "state": {
+              "waiting": {
+                "reason": "RunContainerError",
+                "message": "failed to start container \"b201927f10154b9ab9913f65aa13b46e5eeed74b8efff500d11e3f08af09621b\": Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 127,
+                "reason": "ContainerCannotRun",
+                "message": "failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: \"wge\": executable file not found in $PATH: unknown",
+                "startedAt": "2023-07-11T04:01:16Z",
+                "finishedAt": "2023-07-11T04:01:16Z",
+                "containerID": "docker://b201927f10154b9ab9913f65aa13b46e5eeed74b8efff500d11e3f08af09621b"
+              }
+            },
+            "ready": false,
+            "restartCount": 1,
+            "image": "busybox:1.28",
+            "imageID": "docker-pullable://busybox@sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+            "containerID": "docker://b201927f10154b9ab9913f65aa13b46e5eeed74b8efff500d11e3f08af09621b"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "name": "nginx",
+            "state": {
+              "waiting": {
+                "reason": "PodInitializing"
+              }
+            },
+            "lastState": {},
+            "ready": false,
+            "restartCount": 0,
+            "image": "nginx",
+            "imageID": "",
+            "started": false
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -58,16 +58,23 @@ func GetPodStatusReason(pod *corev1.Pod) (string, string) {
 			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
 			initializing = true
 		}
+
+		if container.LastTerminationState.Terminated != nil && container.LastTerminationState.Terminated.Message != "" {
+			message += container.LastTerminationState.Terminated.Message
+		}
 		break
 	}
 	if !initializing {
 		hasRunning := false
-		fmt.Println(pod.Status.Conditions[0].Message)
+
 		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
 			container := pod.Status.ContainerStatuses[i]
 
 			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
 				reason = container.State.Waiting.Reason
+				if container.LastTerminationState.Terminated != nil && container.LastTerminationState.Terminated.Message != "" {
+					message += container.LastTerminationState.Terminated.Message
+				}
 			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
 				reason = container.State.Terminated.Reason
 			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {

--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -72,8 +72,12 @@ func GetPodStatusReason(pod *corev1.Pod) (string, string) {
 
 			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
 				reason = container.State.Waiting.Reason
-				if container.LastTerminationState.Terminated != nil && container.LastTerminationState.Terminated.Message != "" {
-					message += container.LastTerminationState.Terminated.Message
+				if container.LastTerminationState.Terminated != nil {
+					if container.LastTerminationState.Terminated.Message != "" {
+						message += container.LastTerminationState.Terminated.Message
+					} else {
+						message += fmt.Sprintf("ExitCode:%d", container.LastTerminationState.Terminated.ExitCode)
+					}
 				}
 			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
 				reason = container.State.Terminated.Reason

--- a/pkg/k8sutil/pod.go
+++ b/pkg/k8sutil/pod.go
@@ -77,6 +77,7 @@ func GetPodStatusReason(pod *corev1.Pod) (string, string) {
 				}
 			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
 				reason = container.State.Terminated.Reason
+				message = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
 			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
 				if container.State.Terminated.Signal != 0 {
 					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)


### PR DESCRIPTION
## Description, Motivation and Context

- add event message from unhealthy pod
- if the pod is crashing, it will return the last terminated pod messages
- if the pod is crashing and no terminated pod messages, it will return exit code
- if the pod is crashing with initial container, it will check events and return the warning messages
- the clusterPodStatuses will check both events and pod status to find all the useful messages or exit code

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
