### PR TITLE
feat(cluster_resources): add leases and service account

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -1978,7 +1978,7 @@ func endpoints(ctx context.Context, client *kubernetes.Clientset, namespaces []s
 	return endpointsByNamespace, errorsByNamespace
 }
 
-func serviceAccounts(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
+func serviceAccounts(ctx context.Context, client kubernetes.Interface, namespaces []string) (map[string][]byte, map[string]string) {
 	serviceAccountsByNamespace := make(map[string][]byte)
 	errorsByNamespace := make(map[string]string)
 
@@ -2013,7 +2013,7 @@ func serviceAccounts(ctx context.Context, client *kubernetes.Clientset, namespac
 	return serviceAccountsByNamespace, errorsByNamespace
 }
 
-func leases(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
+func leases(ctx context.Context, client kubernetes.Interface, namespaces []string) (map[string][]byte, map[string]string) {
 	leasesByNamespace := make(map[string][]byte)
 	errorsByNamespace := make(map[string]string)
 

--- a/pkg/collect/cluster_resources_test.go
+++ b/pkg/collect/cluster_resources_test.go
@@ -10,10 +10,94 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
+
+func Test_ConfigMaps(t *testing.T) {
+	tests := []struct {
+		name          string
+		configMapName string
+		namespaces    []string
+	}{
+		{
+			name:          "single namespace",
+			configMapName: "default",
+			namespaces:    []string{"default"},
+		},
+		{
+			name:          "multiple namespaces",
+			configMapName: "default",
+			namespaces:    []string{"default", "test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := testclient.NewSimpleClientset()
+			ctx := context.Background()
+			err := createConfigMaps(client, tt.configMapName, tt.namespaces)
+			require.NoError(t, err)
+
+			configMaps, _ := configMaps(ctx, client, tt.namespaces)
+			assert.Equal(t, len(tt.namespaces), len(configMaps))
+
+			for _, ns := range tt.namespaces {
+				assert.NotEmpty(t, configMaps[ns+".json"])
+			}
+		})
+	}
+}
+
+func createConfigMaps(client kubernetes.Interface, configMapName string, namespaces []string) error {
+	for _, ns := range namespaces {
+		_, err := client.CoreV1().ConfigMaps(ns).Create(context.Background(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMapName,
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Test_VolumeAttachments(t *testing.T) {
+	tests := []struct {
+		name      string
+		leaseName string
+	}{
+		{
+			name:      "single namespace",
+			leaseName: "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := testclient.NewSimpleClientset()
+			ctx := context.Background()
+			err := createTestVolumeAttachments(client, tt.leaseName)
+			require.NoError(t, err)
+
+			volumeAttachments, _ := volumeAttachments(ctx, client)
+			assert.NotEmpty(t, volumeAttachments)
+		})
+	}
+}
+
+func createTestVolumeAttachments(client kubernetes.Interface, leaseName string) error {
+	_, err := client.StorageV1().VolumeAttachments().Create(context.Background(), &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: leaseName,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func Test_Leases(t *testing.T) {
 	tests := []struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,6 +54,8 @@ const (
 	CLUSTER_RESOURCES_CLUSTER_ROLE_BINDINGS       = "clusterrolebindings"
 	CLUSTER_RESOURCES_PRIORITY_CLASS              = "priorityclasses"
 	CLUSTER_RESOURCES_ENDPOINTS                   = "endpoints"
+	CLUSTER_RESOURCES_SERVICE_ACCOUNTS            = "serviceaccounts"
+	CLUSTER_RESOURCES_LEASES                      = "leases"
 
 	// SelfSubjectRulesReview evaluation responses
 	SELFSUBJECTRULESREVIEW_ERROR_AUTHORIZATION_WEBHOOK_UNSUPPORTED = "webhook authorizer does not support user rule resolution"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,6 +56,8 @@ const (
 	CLUSTER_RESOURCES_ENDPOINTS                   = "endpoints"
 	CLUSTER_RESOURCES_SERVICE_ACCOUNTS            = "serviceaccounts"
 	CLUSTER_RESOURCES_LEASES                      = "leases"
+	CLUSTER_RESOURCES_VOLUME_ATTACHMENTS          = "volumeattachments"
+	CLUSTER_RESOURCES_CONFIGMAPS                  = "configmaps"
 
 	// SelfSubjectRulesReview evaluation responses
 	SELFSUBJECTRULESREVIEW_ERROR_AUTHORIZATION_WEBHOOK_UNSUPPORTED = "webhook authorizer does not support user rule resolution"

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -41,6 +41,8 @@ fi
 base_path="$tmpdir/$bundle_directory_name/cluster-resources"
 folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "resource-quota" "rolebindings" "serviceaccounts")
 
+files=("volumeattachments")
+
 for folder in "${folders[@]}"; do
     if [ -d "$base_path/$folder" ]; then
         echo "$folder directory was collected"
@@ -52,6 +54,16 @@ for folder in "${folders[@]}"; do
         fi
     else
         echo "The $folder folder does not exist in $base_path path."
+        exit 1
+    fi
+done
+
+for file in "${files[@]}"; do
+    if [ -e "$base_path/$file.json" ]
+    then
+        echo "$file.json file was collected"
+    else
+        echo "The $file.json file does not exist in $base_path path."
         exit 1
     fi
 done

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -38,6 +38,13 @@ if grep -q "No matching files" "$tmpdir/$bundle_directory_name/analysis.json"; t
     exit 1
 fi
 
+if [ -d "$tmpdir/$bundle_directory_name/cluster-resources/serviceaccounts" ]; then
+    echo "Service Accounts directory was collected"
+else
+    echo "The serviceaccounts folder does not exist in /cluster-resources/ path."
+    exit 1
+fi 
+
 EXIT_STATUS=0
 jq -r '.[].insight.severity' "$tmpdir/$bundle_directory_name/analysis.json" | while read i; do
     if [ $i == "error" ]; then

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -41,7 +41,7 @@ fi
 base_path="$tmpdir/$bundle_directory_name/cluster-resources"
 folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "resource-quota" "rolebindings" "serviceaccounts")
 
-files=("volumeattachments")
+files=("namespaces" "volumeattachments" "pvs" "groups" "nodes" "priorityclasses" "resources")
 
 for folder in "${folders[@]}"; do
     if [ -d "$base_path/$folder" ]; then

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -39,7 +39,7 @@ if grep -q "No matching files" "$tmpdir/$bundle_directory_name/analysis.json"; t
 fi
 
 base_path="$tmpdir/$bundle_directory_name/cluster-resources"
-folders=("serviceaccounts" "services" "leases")
+folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "volumeattachments" "resource-quota" "rolebindings" "serviceaccounts")
 
 for folder in "${folders[@]}"; do
     if [ -d "$base_path/$folder" ]; then

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -41,7 +41,7 @@ fi
 base_path="$tmpdir/$bundle_directory_name/cluster-resources"
 folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "resource-quota" "rolebindings" "serviceaccounts")
 
-files=("volumeattachments")
+files=("namespaces" "volumeattachments" "pvs" "groups" "nodes" "priorityclasses" "resources")
 
 for folder in "${folders[@]}"; do
     if [ -d "$base_path/$folder" ]; then
@@ -61,7 +61,6 @@ done
 for file in "${files[@]}"; do
     if [ -e "$base_path/$file.json" ]
     then
-        cat "$base_path/$file.json"
         echo "$file.json file was collected"
     else
         echo "The $file.json file does not exist in $base_path path."

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -39,7 +39,7 @@ if grep -q "No matching files" "$tmpdir/$bundle_directory_name/analysis.json"; t
 fi
 
 base_path="$tmpdir/$bundle_directory_name/cluster-resources"
-folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "volumeattachments" "resource-quota" "rolebindings" "serviceaccounts")
+folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "resource-quota" "rolebindings" "serviceaccounts")
 
 for folder in "${folders[@]}"; do
     if [ -d "$base_path/$folder" ]; then

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -41,7 +41,7 @@ fi
 base_path="$tmpdir/$bundle_directory_name/cluster-resources"
 folders=("auth-cani-list" "configmaps" "daemonsets" "endpoints" "events" "deployments" "leases" "services" "pvcs" "pvcs" "jobs" "roles" "statefulsets" "network-policy" "pods" "resource-quota" "rolebindings" "serviceaccounts")
 
-files=("namespaces" "volumeattachments" "pvs" "groups" "nodes" "priorityclasses" "resources")
+files=("volumeattachments")
 
 for folder in "${folders[@]}"; do
     if [ -d "$base_path/$folder" ]; then
@@ -61,6 +61,7 @@ done
 for file in "${files[@]}"; do
     if [ -e "$base_path/$file.json" ]
     then
+        cat "$base_path/$file.json"
         echo "$file.json file was collected"
     else
         echo "The $file.json file does not exist in $base_path path."

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -38,12 +38,23 @@ if grep -q "No matching files" "$tmpdir/$bundle_directory_name/analysis.json"; t
     exit 1
 fi
 
-if [ -d "$tmpdir/$bundle_directory_name/cluster-resources/serviceaccounts" ]; then
-    echo "Service Accounts directory was collected"
-else
-    echo "The serviceaccounts folder does not exist in /cluster-resources/ path."
-    exit 1
-fi 
+base_path="$tmpdir/$bundle_directory_name/cluster-resources"
+folders=("serviceaccounts" "services" "leases")
+
+for folder in "${folders[@]}"; do
+    if [ -d "$base_path/$folder" ]; then
+        echo "$folder directory was collected"
+        if [ "$(ls -A $base_path/$folder)" ]; then
+            echo "$folder directory is not empty"
+        else
+            echo "$folder directory is empty"
+            exit 1
+        fi
+    else
+        echo "The $folder folder does not exist in $base_path path."
+        exit 1
+    fi
+done
 
 EXIT_STATUS=0
 jq -r '.[].insight.severity' "$tmpdir/$bundle_directory_name/analysis.json" | while read i; do


### PR DESCRIPTION
## Description, Motivation and Context

- add leases and service accounts for [Cluster resources collector](https://troubleshoot.sh/docs/collect/cluster-resources/)
- add configmap and volume attachments
<!--- If it relates to an open issue, please link to the issue here.

e.g.
Fixes: #414
-->
Fixes: 
#1157
#1217

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
