### PR TITLE
feat: Add Strict flag to LoadSpecs API

### DIFF
--- a/internal/traces/exporter.go
+++ b/internal/traces/exporter.go
@@ -22,7 +22,7 @@ var (
 	printer  = message.NewPrinter(language.English)
 )
 
-const legend = "Suceeded (S), eXcluded (X), Failed (F)\n"
+const legend = "Succeeded (S), eXcluded (X), Failed (F)\n"
 
 // FUTURE WORK: This exporter should only be used by troubleshoot CLIs
 // until the following issue is addressed:

--- a/internal/traces/exporter_test.go
+++ b/internal/traces/exporter_test.go
@@ -76,7 +76,7 @@ func TestExporter_GetSummary(t *testing.T) {
 			},
 			want: `
 ============ Collectors summary =============
-Suceeded (S), eXcluded (X), Failed (F)
+Succeeded (S), eXcluded (X), Failed (F)
 =============================================
 all-logs (S)           : 60,000ms
 host-os (S)            : 1,000ms
@@ -118,7 +118,7 @@ failed-collector (F)   : 1ms`,
 			},
 			want: `
 ============= Analyzers summary =============
-Suceeded (S), eXcluded (X), Failed (F)
+Succeeded (S), eXcluded (X), Failed (F)
 =============================================
 host-cpu (S)          : 60,000ms
 cluster-version (S)   : 1,000ms

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/troubleshoot/internal/util"
@@ -35,20 +34,34 @@ type parsedDoc struct {
 type LoadOptions struct {
 	RawSpecs []string
 	RawSpec  string
+
+	// If true, the loader will return an error if any of the specs are not valid
+	// else the invalid specs will be ignored
+	Strict bool
 }
 
 // LoadSpecs takes sources to load specs from and returns a TroubleshootKinds object
 // that contains all the parsed troubleshoot specs.
 //
-// The fetched specs need to be yaml documents. The documents can be a multidoc yaml
-// separated by "---" which get split and parsed one at a time. This function will
-// return an error if any of the documents are not valid yaml. If Secrets or ConfigMaps
-// are found, they will be parsed and the support bundle, redactor or preflight spec
-// will be extracted from them, else they will be ignored.
-// Any other yaml documents will be ignored.
+// The fetched specs should be yaml documents. The documents can be multidoc yamls
+// separated by "---" which get split and parsed one at a time. All troubleshoot
+// specs are extracted from the documents and returned in a TroubleshootKinds object.
+//
+// If Secrets or ConfigMaps are found, they are parsed and the support bundle, redactor
+// or preflight spec extracted from them. All other yaml documents will be ignored.
+//
+// If the `Strict` flag is set to true, this function will return an error if any of
+// the documents are not valid, else the invalid documents will be ignored.
 func LoadSpecs(ctx context.Context, opt LoadOptions) (*TroubleshootKinds, error) {
 	opt.RawSpecs = append(opt.RawSpecs, opt.RawSpec)
-	return loadFromStrings(opt.RawSpecs...)
+	l := specLoader{
+		strict: opt.Strict,
+	}
+	return l.loadFromStrings(opt.RawSpecs...)
+}
+
+type specLoader struct {
+	strict bool
 }
 
 type TroubleshootKinds struct {
@@ -78,13 +91,13 @@ func NewTroubleshootKinds() *TroubleshootKinds {
 }
 
 // loadFromStrings accepts a list of strings (exploded) which should be yaml documents
-func loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, error) {
+func (l *specLoader) loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, error) {
 	splitdocs := []string{}
 	multiRawDocs := []string{}
 
 	// 1. First split multidoc yaml documents.
 	for _, rawSpec := range rawSpecs {
-		multiRawDocs = append(multiRawDocs, strings.Split(rawSpec, "\n---\n")...)
+		multiRawDocs = append(multiRawDocs, util.SplitYAML(rawSpec)...)
 	}
 
 	// 2. Go through each document to see if it is a configmap, secret or troubleshoot kind
@@ -95,6 +108,9 @@ func loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, error) {
 
 		err := yaml.Unmarshal([]byte(rawDoc), &parsed)
 		if err != nil {
+			if !l.strict {
+				continue
+			}
 			return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Wrapf(err, "failed to parse yaml: '%s'", string(rawDoc)))
 		}
 
@@ -102,6 +118,9 @@ func loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, error) {
 			// Extract specs from configmap or secret
 			obj, _, err := decoder.Decode([]byte(rawDoc), nil, nil)
 			if err != nil {
+				if !l.strict {
+					continue
+				}
 				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES,
 					errors.Wrapf(err, "failed to decode raw spec: '%s'", string(rawDoc)),
 				)
@@ -110,14 +129,20 @@ func loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, error) {
 			// 3. Extract the raw troubleshoot specs
 			switch v := obj.(type) {
 			case *v1.ConfigMap:
-				specs, err := getSpecFromConfigMap(v)
+				specs, err := l.getSpecFromConfigMap(v)
 				if err != nil {
+					if !l.strict {
+						continue
+					}
 					return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
 				}
 				splitdocs = append(splitdocs, specs...)
 			case *v1.Secret:
-				specs, err := getSpecFromSecret(v)
+				specs, err := l.getSpecFromSecret(v)
 				if err != nil {
+					if !l.strict {
+						continue
+					}
 					return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
 				}
 				splitdocs = append(splitdocs, specs...)
@@ -133,20 +158,26 @@ func loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, error) {
 	}
 
 	// 4. Then load the specs into the kinds struct
-	return loadFromSplitDocs(splitdocs)
+	return l.loadFromSplitDocs(splitdocs)
 }
 
-func loadFromSplitDocs(splitdocs []string) (*TroubleshootKinds, error) {
+func (l *specLoader) loadFromSplitDocs(splitdocs []string) (*TroubleshootKinds, error) {
 	kinds := NewTroubleshootKinds()
 
 	for _, doc := range splitdocs {
 		converted, err := docrewrite.ConvertToV1Beta2([]byte(doc))
 		if err != nil {
+			if !l.strict {
+				continue
+			}
 			return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Wrapf(err, "failed to convert doc to troubleshoot.sh/v1beta2 kind: '%s'", doc))
 		}
 
 		obj, _, err := decoder.Decode([]byte(converted), nil, nil)
 		if err != nil {
+			if !l.strict {
+				continue
+			}
 			return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Wrapf(err, "failed to decode '%s'", converted))
 		}
 
@@ -193,7 +224,7 @@ func isConfigMap(parsedDocHead parsedDoc) bool {
 }
 
 // getSpecFromConfigMap extracts multiple troubleshoot specs from a secret
-func getSpecFromConfigMap(cm *v1.ConfigMap) ([]string, error) {
+func (l *specLoader) getSpecFromConfigMap(cm *v1.ConfigMap) ([]string, error) {
 	specs := []string{}
 
 	str, ok := cm.Data[constants.SupportBundleKey]
@@ -225,7 +256,7 @@ func getSpecFromConfigMap(cm *v1.ConfigMap) ([]string, error) {
 }
 
 // getSpecFromSecret extracts multiple troubleshoot specs from a secret
-func getSpecFromSecret(secret *v1.Secret) ([]string, error) {
+func (l *specLoader) getSpecFromSecret(secret *v1.Secret) ([]string, error) {
 	specs := []string{}
 
 	specBytes, ok := secret.Data[constants.SupportBundleKey]

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -77,7 +77,7 @@ array:- 1
 
 			kinds, err = LoadSpecs(ctx, LoadOptions{RawSpec: ts, Strict: false})
 			assert.NoError(t, err)
-			assert.Nil(t, kinds)
+			assert.Equal(t, NewTroubleshootKinds(), kinds)
 		})
 	}
 }

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -125,6 +125,19 @@ func TestLoadingInvalidYaml_IgnoreDocs(t *testing.T) {
 					},
 				},
 			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SupportBundle",
+					APIVersion: "troubleshoot.sh/v1beta2",
+				},
+				Spec: troubleshootv1beta2.SupportBundleSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+						},
+					},
+				},
+			},
 		},
 		PreflightsV1Beta2: []troubleshootv1beta2.Preflight{
 			{
@@ -134,6 +147,22 @@ func TestLoadingInvalidYaml_IgnoreDocs(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "preflight-1",
+				},
+				Spec: troubleshootv1beta2.PreflightSpec{
+					Collectors: []*troubleshootv1beta2.Collect{
+						{
+							ClusterResources: &troubleshootv1beta2.ClusterResources{},
+						},
+					},
+				},
+			},
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Preflight",
+					APIVersion: "troubleshoot.sh/v1beta2",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "preflight-2",
 				},
 				Spec: troubleshootv1beta2.PreflightSpec{
 					Collectors: []*troubleshootv1beta2.Collect{

--- a/testdata/yamldocs/multidoc-spec-with-invalids.yaml
+++ b/testdata/yamldocs/multidoc-spec-with-invalids.yaml
@@ -1,0 +1,79 @@
+---
+"@"
+---
+apiVersion: troubleshoot.sh/v1beta2
+kind: Collector
+spec:
+  collectors:
+  - clusterResources:
+      collectorName: my-cluster-resources
+---
+apiVersion: troubleshoot.sh/v1beta2
+kind: Redactor
+spec:
+  redactors:
+  - : replace password
+---
+apiVersion: troubleshoot.sh/v1beta2
+metadata:
+  name: certificate
+spec:
+  collectors:
+    - cpu: {}
+---
+kind: SupportBundle
+metadata:
+  name: my-support-bundle
+spec:
+  collectors:
+    - logs:
+        name: all-logs
+  hostCollectors:
+    - hostOS: {}
+  analyzers:
+    - clusterVersion: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sb-spec
+  labels:
+    troubleshoot.io/kind: support-bundle
+data:
+  support-bundle-spec: |-
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    spec:
+      collectors:
+        - logs:
+            name: all-logs
+    ---
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    spec:
+      collectors:
+        - : {}
+    ---
+    apiVersion: troubleshoot.sh/v1beta2
+      kind: SupportBundle
+    spec:
+      collectors:
+        - clusterInfo: {}
+---
+apiVersion: v1
+kind: Secret
+stringData:
+  preflight.yaml: |-
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Preflight
+    metadata:
+      name: preflight-1
+    spec:
+      collectors:
+        - clusterResources: {}
+    ---
+    apiVersion: troubleshoot.sh/v1beta2
+      kind: Preflight
+    spec:
+      :
+        - clusterInfo: {}

--- a/testdata/yamldocs/multidoc-spec-with-invalids.yaml
+++ b/testdata/yamldocs/multidoc-spec-with-invalids.yaml
@@ -59,10 +59,6 @@ data:
     spec:
       collectors:
         - clusterInfo: {}
----
-apiVersion: v1
-kind: Secret
-stringData:
   preflight.yaml: |-
     apiVersion: troubleshoot.sh/v1beta2
     kind: Preflight
@@ -76,4 +72,34 @@ stringData:
       kind: Preflight
     spec:
       :
+        - clusterInfo: {}
+---
+apiVersion: v1
+kind: Secret
+stringData:
+  preflight.yaml: |-
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Preflight
+    metadata:
+      name: preflight-2
+    spec:
+      collectors:
+        - clusterResources: {}
+    ---
+    apiVersion: troubleshoot.sh/v1beta2
+      kind: Preflight
+    spec:
+      :
+        - clusterInfo: {}
+  support-bundle-spec: |-
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    spec:
+      collectors:
+        - : {}
+    ---
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    spec:
+      collectors:
         - clusterInfo: {}


### PR DESCRIPTION
## Description, Motivation and Context

Strict flag which can be used to toggle between true (raising errors if a document is invalid)
and false (ignoring invalid documents, perhaps logging a warning).

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1272

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
