### PR TITLE
chore: export error ErrInsufficientPermissionsToRun and func ShowTextResultsStructured

### DIFF
--- a/pkg/collect/collect.go
+++ b/pkg/collect/collect.go
@@ -15,8 +15,8 @@ import (
 var (
 	// ErrCollectorNotFound is returned when an undefined host collector is
 	// specified by the user.
-	ErrHostCollectorNotFound   = errors.New("unrecognized host collector")
-	ErrInsufficientPermissions = errors.New("insufficient permissions to run all collectors")
+	ErrHostCollectorNotFound        = errors.New("unrecognized host collector")
+	ErrInsufficientPermissionsToRun = errors.New("insufficient permissions to run all collectors")
 )
 
 type CollectorRunOpts struct {
@@ -130,7 +130,7 @@ func CollectRemote(c *troubleshootv1beta2.RemoteCollector, additionalRedactors *
 
 	if foundForbidden && !opts.CollectWithoutPermissions {
 		collectResult.isRBACAllowed = false
-		return collectResult, ErrInsufficientPermissions
+		return collectResult, ErrInsufficientPermissionsToRun
 	}
 
 	// Run collectors synchronously.

--- a/pkg/collect/collect.go
+++ b/pkg/collect/collect.go
@@ -15,7 +15,8 @@ import (
 var (
 	// ErrCollectorNotFound is returned when an undefined host collector is
 	// specified by the user.
-	ErrHostCollectorNotFound = errors.New("unrecognized host collector")
+	ErrHostCollectorNotFound   = errors.New("unrecognized host collector")
+	ErrInsufficientPermissions = errors.New("insufficient permissions to run all collectors")
 )
 
 type CollectorRunOpts struct {
@@ -129,7 +130,7 @@ func CollectRemote(c *troubleshootv1beta2.RemoteCollector, additionalRedactors *
 
 	if foundForbidden && !opts.CollectWithoutPermissions {
 		collectResult.isRBACAllowed = false
-		return collectResult, errors.New("insufficient permissions to run all collectors")
+		return collectResult, ErrInsufficientPermissions
 	}
 
 	// Run collectors synchronously.

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -227,7 +227,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 
 	if foundForbidden && !opts.IgnorePermissionErrors {
 		collectResult.isRBACAllowed = false
-		return collectResult, collect.ErrInsufficientPermissions
+		return collectResult, collect.ErrInsufficientPermissionsToRun
 	}
 
 	for i, collector := range allCollectors {

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -227,7 +227,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 
 	if foundForbidden && !opts.IgnorePermissionErrors {
 		collectResult.isRBACAllowed = false
-		return collectResult, errors.New("insufficient permissions to run all collectors")
+		return collectResult, collect.ErrInsufficientPermissions
 	}
 
 	for i, collector := range allCollectors {

--- a/pkg/preflight/text_results.go
+++ b/pkg/preflight/text_results.go
@@ -64,29 +64,29 @@ func showTextResultsHuman(preflightName string, analyzeResults []*analyzerunner.
 	return results, nil
 }
 
-type textResultOutput struct {
+type TextResultOutput struct {
 	Title   string `json:"title" yaml:"title"`
 	Message string `json:"message" yaml:"message"`
 	URI     string `json:"uri,omitempty" yaml:"uri,omitempty"`
 	Strict  bool   `json:"strict,omitempty" yaml:"strict,omitempty"`
 }
 
-type textOutput struct {
-	Pass []textResultOutput `json:"pass,omitempty" yaml:"pass,omitempty"`
-	Warn []textResultOutput `json:"warn,omitempty" yaml:"warn,omitempty"`
-	Fail []textResultOutput `json:"fail,omitempty" yaml:"fail,omitempty"`
+type TextOutput struct {
+	Pass []TextResultOutput `json:"pass,omitempty" yaml:"pass,omitempty"`
+	Warn []TextResultOutput `json:"warn,omitempty" yaml:"warn,omitempty"`
+	Fail []TextResultOutput `json:"fail,omitempty" yaml:"fail,omitempty"`
 }
 
 // Used by both JSON and YAML outputs
-func showTextResultsStructured(preflightName string, analyzeResults []*analyzerunner.AnalyzeResult) *textOutput {
-	output := textOutput{
-		Pass: []textResultOutput{},
-		Warn: []textResultOutput{},
-		Fail: []textResultOutput{},
+func ShowTextResultsStructured(preflightName string, analyzeResults []*analyzerunner.AnalyzeResult) *TextOutput {
+	output := TextOutput{
+		Pass: []TextResultOutput{},
+		Warn: []TextResultOutput{},
+		Fail: []TextResultOutput{},
 	}
 
 	for _, analyzeResult := range analyzeResults {
-		resultOutput := textResultOutput{
+		resultOutput := TextResultOutput{
 			Title:   analyzeResult.Title,
 			Message: analyzeResult.Message,
 			URI:     analyzeResult.URI,
@@ -109,7 +109,7 @@ func showTextResultsStructured(preflightName string, analyzeResults []*analyzeru
 }
 
 func showTextResultsJSON(preflightName string, analyzeResults []*analyzerunner.AnalyzeResult) (string, error) {
-	output := showTextResultsStructured(preflightName, analyzeResults)
+	output := ShowTextResultsStructured(preflightName, analyzeResults)
 
 	b, err := json.MarshalIndent(*output, "", "  ")
 	if err != nil {
@@ -120,7 +120,7 @@ func showTextResultsJSON(preflightName string, analyzeResults []*analyzerunner.A
 }
 
 func showTextResultsYAML(preflightName string, analyzeResults []*analyzerunner.AnalyzeResult) (string, error) {
-	output := showTextResultsStructured(preflightName, analyzeResults)
+	output := ShowTextResultsStructured(preflightName, analyzeResults)
 
 	b, err := yaml.Marshal(*output)
 	if err != nil {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -142,7 +142,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 	}
 
 	if foundForbidden && !opts.CollectWithoutPermissions {
-		return nil, collect.ErrInsufficientPermissions
+		return nil, collect.ErrInsufficientPermissionsToRun
 	}
 
 	for _, collector := range allCollectors {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -142,7 +142,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 	}
 
 	if foundForbidden && !opts.CollectWithoutPermissions {
-		return nil, errors.New("insufficient permissions to run all collectors")
+		return nil, collect.ErrInsufficientPermissions
 	}
 
 	for _, collector := range allCollectors {


### PR DESCRIPTION
## Description, Motivation and Context

chore: 
- export ErrInsufficientPermissionsToRun: kots and c11y rely on the error to check preflight failures
https://github.com/replicatedhq/kots/blob/009ff86b7b72f2f144eeb25189cf2dbd0d588259/pkg/preflight/execute.go#L176-L182

- export func ShowTextResultsStructured: used in c11y `replicated cluster prepare` to print preflight results when running helm charts
<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
