### PR TITLE
Feat(redact): reduce regex cpu usage and improve redact efficient  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build:
 
 .PHONY: support-bundle
 support-bundle:
-	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle github.com/replicatedhq/troubleshoot/cmd/troubleshoot
+	 GOOS=linux GOARCH=amd64 go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle-linux github.com/replicatedhq/troubleshoot/cmd/troubleshoot
 
 .PHONY: preflight
 preflight:

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build:
 
 .PHONY: support-bundle
 support-bundle:
-	 GOOS=linux GOARCH=amd64 go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle-linux github.com/replicatedhq/troubleshoot/cmd/troubleshoot
+	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle github.com/replicatedhq/troubleshoot/cmd/troubleshoot
 
 .PHONY: preflight
 preflight:

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -5,9 +5,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -16,108 +18,124 @@ import (
 )
 
 func RedactResult(bundlePath string, input CollectorResult, additionalRedactors []*troubleshootv1beta2.Redact) error {
-	processedSymlinks := make(map[string]bool)
+	wg := &sync.WaitGroup{}
+
+	// Error channel to capture errors from goroutines
+	errorCh := make(chan error, len(input))
 
 	for k, v := range input {
-		file := k
 
-		var reader io.Reader
-		if v == nil {
-			// Check if file has been processed already
-			if processedSymlinks[file] {
-				continue
-			}
+		wg.Add(1)
 
-			// Collected contents are in a file. Get a reader to the file.
-			fullPath := filepath.Join(bundlePath, file)
-			info, err := os.Lstat(fullPath)
-			if err != nil {
-				if os.IsNotExist(errors.Cause(err)) {
-					// File not found, moving on.
-					continue
-				}
-				return errors.Wrap(err, "failed to stat file")
-			}
+		go func(file string, data []byte) {
+			defer wg.Done()
+			var reader io.Reader
+			if data == nil {
 
-			// Redact the target file of a symlink
-			// There is an opportunity for improving performance here by skipping symlinks
-			// if a target has been redacted already, but that would require
-			// some extra logic to ensure that a spec filtering only symlinks still works.
-			if info.Mode().Type() == os.ModeSymlink {
-				symlink := file
-				target, err := os.Readlink(fullPath)
+				// Collected contents are in a file. Get a reader to the file.
+				info, err := os.Lstat(filepath.Join(bundlePath, file))
 				if err != nil {
-					return errors.Wrap(err, "failed to read symlink")
+					if os.IsNotExist(errors.Cause(err)) {
+						// File not found, moving on.
+						return
+					}
+					errorCh <- errors.Wrap(err, "failed to stat file")
+					return
 				}
 
-				// Mark symlink target as processed
-				processedSymlinks[target] = true
-
-				// Get the relative path to the target file to conform with
-				// the path formats of the CollectorResult
-				file, err = filepath.Rel(bundlePath, target)
+				if info.Mode().Type() == os.ModeSymlink {
+					symlink := file
+					target, err := os.Readlink(filepath.Join(bundlePath, symlink))
+					if err != nil {
+						errorCh <- errors.Wrap(err, "failed to read symlink")
+						return
+					}
+					// Get the relative path to the target file to conform with
+					// the path formats of the CollectorResult
+					file, err = filepath.Rel(bundlePath, target)
+					if err != nil {
+						errorCh <- errors.Wrap(err, "failed to get relative path")
+						return
+					}
+					klog.V(2).Infof("Redacting %s (symlink => %s)\n", file, symlink)
+				} else {
+					klog.V(2).Infof("Redacting %s\n", file)
+				}
+				r, err := input.GetReader(bundlePath, file)
 				if err != nil {
-					return errors.Wrap(err, "failed to get relative path")
+					if os.IsNotExist(errors.Cause(err)) {
+						return
+					}
+					errorCh <- errors.Wrap(err, "failed to get reader")
+					return
 				}
-				klog.V(2).Infof("Redacting %s (symlink => %s)\n", file, symlink)
+				defer r.Close()
+
+				reader = r
 			} else {
-				klog.V(2).Infof("Redacting %s\n", file)
+				// Collected contents are in memory. Get a reader to the memory buffer.
+				reader = bytes.NewBuffer(data)
 			}
-			r, err := input.GetReader(bundlePath, file)
-			if err != nil {
-				if os.IsNotExist(errors.Cause(err)) {
-					continue
+
+			// If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is
+			// decompressed and each file inside the tar redacted and compressed back into the archive.
+			if filepath.Ext(file) == ".tar" || filepath.Ext(file) == ".tgz" || strings.HasSuffix(file, ".tar.gz") {
+				tmpDir, err := ioutil.TempDir("", "troubleshoot-subresult-")
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to create temp dir")
+					return
 				}
-				return errors.Wrap(err, "failed to get reader")
+				defer os.RemoveAll(tmpDir)
+
+				subResult, tarHeaders, err := decompressFile(tmpDir, reader, file)
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to decompress file")
+					return
+				}
+				err = RedactResult(tmpDir, subResult, additionalRedactors)
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to redact file")
+					return
+				}
+
+				dstFilename := filepath.Join(bundlePath, file)
+				err = compressFiles(tmpDir, subResult, tarHeaders, dstFilename)
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to re-compress file")
+					return
+				}
+
+				os.RemoveAll(tmpDir) // ensure clean up on each iteration in addition to the defer
+
+				//Content of the tar file was redacted. return to next file.
+				return
 			}
-			defer r.Close()
 
-			reader = r
-		} else {
-			// Collected contents are in memory. Get a reader to the memory buffer.
-			reader = bytes.NewBuffer(v)
-		}
-
-		// If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is
-		// decompressed and each file inside the tar redacted and compressed back into the archive.
-		if filepath.Ext(file) == ".tar" || filepath.Ext(file) == ".tgz" || strings.HasSuffix(file, ".tar.gz") {
-			tmpDir, err := os.MkdirTemp("", "troubleshoot-subresult-")
+			redacted, err := redact.Redact(reader, file, additionalRedactors)
 			if err != nil {
-				return errors.Wrap(err, "failed to create temp dir")
+				errorCh <- errors.Wrap(err, "failed to redact io stream")
+				return
 			}
-			defer os.RemoveAll(tmpDir)
 
-			subResult, tarHeaders, err := decompressFile(tmpDir, reader, file)
+			err = input.ReplaceResult(bundlePath, file, redacted)
 			if err != nil {
-				return errors.Wrap(err, "failed to decompress file")
+				errorCh <- errors.Wrap(err, "failed to create redacted result")
+				return
 			}
-			err = RedactResult(tmpDir, subResult, additionalRedactors)
-			if err != nil {
-				return errors.Wrap(err, "failed to redact file")
-			}
+		}(k, v)
+	}
 
-			dstFilename := filepath.Join(bundlePath, file)
-			err = compressFiles(tmpDir, subResult, tarHeaders, dstFilename)
-			if err != nil {
-				return errors.Wrap(err, "failed to re-compress file")
-			}
+	go func() {
+		wg.Wait()
+		close(errorCh)
+	}()
 
-			os.RemoveAll(tmpDir) // ensure clean up on each iteration in addition to the defer
-
-			//Content of the tar file was redacted. Continue to next file.
-			continue
-		}
-
-		redacted, err := redact.Redact(reader, file, additionalRedactors)
+	for err := range errorCh {
 		if err != nil {
-			return errors.Wrap(err, "failed to redact io stream")
-		}
-
-		err = input.ReplaceResult(bundlePath, file, redacted)
-		if err != nil {
-			return errors.Wrap(err, "failed to create redacted result")
+			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -111,7 +111,7 @@ func RedactResult(bundlePath string, input CollectorResult, additionalRedactors 
 				return
 			}
 
-			redacted, err := redact.Redact(reader, file, additionalRedactors)
+			redacted, err := redact.Redact(reader, file, bundlePath, additionalRedactors)
 			if err != nil {
 				errorCh <- errors.Wrap(err, "failed to redact io stream")
 				return

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -17,97 +18,124 @@ import (
 )
 
 func RedactResult(bundlePath string, input CollectorResult, additionalRedactors []*troubleshootv1beta2.Redact) error {
+	wg := &sync.WaitGroup{}
+
+	// Error channel to capture errors from goroutines
+	errorCh := make(chan error, len(input))
+
 	for k, v := range input {
-		file := k
 
-		var reader io.Reader
-		if v == nil {
-			// Collected contents are in a file. Get a reader to the file.
-			info, err := os.Lstat(filepath.Join(bundlePath, file))
-			if err != nil {
-				if os.IsNotExist(errors.Cause(err)) {
-					// File not found, moving on.
-					continue
-				}
-				return errors.Wrap(err, "failed to stat file")
-			}
+		wg.Add(1)
 
-			// Redact the target file of a symlink
-			// There is an opportunity for improving performance here by skipping symlinks
-			// if a target has been redacted already, but that would require
-			// some extra logic to ensure that a spec filtering only symlinks still works.
-			if info.Mode().Type() == os.ModeSymlink {
-				symlink := file
-				target, err := os.Readlink(filepath.Join(bundlePath, symlink))
+		go func(file string, data []byte) {
+			defer wg.Done()
+			var reader io.Reader
+			if data == nil {
+
+				// Collected contents are in a file. Get a reader to the file.
+				info, err := os.Lstat(filepath.Join(bundlePath, file))
 				if err != nil {
-					return errors.Wrap(err, "failed to read symlink")
+					if os.IsNotExist(errors.Cause(err)) {
+						// File not found, moving on.
+						return
+					}
+					errorCh <- errors.Wrap(err, "failed to stat file")
+					return
 				}
 
-				// Get the relative path to the target file to conform with
-				// the path formats of the CollectorResult
-				file, err = filepath.Rel(bundlePath, target)
-				if err != nil {
-					return errors.Wrap(err, "failed to get relative path")
+				if info.Mode().Type() == os.ModeSymlink {
+					symlink := file
+					target, err := os.Readlink(filepath.Join(bundlePath, symlink))
+					if err != nil {
+						errorCh <- errors.Wrap(err, "failed to read symlink")
+						return
+					}
+					// Get the relative path to the target file to conform with
+					// the path formats of the CollectorResult
+					file, err = filepath.Rel(bundlePath, target)
+					if err != nil {
+						errorCh <- errors.Wrap(err, "failed to get relative path")
+						return
+					}
+					klog.V(2).Infof("Redacting %s (symlink => %s)\n", file, symlink)
+				} else {
+					klog.V(2).Infof("Redacting %s\n", file)
 				}
-				klog.V(2).Infof("Redacting %s (symlink => %s)\n", file, symlink)
+				r, err := input.GetReader(bundlePath, file)
+				if err != nil {
+					if os.IsNotExist(errors.Cause(err)) {
+						return
+					}
+					errorCh <- errors.Wrap(err, "failed to get reader")
+					return
+				}
+				defer r.Close()
+
+				reader = r
 			} else {
-				klog.V(2).Infof("Redacting %s\n", file)
+				// Collected contents are in memory. Get a reader to the memory buffer.
+				reader = bytes.NewBuffer(data)
 			}
-			r, err := input.GetReader(bundlePath, file)
-			if err != nil {
-				if os.IsNotExist(errors.Cause(err)) {
-					continue
+
+			// If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is
+			// decompressed and each file inside the tar redacted and compressed back into the archive.
+			if filepath.Ext(file) == ".tar" || filepath.Ext(file) == ".tgz" || strings.HasSuffix(file, ".tar.gz") {
+				tmpDir, err := ioutil.TempDir("", "troubleshoot-subresult-")
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to create temp dir")
+					return
 				}
-				return errors.Wrap(err, "failed to get reader")
+				defer os.RemoveAll(tmpDir)
+
+				subResult, tarHeaders, err := decompressFile(tmpDir, reader, file)
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to decompress file")
+					return
+				}
+				err = RedactResult(tmpDir, subResult, additionalRedactors)
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to redact file")
+					return
+				}
+
+				dstFilename := filepath.Join(bundlePath, file)
+				err = compressFiles(tmpDir, subResult, tarHeaders, dstFilename)
+				if err != nil {
+					errorCh <- errors.Wrap(err, "failed to re-compress file")
+					return
+				}
+
+				os.RemoveAll(tmpDir) // ensure clean up on each iteration in addition to the defer
+
+				//Content of the tar file was redacted. return to next file.
+				return
 			}
-			defer r.Close()
 
-			reader = r
-		} else {
-			// Collected contents are in memory. Get a reader to the memory buffer.
-			reader = bytes.NewBuffer(v)
-		}
-
-		// If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is
-		// decompressed and each file inside the tar redacted and compressed back into the archive.
-		if filepath.Ext(file) == ".tar" || filepath.Ext(file) == ".tgz" || strings.HasSuffix(file, ".tar.gz") {
-			tmpDir, err := ioutil.TempDir("", "troubleshoot-subresult-")
+			redacted, err := redact.Redact(reader, file, additionalRedactors)
 			if err != nil {
-				return errors.Wrap(err, "failed to create temp dir")
+				errorCh <- errors.Wrap(err, "failed to redact io stream")
+				return
 			}
-			defer os.RemoveAll(tmpDir)
 
-			subResult, tarHeaders, err := decompressFile(tmpDir, reader, file)
+			err = input.ReplaceResult(bundlePath, file, redacted)
 			if err != nil {
-				return errors.Wrap(err, "failed to decompress file")
+				errorCh <- errors.Wrap(err, "failed to create redacted result")
+				return
 			}
-			err = RedactResult(tmpDir, subResult, additionalRedactors)
-			if err != nil {
-				return errors.Wrap(err, "failed to redact file")
-			}
+		}(k, v)
+	}
 
-			dstFilename := filepath.Join(bundlePath, file)
-			err = compressFiles(tmpDir, subResult, tarHeaders, dstFilename)
-			if err != nil {
-				return errors.Wrap(err, "failed to re-compress file")
-			}
+	go func() {
+		wg.Wait()
+		close(errorCh)
+	}()
 
-			os.RemoveAll(tmpDir) // ensure clean up on each iteration in addition to the defer
-
-			//Content of the tar file was redacted. Continue to next file.
-			continue
-		}
-
-		redacted, err := redact.Redact(reader, file, bundlePath, additionalRedactors)
+	for err := range errorCh {
 		if err != nil {
-			return errors.Wrap(err, "failed to redact io stream")
-		}
-
-		err = input.ReplaceResult(bundlePath, file, redacted)
-		if err != nil {
-			return errors.Wrap(err, "failed to create redacted result")
+			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -43,6 +43,10 @@ func RedactResult(bundlePath string, input CollectorResult, additionalRedactors 
 					return
 				}
 
+				// Redact the target file of a symlink
+				// There is an opportunity for improving performance here by skipping symlinks
+				// if a target has been redacted already, but that would require
+				// some extra logic to ensure that a spec filtering only symlinks still works.
 				if info.Mode().Type() == os.ModeSymlink {
 					symlink := file
 					target, err := os.Readlink(filepath.Join(bundlePath, symlink))

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -18,124 +17,97 @@ import (
 )
 
 func RedactResult(bundlePath string, input CollectorResult, additionalRedactors []*troubleshootv1beta2.Redact) error {
-	wg := &sync.WaitGroup{}
-
-	// Error channel to capture errors from goroutines
-	errorCh := make(chan error, len(input))
-
 	for k, v := range input {
+		file := k
 
-		wg.Add(1)
+		var reader io.Reader
+		if v == nil {
+			// Collected contents are in a file. Get a reader to the file.
+			info, err := os.Lstat(filepath.Join(bundlePath, file))
+			if err != nil {
+				if os.IsNotExist(errors.Cause(err)) {
+					// File not found, moving on.
+					continue
+				}
+				return errors.Wrap(err, "failed to stat file")
+			}
 
-		go func(file string, data []byte) {
-			defer wg.Done()
-			var reader io.Reader
-			if data == nil {
-
-				// Collected contents are in a file. Get a reader to the file.
-				info, err := os.Lstat(filepath.Join(bundlePath, file))
+			// Redact the target file of a symlink
+			// There is an opportunity for improving performance here by skipping symlinks
+			// if a target has been redacted already, but that would require
+			// some extra logic to ensure that a spec filtering only symlinks still works.
+			if info.Mode().Type() == os.ModeSymlink {
+				symlink := file
+				target, err := os.Readlink(filepath.Join(bundlePath, symlink))
 				if err != nil {
-					if os.IsNotExist(errors.Cause(err)) {
-						// File not found, moving on.
-						return
-					}
-					errorCh <- errors.Wrap(err, "failed to stat file")
-					return
+					return errors.Wrap(err, "failed to read symlink")
 				}
 
-				if info.Mode().Type() == os.ModeSymlink {
-					symlink := file
-					target, err := os.Readlink(filepath.Join(bundlePath, symlink))
-					if err != nil {
-						errorCh <- errors.Wrap(err, "failed to read symlink")
-						return
-					}
-					// Get the relative path to the target file to conform with
-					// the path formats of the CollectorResult
-					file, err = filepath.Rel(bundlePath, target)
-					if err != nil {
-						errorCh <- errors.Wrap(err, "failed to get relative path")
-						return
-					}
-					klog.V(2).Infof("Redacting %s (symlink => %s)\n", file, symlink)
-				} else {
-					klog.V(2).Infof("Redacting %s\n", file)
-				}
-				r, err := input.GetReader(bundlePath, file)
+				// Get the relative path to the target file to conform with
+				// the path formats of the CollectorResult
+				file, err = filepath.Rel(bundlePath, target)
 				if err != nil {
-					if os.IsNotExist(errors.Cause(err)) {
-						return
-					}
-					errorCh <- errors.Wrap(err, "failed to get reader")
-					return
+					return errors.Wrap(err, "failed to get relative path")
 				}
-				defer r.Close()
-
-				reader = r
+				klog.V(2).Infof("Redacting %s (symlink => %s)\n", file, symlink)
 			} else {
-				// Collected contents are in memory. Get a reader to the memory buffer.
-				reader = bytes.NewBuffer(data)
+				klog.V(2).Infof("Redacting %s\n", file)
 			}
-
-			// If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is
-			// decompressed and each file inside the tar redacted and compressed back into the archive.
-			if filepath.Ext(file) == ".tar" || filepath.Ext(file) == ".tgz" || strings.HasSuffix(file, ".tar.gz") {
-				tmpDir, err := ioutil.TempDir("", "troubleshoot-subresult-")
-				if err != nil {
-					errorCh <- errors.Wrap(err, "failed to create temp dir")
-					return
-				}
-				defer os.RemoveAll(tmpDir)
-
-				subResult, tarHeaders, err := decompressFile(tmpDir, reader, file)
-				if err != nil {
-					errorCh <- errors.Wrap(err, "failed to decompress file")
-					return
-				}
-				err = RedactResult(tmpDir, subResult, additionalRedactors)
-				if err != nil {
-					errorCh <- errors.Wrap(err, "failed to redact file")
-					return
-				}
-
-				dstFilename := filepath.Join(bundlePath, file)
-				err = compressFiles(tmpDir, subResult, tarHeaders, dstFilename)
-				if err != nil {
-					errorCh <- errors.Wrap(err, "failed to re-compress file")
-					return
-				}
-
-				os.RemoveAll(tmpDir) // ensure clean up on each iteration in addition to the defer
-
-				//Content of the tar file was redacted. return to next file.
-				return
-			}
-
-			redacted, err := redact.Redact(reader, file, bundlePath, additionalRedactors)
+			r, err := input.GetReader(bundlePath, file)
 			if err != nil {
-				errorCh <- errors.Wrap(err, "failed to redact io stream")
-				return
+				if os.IsNotExist(errors.Cause(err)) {
+					continue
+				}
+				return errors.Wrap(err, "failed to get reader")
 			}
+			defer r.Close()
 
-			err = input.ReplaceResult(bundlePath, file, redacted)
+			reader = r
+		} else {
+			// Collected contents are in memory. Get a reader to the memory buffer.
+			reader = bytes.NewBuffer(v)
+		}
+
+		// If the file is .tar, .tgz or .tar.gz, it must not be redacted. Instead it is
+		// decompressed and each file inside the tar redacted and compressed back into the archive.
+		if filepath.Ext(file) == ".tar" || filepath.Ext(file) == ".tgz" || strings.HasSuffix(file, ".tar.gz") {
+			tmpDir, err := ioutil.TempDir("", "troubleshoot-subresult-")
 			if err != nil {
-				errorCh <- errors.Wrap(err, "failed to create redacted result")
-				return
+				return errors.Wrap(err, "failed to create temp dir")
 			}
-		}(k, v)
-	}
+			defer os.RemoveAll(tmpDir)
 
-	go func() {
-		wg.Wait()
-		close(errorCh)
-	}()
+			subResult, tarHeaders, err := decompressFile(tmpDir, reader, file)
+			if err != nil {
+				return errors.Wrap(err, "failed to decompress file")
+			}
+			err = RedactResult(tmpDir, subResult, additionalRedactors)
+			if err != nil {
+				return errors.Wrap(err, "failed to redact file")
+			}
 
-	for err := range errorCh {
+			dstFilename := filepath.Join(bundlePath, file)
+			err = compressFiles(tmpDir, subResult, tarHeaders, dstFilename)
+			if err != nil {
+				return errors.Wrap(err, "failed to re-compress file")
+			}
+
+			os.RemoveAll(tmpDir) // ensure clean up on each iteration in addition to the defer
+
+			//Content of the tar file was redacted. Continue to next file.
+			continue
+		}
+
+		redacted, err := redact.Redact(reader, file, bundlePath, additionalRedactors)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to redact io stream")
+		}
+
+		err = input.ReplaceResult(bundlePath, file, redacted)
+		if err != nil {
+			return errors.Wrap(err, "failed to create redacted result")
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -153,7 +153,7 @@ func (r CollectorResult) ReplaceResult(bundlePath string, relativePath string, r
 	}
 	defer tmpFile.Close()
 
-	_, err = io.CopyBuffer(tmpFile, reader, make([]byte, 1024*1024))
+	_, err = io.Copy(tmpFile, reader)
 	if err != nil {
 		return errors.Wrap(err, "failed to write tmp file")
 	}

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -142,21 +142,18 @@ func (r CollectorResult) ReplaceResult(bundlePath string, relativePath string, r
 		return nil
 	}
 
-	tmpFile, err := os.CreateTemp("", "replace-")
-	if err != nil {
-		return errors.Wrap(err, "failed to create temp file")
-	}
-	defer tmpFile.Close()
+	targetPath := filepath.Join(bundlePath, relativePath)
 
-	_, err = io.Copy(tmpFile, reader)
+	// Open the file directly in the desired location
+	outFile, err := os.Create(targetPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create file")
+	}
+	defer outFile.Close()
+
+	_, err = io.Copy(outFile, reader)
 	if err != nil {
 		return errors.Wrap(err, "failed to write tmp file")
-	}
-
-	// This rename should always be in /tmp, so no cross-partition copying will happen
-	err = os.Rename(tmpFile.Name(), filepath.Join(bundlePath, relativePath))
-	if err != nil {
-		return errors.Wrap(err, "failed to rename tmp file")
 	}
 
 	return nil

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -151,7 +151,7 @@ func (r CollectorResult) ReplaceResult(bundlePath string, relativePath string, r
 	}
 	defer outFile.Close()
 
-	_, err = io.Copy(outFile, reader)
+	_, err = io.CopyBuffer(outFile, reader, make([]byte, 1024*1024))
 	if err != nil {
 		return errors.Wrap(err, "failed to write tmp file")
 	}

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -127,7 +127,12 @@ func (r CollectorResult) SaveResult(bundlePath string, relativePath string, read
 		return errors.Wrap(err, "failed to copy data")
 	}
 
-	klog.V(2).Infof("Added %q to bundle output", relativePath)
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return errors.Wrap(err, "failed to stat file")
+	}
+
+	klog.V(2).Infof("Added %q (%d MB) to bundle output", relativePath, fileInfo.Size()/(1024*1024))
 	return nil
 }
 

--- a/pkg/redact/multi_line.go
+++ b/pkg/redact/multi_line.go
@@ -17,7 +17,7 @@ type MultiLineRedactor struct {
 	isDefault  bool
 }
 
-func NewMultiLineRedactor(re1 lineRedactor, re2 string, maskText, path, name string, isDefault bool) (*MultiLineRedactor, error) {
+func NewMultiLineRedactor(re1 LineRedactor, re2 string, maskText, path, name string, isDefault bool) (*MultiLineRedactor, error) {
 	var scanCompiled *regexp.Regexp
 	compiled1, err := regexp.Compile(re1.regex)
 	if err != nil {

--- a/pkg/redact/multi_line.go
+++ b/pkg/redact/multi_line.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 )
 
 type MultiLineRedactor struct {
@@ -64,8 +65,8 @@ func (r *MultiLineRedactor) Redact(input io.Reader, path string) io.Reader {
 			lineNum++ // the first line that can be redacted is line 2
 
 			// If line1 matches re1, then transform line2 using re2
-
-			if r.scan != nil && !r.scan.MatchString(line1) {
+			lowerLine1 := strings.ToLower(line1)
+			if r.scan != nil && !r.scan.MatchString(lowerLine1) {
 				fmt.Fprintf(writer, "%s\n", line1)
 				line1, line2, err = getNextTwoLines(reader, &line2)
 				flushLastLine = true

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -46,11 +46,6 @@ type Redaction struct {
 	IsDefaultRedactor bool   `json:"isDefaultRedactor" yaml:"isDefaultRedactor"`
 }
 
-type LineRedactor struct {
-	regex string
-	scan  string
-}
-
 func Redact(input io.Reader, path string, additionalRedactors []*troubleshootv1beta2.Redact) (io.Reader, error) {
 	redactors, err := getRedactors(path)
 	if err != nil {
@@ -110,16 +105,12 @@ func buildAdditionalRedactors(path string, redacts []*troubleshootv1beta2.Redact
 		for j, re := range redact.Removals.Regex {
 			var newRedactor Redactor
 			if re.Selector != "" {
-				newRedactor, err = NewMultiLineRedactor(LineRedactor{
-					regex: re.Selector,
-				}, re.Redactor, MASK_TEXT, path, redactorName(i, j, redact.Name, "multiLine"), false)
+				newRedactor, err = NewMultiLineRedactor(re.Selector, re.Redactor, MASK_TEXT, path, redactorName(i, j, redact.Name, "multiLine"), false)
 				if err != nil {
 					return nil, errors.Wrapf(err, "multiline redactor %+v", re)
 				}
 			} else {
-				newRedactor, err = NewSingleLineRedactor(LineRedactor{
-					regex: re.Redactor,
-				}, MASK_TEXT, path, redactorName(i, j, redact.Name, "regex"), false)
+				newRedactor, err = NewSingleLineRedactor(re.Redactor, MASK_TEXT, path, redactorName(i, j, redact.Name, "regex"), false)
 				if err != nil {
 					return nil, errors.Wrapf(err, "redactor %q", re)
 				}
@@ -174,143 +165,88 @@ func getRedactors(path string) ([]Redactor, error) {
 	// groups named with `?P<mask>` will be masked
 	// groups named with `?P<drop>` will be removed (replaced with empty strings)
 	singleLines := []struct {
-		regex LineRedactor
+		regex string
 		name  string
 	}{
 		// aws secrets
 		{
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `secret_?access_?key`,
-			},
-			name: "Redact values for environment variables that look like AWS Secret Access Keys",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*secret_?access_?key\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables that look like AWS Secret Access Keys",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `access_?key_?id`,
-			},
-			name: "Redact values for environment variables that look like AWS Access Keys",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*access_?key_?id\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables that look like AWS Access Keys",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `owner_?account`,
-			},
-			name: "Redact values for environment variables that look like AWS Owner or Account numbers",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*owner_?account\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables that look like AWS Owner or Account numbers",
 		},
 		// passwords in general
 		{
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `password`,
-			},
-			name: "Redact values for environment variables with names beginning with 'password'",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables with names beginning with 'password'",
 		},
 		// tokens in general
 		{
-
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `token`,
-			},
-			name: "Redact values for environment variables with names beginning with 'token'",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables with names beginning with 'token'",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `database`,
-			},
-			name: "Redact values for environment variables with names beginning with 'database'",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables with names beginning with 'database'",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `user`,
-			},
-			name: "Redact values for environment variables with names beginning with 'user'",
+			regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+			name:  "Redact values for environment variables with names beginning with 'user'",
 		},
 		// connection strings with username and password
 		// http://user:password@host:8888
 		{
-			regex: LineRedactor{
-				regex: `(?i)(https?|ftp)(:\/\/)(?P<mask>[^:\"\/]+){1}(:)(?P<mask>[^@\"\/]+){1}(?P<host>@[^:\/\s\"]+){1}(?P<port>:[\d]+)?`,
-				scan:  `https?|ftp`,
-			},
-			name: "Redact connection strings with username and password",
+			regex: `(?i)(https?|ftp)(:\/\/)(?P<mask>[^:\"\/]+){1}(:)(?P<mask>[^@\"\/]+){1}(?P<host>@[^:\/\s\"]+){1}(?P<port>:[\d]+)?`,
+			name:  "Redact connection strings with username and password",
 		},
 		// user:password@tcp(host:3309)/db-name
 		{
-			regex: LineRedactor{
-				regex: `\b(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@tcp\()(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\)\/)(?P<mask>[\w\d\S-_]+){1}\b`,
-				scan:  `@tcp`,
-			},
-			name: "Redact database connection strings that contain username and password",
+			regex: `\b(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@tcp\()(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\)\/)(?P<mask>[\w\d\S-_]+){1}\b`,
+			name:  "Redact database connection strings that contain username and password",
 		},
 		// standard postgres and mysql connection strings
 		// protocol://user:password@host:5432/db
 		{
-			regex: LineRedactor{
-				regex: `\b(\w*:\/\/)(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@)(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\/)(?P<mask>[\w\d\S-_]+){1}\b`,
-				scan:  `\b(\w*:\/\/)([^:\"\/]*)(:)([^@\"\/]*)(@)([^:\"\/]*)(:[\d]*)?(\/)([\w\d\S-_]+)\b`,
-			},
-			name: "Redact database connection strings that contain username and password",
+			regex: `\b(\w*:\/\/)(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@)(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\/)(?P<mask>[\w\d\S-_]+){1}\b`,
+			name:  "Redact database connection strings that contain username and password",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(Data Source *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `data source`,
-			},
-			name: "Redact 'Data Source' values commonly found in database connection strings",
+			regex: `(?i)(data source *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'data source' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(location *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `location`,
-			},
-			name: "Redact 'location' values commonly found in database connection strings",
+			regex: `(?i)(location *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'location' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(User ID *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `user id`,
-			},
-			name: "Redact 'User ID' values commonly found in database connection strings",
+			regex: `(?i)(user id *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'user id' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(password *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `password`,
-			},
-			name: "Redact 'password' values commonly found in database connection strings",
+			regex: `(?i)(password *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'password' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(Server *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `server`,
-			},
-			name: "Redact 'Server' values commonly found in database connection strings",
+			regex: `(?i)(server *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'server' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(Database *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `database`,
-			},
-			name: "Redact 'Database' values commonly found in database connection strings",
+			regex: `(?i)(database *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'database' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(Uid *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `uid`,
-			},
-			name: "Redact 'UID' values commonly found in database connection strings",
+			regex: `(?i)(uid *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'uid' values commonly found in database connection strings",
 		},
 		{
-			regex: LineRedactor{
-				regex: `(?i)(Pwd *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `pwd`,
-			},
-			name: "Redact 'Pwd' values commonly found in database connection strings",
+			regex: `(?i)(pwd *= *)(?P<mask>[^\;]+)(;)`,
+			name:  "Redact 'pwd' values commonly found in database connection strings",
 		},
 	}
 
@@ -324,78 +260,54 @@ func getRedactors(path string) ([]Redactor, error) {
 	}
 
 	doubleLines := []struct {
-		selector LineRedactor
-		redactor string
-		name     string
+		line1 string
+		line2 string
+		name  string
 	}{
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *"[^\"]*SECRET_?ACCESS_?KEY[^\"]*"`,
-				scan:  `secret_?access_?key`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact AWS Secret Access Key values in multiline JSON",
+			line1: `(?i)"name": *"[^\"]*secret_?access_?key[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact AWS Secret Access Key values in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *"[^\"]*ACCESS_?KEY_?ID[^\"]*"`,
-				scan:  `access_?key_?id`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact AWS Access Key ID values in multiline JSON",
+			line1: `(?i)"name": *"[^\"]*access_?key_?id[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact AWS Access Key ID values in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *"[^\"]*OWNER_?ACCOUNT[^\"]*"`,
-				scan:  `owner_?account`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact AWS Owner and Account Numbers in multiline JSON",
+			line1: `(?i)"name": *"[^\"]*owner_?account[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact AWS Owner and Account Numbers in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *".*password[^\"]*"`,
-				scan:  `password`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact password environment variables in multiline JSON",
+			line1: `(?i)"name": *".*password[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact password environment variables in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *".*token[^\"]*"`,
-				scan:  `token`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact values that look like API tokens in multiline JSON",
+			line1: `(?i)"name": *".*token[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact values that look like API tokens in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *".*database[^\"]*"`,
-				scan:  `database`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact database connection strings in multiline JSON",
+			line1: `(?i)"name": *".*database[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact database connection strings in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"name": *".*user[^\"]*"`,
-				scan:  `user`,
-			},
-			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:     "Redact usernames in multiline JSON",
+			line1: `(?i)"name": *".*user[^\"]*"`,
+			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:  "Redact usernames in multiline JSON",
 		},
 		{
-			selector: LineRedactor{
-				regex: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
-				scan:  `(osd|client|mgr)`,
-			},
-			redactor: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
-			name:     "Redact 'key' values found in Ceph auth lists",
+			line1: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
+			line2: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
+			name:  "Redact 'key' values found in Ceph auth lists",
 		},
 	}
 
 	for _, l := range doubleLines {
-		r, err := NewMultiLineRedactor(l.selector, l.redactor, MASK_TEXT, path, l.name, true)
+		r, err := NewMultiLineRedactor(l.line1, l.line2, MASK_TEXT, path, l.name, true)
 		if err != nil {
 			return nil, err // maybe skip broken ones?
 		}

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -255,11 +255,13 @@ func getRedactors(path string, bundlePath string) ([]Redactor, error) {
 
 	redactors := make([]Redactor, 0)
 	for _, re := range singleLines {
+		fmt.Println("Start to add redactor for " + re.name)
 		r, err := NewSingleLineRedactor(re.regex, MASK_TEXT, path, bundlePath, re.name, true)
 		if err != nil {
 			return nil, err // maybe skip broken ones?
 		}
 		if r != nil {
+			fmt.Println("Added redactor for " + re.name)
 			redactors = append(redactors, r)
 		}
 	}

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -181,21 +181,21 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `SECRET_?ACCESS_?KEY`,
+				scan:  `(?i)SECRET_?ACCESS_?KEY`,
 			},
 			name: "Redact values for environment variables that look like AWS Secret Access Keys",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `ACCESS_?KEY_?ID`,
+				scan:  `(?i)ACCESS_?KEY_?ID`,
 			},
 			name: "Redact values for environment variables that look like AWS Access Keys",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `OWNER_?ACCOUNT`,
+				scan:  `(?i)OWNER_?ACCOUNT`,
 			},
 			name: "Redact values for environment variables that look like AWS Owner or Account numbers",
 		},
@@ -203,7 +203,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `password[^\"]`,
+				scan:  `(?i)password`,
 			},
 			name: "Redact values for environment variables with names beginning with 'password'",
 		},
@@ -212,21 +212,21 @@ func getRedactors(path string) ([]Redactor, error) {
 
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `token[^\"]`,
+				scan:  `(?i)token`,
 			},
 			name: "Redact values for environment variables with names beginning with 'token'",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `database[^\"]`,
+				scan:  `(?i)database`,
 			},
 			name: "Redact values for environment variables with names beginning with 'database'",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `user[^\"]`,
+				scan:  `(?i)user`,
 			},
 			name: "Redact values for environment variables with names beginning with 'user'",
 		},
@@ -235,7 +235,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: lineRedactor{
 				regex: `(?i)(https?|ftp)(:\/\/)(?P<mask>[^:\"\/]+){1}(:)(?P<mask>[^@\"\/]+){1}(?P<host>@[^:\/\s\"]+){1}(?P<port>:[\d]+)?`,
-				scan:  `https?|ftp`,
+				scan:  `(?i)https?|ftp`,
 			},
 			name: "Redact connection strings with username and password",
 		},
@@ -259,56 +259,56 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: lineRedactor{
 				regex: `(?i)(Data Source *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `Data Source `,
+				scan:  `(?i)Data Source`,
 			},
 			name: "Redact 'Data Source' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(location *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `location `,
+				scan:  `(?i)location`,
 			},
 			name: "Redact 'location' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(User ID *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `User ID `,
+				scan:  `(?i)User ID`,
 			},
 			name: "Redact 'User ID' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(password *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `password `,
+				scan:  `(?i)password`,
 			},
 			name: "Redact 'password' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(Server *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `Server `,
+				scan:  `(?i)Server`,
 			},
 			name: "Redact 'Server' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(Database *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `Database `,
+				scan:  `(?i)Database`,
 			},
 			name: "Redact 'Database' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(Uid *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `Uid `,
+				scan:  `(?i)Uid`,
 			},
 			name: "Redact 'UID' values commonly found in database connection strings",
 		},
 		{
 			regex: lineRedactor{
 				regex: `(?i)(Pwd *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `Pwd `,
+				scan:  `(?i)Pwd`,
 			},
 			name: "Redact 'Pwd' values commonly found in database connection strings",
 		},
@@ -339,7 +339,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"name": *"[^\"]*ACCESS_?KEY_?ID[^\"]*"`,
-				scan:  `ACCESS_?KEY_?ID`,
+				scan:  `(?i)ACCESS_?KEY_?ID`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact AWS Access Key ID values in multiline JSON",
@@ -347,7 +347,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"name": *"[^\"]*OWNER_?ACCOUNT[^\"]*"`,
-				scan:  `OWNER_?ACCOUNT`,
+				scan:  `(?i)OWNER_?ACCOUNT`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact AWS Owner and Account Numbers in multiline JSON",
@@ -355,7 +355,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"name": *".*password[^\"]*"`,
-				scan:  `password`,
+				scan:  `(?i)password`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact password environment variables in multiline JSON",
@@ -363,7 +363,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"name": *".*token[^\"]*"`,
-				scan:  `token`,
+				scan:  `(?i)token`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact values that look like API tokens in multiline JSON",
@@ -371,7 +371,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"name": *".*database[^\"]*"`,
-				scan:  `database`,
+				scan:  `(?i)database`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact database connection strings in multiline JSON",
@@ -379,7 +379,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"name": *".*user[^\"]*"`,
-				scan:  `user`,
+				scan:  `(?i)user`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact usernames in multiline JSON",
@@ -387,7 +387,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: lineRedactor{
 				regex: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
-				scan:  `(osd|client|mgr)`,
+				scan:  `(?i)(osd|client|mgr)`,
 			},
 			redactor: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
 			name:     "Redact 'key' values found in Ceph auth lists",

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -46,8 +46,8 @@ type Redaction struct {
 	IsDefaultRedactor bool   `json:"isDefaultRedactor" yaml:"isDefaultRedactor"`
 }
 
-func Redact(input io.Reader, path string, bundlePath string, additionalRedactors []*troubleshootv1beta2.Redact) (io.Reader, error) {
-	redactors, err := getRedactors(path, bundlePath)
+func Redact(input io.Reader, path string, additionalRedactors []*troubleshootv1beta2.Redact) (io.Reader, error) {
+	redactors, err := getRedactors(path)
 	if err != nil {
 		return nil, err
 	}
@@ -105,20 +105,21 @@ func buildAdditionalRedactors(path string, redacts []*troubleshootv1beta2.Redact
 		for j, re := range redact.Removals.Regex {
 			var newRedactor Redactor
 			if re.Selector != "" {
-				newRedactor, err = NewMultiLineRedactor(re.Selector, re.Redactor, MASK_TEXT, path, redactorName(i, j, redact.Name, "multiLine"), false)
+				newRedactor, err = NewMultiLineRedactor(lineRedactor{
+					regex: re.Selector,
+				}, re.Redactor, MASK_TEXT, path, redactorName(i, j, redact.Name, "multiLine"), false)
 				if err != nil {
 					return nil, errors.Wrapf(err, "multiline redactor %+v", re)
 				}
 			} else {
-				newRedactor, err = NewSingleLineRedactor(re.Redactor, MASK_TEXT, path, "", redactorName(i, j, redact.Name, "regex"), false)
+				newRedactor, err = NewSingleLineRedactor(lineRedactor{
+					regex: re.Redactor,
+				}, MASK_TEXT, path, redactorName(i, j, redact.Name, "regex"), false)
 				if err != nil {
 					return nil, errors.Wrapf(err, "redactor %q", re)
 				}
 			}
-
-			if newRedactor != nil {
-				additionalRedactors = append(additionalRedactors, newRedactor)
-			}
+			additionalRedactors = append(additionalRedactors, newRedactor)
 		}
 
 		for j, yaml := range redact.Removals.YamlPath {
@@ -161,160 +162,240 @@ func redactMatchesPath(path string, redact *troubleshootv1beta2.Redact) (bool, e
 	return false, nil
 }
 
-func getRedactors(path string, bundlePath string) ([]Redactor, error) {
+type lineRedactor struct {
+	regex string
+	scan  string
+}
+
+func getRedactors(path string) ([]Redactor, error) {
 	// TODO: Make this configurable
 
 	// (?i) makes it case insensitive
 	// groups named with `?P<mask>` will be masked
 	// groups named with `?P<drop>` will be removed (replaced with empty strings)
 	singleLines := []struct {
-		regex string
+		regex lineRedactor
 		name  string
 	}{
 		// aws secrets
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables that look like AWS Secret Access Keys",
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `SECRET_?ACCESS_?KEY`,
+			},
+			name: "Redact values for environment variables that look like AWS Secret Access Keys",
 		},
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables that look like AWS Access Keys",
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `ACCESS_?KEY_?ID`,
+			},
+			name: "Redact values for environment variables that look like AWS Access Keys",
 		},
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables that look like AWS Owner or Account numbers",
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `OWNER_?ACCOUNT`,
+			},
+			name: "Redact values for environment variables that look like AWS Owner or Account numbers",
 		},
 		// passwords in general
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables with names beginning with 'password'",
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `password[^\"]`,
+			},
+			name: "Redact values for environment variables with names beginning with 'password'",
 		},
 		// tokens in general
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables with names beginning with 'token'",
+
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `token[^\"]`,
+			},
+			name: "Redact values for environment variables with names beginning with 'token'",
 		},
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables with names beginning with 'database'",
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `database[^\"]`,
+			},
+			name: "Redact values for environment variables with names beginning with 'database'",
 		},
 		{
-			regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-			name:  "Redact values for environment variables with names beginning with 'user'",
+			regex: lineRedactor{
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				scan:  `user[^\"]`,
+			},
+			name: "Redact values for environment variables with names beginning with 'user'",
 		},
 		// connection strings with username and password
 		// http://user:password@host:8888
 		{
-			regex: `(?i)(https?|ftp)(:\/\/)(?P<mask>[^:\"\/]+){1}(:)(?P<mask>[^@\"\/]+){1}(?P<host>@[^:\/\s\"]+){1}(?P<port>:[\d]+)?`,
-			name:  "Redact connection strings with username and password",
+			regex: lineRedactor{
+				regex: `(?i)(https?|ftp)(:\/\/)(?P<mask>[^:\"\/]+){1}(:)(?P<mask>[^@\"\/]+){1}(?P<host>@[^:\/\s\"]+){1}(?P<port>:[\d]+)?`,
+				scan:  `https?|ftp`,
+			},
+			name: "Redact connection strings with username and password",
 		},
 		// user:password@tcp(host:3309)/db-name
 		{
-			regex: `\b(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@tcp\()(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\)\/)(?P<mask>[\w\d\S-_]+){1}\b`,
-			name:  "Redact database connection strings that contain username and password",
+			regex: lineRedactor{
+				regex: `\b(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@tcp\()(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\)\/)(?P<mask>[\w\d\S-_]+){1}\b`,
+				scan:  `@tcp`,
+			},
+			name: "Redact database connection strings that contain username and password",
 		},
 		// standard postgres and mysql connection strings
 		// protocol://user:password@host:5432/db
 		{
-			regex: `\b(\w*:\/\/)(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@)(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\/)(?P<mask>[\w\d\S-_]+){1}\b`,
-			name:  "Redact database connection strings that contain username and password",
+			regex: lineRedactor{
+				regex: `\b(\w*:\/\/)(?P<mask>[^:\"\/]*){1}(:)(?P<mask>[^:\"\/]*){1}(@)(?P<mask>[^:\"\/]*){1}(?P<port>:[\d]*)?(\/)(?P<mask>[\w\d\S-_]+){1}\b`,
+				scan:  `\b(\w*:\/\/)([^:\"\/]*)(:)([^@\"\/]*)(@)([^:\"\/]*)(:[\d]*)?(\/)([\w\d\S-_]+)\b`,
+			},
+			name: "Redact database connection strings that contain username and password",
 		},
 		{
-			regex: `(?i)(Data Source *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'Data Source' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(Data Source *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `Data Source `,
+			},
+			name: "Redact 'Data Source' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(location *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'location' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(location *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `location `,
+			},
+			name: "Redact 'location' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(User ID *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'User ID' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(User ID *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `User ID `,
+			},
+			name: "Redact 'User ID' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(password *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'password' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(password *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `password `,
+			},
+			name: "Redact 'password' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(Server *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'Server' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(Server *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `Server `,
+			},
+			name: "Redact 'Server' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(Database *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'Database' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(Database *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `Database `,
+			},
+			name: "Redact 'Database' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(Uid *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'UID' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(Uid *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `Uid `,
+			},
+			name: "Redact 'UID' values commonly found in database connection strings",
 		},
 		{
-			regex: `(?i)(Pwd *= *)(?P<mask>[^\;]+)(;)`,
-			name:  "Redact 'Pwd' values commonly found in database connection strings",
+			regex: lineRedactor{
+				regex: `(?i)(Pwd *= *)(?P<mask>[^\;]+)(;)`,
+				scan:  `Pwd `,
+			},
+			name: "Redact 'Pwd' values commonly found in database connection strings",
 		},
 	}
 
 	redactors := make([]Redactor, 0)
 	for _, re := range singleLines {
-		fmt.Println("Start to add redactor for " + re.name)
-		r, err := NewSingleLineRedactor(re.regex, MASK_TEXT, path, bundlePath, re.name, true)
+		r, err := NewSingleLineRedactor(re.regex, MASK_TEXT, path, re.name, true)
 		if err != nil {
 			return nil, err // maybe skip broken ones?
 		}
-		if r != nil {
-			fmt.Println("Added redactor for " + re.name)
-			redactors = append(redactors, r)
-		}
+		redactors = append(redactors, r)
 	}
 
 	doubleLines := []struct {
-		line1 string
-		line2 string
-		name  string
+		selector lineRedactor
+		redactor string
+		name     string
 	}{
 		{
-			line1: `(?i)"name": *"[^\"]*SECRET_?ACCESS_?KEY[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact AWS Secret Access Key values in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *"[^\"]*SECRET_?ACCESS_?KEY[^\"]*"`,
+				scan:  `SECRET_?ACCESS_?KEY`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact AWS Secret Access Key values in multiline JSON",
 		},
 		{
-			line1: `(?i)"name": *"[^\"]*ACCESS_?KEY_?ID[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact AWS Access Key ID values in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *"[^\"]*ACCESS_?KEY_?ID[^\"]*"`,
+				scan:  `ACCESS_?KEY_?ID`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact AWS Access Key ID values in multiline JSON",
 		},
 		{
-			line1: `(?i)"name": *"[^\"]*OWNER_?ACCOUNT[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact AWS Owner and Account Numbers in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *"[^\"]*OWNER_?ACCOUNT[^\"]*"`,
+				scan:  `OWNER_?ACCOUNT`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact AWS Owner and Account Numbers in multiline JSON",
 		},
 		{
-			line1: `(?i)"name": *".*password[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact password environment variables in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *".*password[^\"]*"`,
+				scan:  `password`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact password environment variables in multiline JSON",
 		},
 		{
-			line1: `(?i)"name": *".*token[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact values that look like API tokens in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *".*token[^\"]*"`,
+				scan:  `token`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact values that look like API tokens in multiline JSON",
 		},
 		{
-			line1: `(?i)"name": *".*database[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact database connection strings in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *".*database[^\"]*"`,
+				scan:  `database`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact database connection strings in multiline JSON",
 		},
 		{
-			line1: `(?i)"name": *".*user[^\"]*"`,
-			line2: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
-			name:  "Redact usernames in multiline JSON",
+			selector: lineRedactor{
+				regex: `(?i)"name": *".*user[^\"]*"`,
+				scan:  `user`,
+			},
+			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			name:     "Redact usernames in multiline JSON",
 		},
 		{
-			line1: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
-			line2: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
-			name:  "Redact 'key' values found in Ceph auth lists",
+			selector: lineRedactor{
+				regex: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
+				scan:  `(osd|client|mgr)`,
+			},
+			redactor: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
+			name:     "Redact 'key' values found in Ceph auth lists",
 		},
 	}
 
 	for _, l := range doubleLines {
-		r, err := NewMultiLineRedactor(l.line1, l.line2, MASK_TEXT, path, l.name, true)
+		r, err := NewMultiLineRedactor(l.selector, l.redactor, MASK_TEXT, path, l.name, true)
 		if err != nil {
 			return nil, err // maybe skip broken ones?
 		}

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -181,21 +181,21 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)SECRET_?ACCESS_?KEY`,
+				scan:  `secret_?access_?key`,
 			},
 			name: "Redact values for environment variables that look like AWS Secret Access Keys",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)ACCESS_?KEY_?ID`,
+				scan:  `access_?key_?id`,
 			},
 			name: "Redact values for environment variables that look like AWS Access Keys",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)OWNER_?ACCOUNT`,
+				scan:  `owner_?account`,
 			},
 			name: "Redact values for environment variables that look like AWS Owner or Account numbers",
 		},
@@ -203,7 +203,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)password`,
+				scan:  `password`,
 			},
 			name: "Redact values for environment variables with names beginning with 'password'",
 		},
@@ -212,21 +212,21 @@ func getRedactors(path string) ([]Redactor, error) {
 
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)token`,
+				scan:  `token`,
 			},
 			name: "Redact values for environment variables with names beginning with 'token'",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)database`,
+				scan:  `database`,
 			},
 			name: "Redact values for environment variables with names beginning with 'database'",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
-				scan:  `(?i)user`,
+				scan:  `user`,
 			},
 			name: "Redact values for environment variables with names beginning with 'user'",
 		},
@@ -235,7 +235,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: LineRedactor{
 				regex: `(?i)(https?|ftp)(:\/\/)(?P<mask>[^:\"\/]+){1}(:)(?P<mask>[^@\"\/]+){1}(?P<host>@[^:\/\s\"]+){1}(?P<port>:[\d]+)?`,
-				scan:  `(?i)https?|ftp`,
+				scan:  `https?|ftp`,
 			},
 			name: "Redact connection strings with username and password",
 		},
@@ -259,56 +259,56 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			regex: LineRedactor{
 				regex: `(?i)(Data Source *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)Data Source`,
+				scan:  `data source`,
 			},
 			name: "Redact 'Data Source' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(location *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)location`,
+				scan:  `location`,
 			},
 			name: "Redact 'location' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(User ID *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)User ID`,
+				scan:  `user id`,
 			},
 			name: "Redact 'User ID' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(password *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)password`,
+				scan:  `password`,
 			},
 			name: "Redact 'password' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(Server *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)Server`,
+				scan:  `server`,
 			},
 			name: "Redact 'Server' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(Database *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)Database`,
+				scan:  `database`,
 			},
 			name: "Redact 'Database' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(Uid *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)Uid`,
+				scan:  `uid`,
 			},
 			name: "Redact 'UID' values commonly found in database connection strings",
 		},
 		{
 			regex: LineRedactor{
 				regex: `(?i)(Pwd *= *)(?P<mask>[^\;]+)(;)`,
-				scan:  `(?i)Pwd`,
+				scan:  `pwd`,
 			},
 			name: "Redact 'Pwd' values commonly found in database connection strings",
 		},
@@ -331,7 +331,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *"[^\"]*SECRET_?ACCESS_?KEY[^\"]*"`,
-				scan:  `SECRET_?ACCESS_?KEY`,
+				scan:  `secret_?access_?key`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact AWS Secret Access Key values in multiline JSON",
@@ -339,7 +339,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *"[^\"]*ACCESS_?KEY_?ID[^\"]*"`,
-				scan:  `(?i)ACCESS_?KEY_?ID`,
+				scan:  `access_?key_?id`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact AWS Access Key ID values in multiline JSON",
@@ -347,7 +347,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *"[^\"]*OWNER_?ACCOUNT[^\"]*"`,
-				scan:  `(?i)OWNER_?ACCOUNT`,
+				scan:  `owner_?account`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact AWS Owner and Account Numbers in multiline JSON",
@@ -355,7 +355,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *".*password[^\"]*"`,
-				scan:  `(?i)password`,
+				scan:  `password`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact password environment variables in multiline JSON",
@@ -363,7 +363,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *".*token[^\"]*"`,
-				scan:  `(?i)token`,
+				scan:  `token`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact values that look like API tokens in multiline JSON",
@@ -371,7 +371,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *".*database[^\"]*"`,
-				scan:  `(?i)database`,
+				scan:  `database`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact database connection strings in multiline JSON",
@@ -379,7 +379,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"name": *".*user[^\"]*"`,
-				scan:  `(?i)user`,
+				scan:  `user`,
 			},
 			redactor: `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
 			name:     "Redact usernames in multiline JSON",
@@ -387,7 +387,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 			selector: LineRedactor{
 				regex: `(?i)"entity": *"(osd|client|mgr)\..*[^\"]*"`,
-				scan:  `(?i)(osd|client|mgr)`,
+				scan:  `(osd|client|mgr)`,
 			},
 			redactor: `(?i)("key": *")(?P<mask>.{38}==[^\"]*)(")`,
 			name:     "Redact 'key' values found in Ceph auth lists",

--- a/pkg/redact/single_line.go
+++ b/pkg/redact/single_line.go
@@ -23,13 +23,24 @@ func NewSingleLineRedactor(re, maskText, path, bundlePath string, name string, i
 		return nil, err
 	}
 
-	content, err := os.ReadFile(filepath.Join(bundlePath, path))
+	// Check if file has lines that match the regex
+	file, err := os.Open(filepath.Join(bundlePath, path))
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 
-	if !compiled.MatchString(string(content)) {
-		fmt.Printf("No matches found for %s in %s\n", re, path)
+	scanner := bufio.NewScanner(file)
+	hasMatch := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if compiled.MatchString(line) {
+			hasMatch = true
+			break
+		}
+	}
+
+	if hasMatch {
 		return nil, nil
 	}
 

--- a/pkg/redact/single_line.go
+++ b/pkg/redact/single_line.go
@@ -50,7 +50,10 @@ func (r *SingleLineRedactor) Redact(input io.Reader, path string) io.Reader {
 
 		substStr := getReplacementPattern(r.re, r.maskText)
 
+		const maxCapacity = 1024 * 1024
+		buf := make([]byte, maxCapacity)
 		scanner := bufio.NewScanner(input)
+		scanner.Buffer(buf, maxCapacity)
 
 		lineNum := 0
 		for scanner.Scan() {

--- a/pkg/redact/single_line.go
+++ b/pkg/redact/single_line.go
@@ -49,10 +49,7 @@ func (r *SingleLineRedactor) Redact(input io.Reader, path string) io.Reader {
 
 		substStr := getReplacementPattern(r.re, r.maskText)
 
-		const maxCapacity = 1024 * 1024
-		buf := make([]byte, maxCapacity)
 		scanner := bufio.NewScanner(input)
-		scanner.Buffer(buf, maxCapacity)
 
 		lineNum := 0
 		for scanner.Scan() {

--- a/pkg/redact/single_line.go
+++ b/pkg/redact/single_line.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"regexp"
+	"strings"
 )
 
 type SingleLineRedactor struct {
@@ -55,9 +56,9 @@ func (r *SingleLineRedactor) Redact(input io.Reader, path string) io.Reader {
 		for scanner.Scan() {
 			lineNum++
 			line := scanner.Text()
-
+			lowerLine := strings.ToLower(line)
 			// if scan is not nil, do not redact if the line does not match
-			if r.scan != nil && !r.scan.MatchString(line) {
+			if r.scan != nil && !r.scan.MatchString(lowerLine) {
 				bufferedWriter.WriteString(line)
 				bufferedWriter.WriteByte('\n')
 				continue

--- a/pkg/redact/single_line.go
+++ b/pkg/redact/single_line.go
@@ -15,7 +15,7 @@ type SingleLineRedactor struct {
 	isDefault  bool
 }
 
-func NewSingleLineRedactor(re lineRedactor, maskText, path, name string, isDefault bool) (*SingleLineRedactor, error) {
+func NewSingleLineRedactor(re LineRedactor, maskText, path, name string, isDefault bool) (*SingleLineRedactor, error) {
 	var scanCompiled *regexp.Regexp
 	compiled, err := regexp.Compile(re.regex)
 	if err != nil {

--- a/pkg/redact/single_line.go
+++ b/pkg/redact/single_line.go
@@ -38,15 +38,11 @@ func (r *SingleLineRedactor) Redact(input io.Reader, path string) io.Reader {
 
 		substStr := getReplacementPattern(r.re, r.maskText)
 
-		reader := bufio.NewReader(input)
+		scanner := bufio.NewScanner(input)
 		lineNum := 0
-		for {
+		for scanner.Scan() {
 			lineNum++
-			var line string
-			line, err = readLine(reader)
-			if err != nil {
-				return
-			}
+			line := scanner.Text()
 
 			if !r.re.MatchString(line) {
 				fmt.Fprintf(writer, "%s\n", line)

--- a/pkg/redact/single_line_test.go
+++ b/pkg/redact/single_line_test.go
@@ -162,7 +162,7 @@ func TestNewSingleLineRedactor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			ResetRedactionList()
-			reRunner, err := NewSingleLineRedactor(lineRedactor{
+			reRunner, err := NewSingleLineRedactor(LineRedactor{
 				regex: tt.re,
 			}, MASK_TEXT, "testfile", tt.name, false)
 			req.NoError(err)


### PR DESCRIPTION
## Description, Motivation and Context

- if the regex is case insensitive, it is not wise to use camel case in regex. That needs be updated in docs
For example. 
```
(?i)(Database *= *)(?P<mask>[^\;]+)(;)   
-> (?i)(database *= *)(?P<mask>[^\;]+)(;)


(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\") 
-> (?i)(\\\"name\\\":\\\"[^\"]*owner_?account\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")
```
- if the regex is case insensitive, all the text read from files of waiting redact will be transformed to lowercase for normalize. 
```
PWD = abcdef;   ->  pwd = abcdef;
```
- case insensitive regex will be split into case-sensitive and insensitive parts. case-sensitive part will be used to check those lowercase texts which can reduce CPU usage. 
```
Original regex:  (?i)(pwd *= *)(?P<mask>[^\;]+)(;) 
For matching
use (pwd *= *)(?P<mask>[^\;]+)(;) 
agaist pwd = abcdef;
```

- if the regex is case sensitive, it will keep passing to redact directly with existing logical
- add goroutine to RedactResult
- use bufio.NewWriter and bufio.NewScanner to improve read and write performance
- klog the size of redact file for better monitoring
<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes: #1151
## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
