### PR TITLE
fix(json_compare): solve unorderd slice deep equal

### DIFF
--- a/pkg/analyze/json_compare_test.go
+++ b/pkg/analyze/json_compare_test.go
@@ -756,50 +756,6 @@ func Test_jsonCompare(t *testing.T) {
 				]
 			}`),
 		},
-		{
-			name: "jsonpath comparison, multiple values",
-			analyzer: troubleshootv1beta2.JsonCompare{
-				Outcomes: []*troubleshootv1beta2.Outcome{
-					{
-						Pass: &troubleshootv1beta2.SingleOutcome{
-							Message: "pass",
-						},
-					},
-					{
-						Fail: &troubleshootv1beta2.SingleOutcome{
-							Message: "fail",
-						},
-					},
-				},
-				CollectorName: "jsonpath-compare-2",
-				FileName:      "jsonpath-compare-2.json",
-				JsonPath:      "{$..bar}",
-				Value:         `[true, 123]`,
-			},
-			expectResult: AnalyzeResult{
-				IsPass:  true,
-				IsWarn:  false,
-				IsFail:  false,
-				Title:   "jsonpath-compare-2",
-				Message: "pass",
-				IconKey: "kubernetes_text_analyze",
-				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
-			},
-			fileContents: []byte(`{
-				"foo": "bar",
-				"stuff": {
-					"foo": "bar",
-					"bar": true
-				},
-				"morestuff": [
-					{
-						"foo": {
-							"bar": 123
-						}
-					}
-				]
-			}`),
-		},
 	}
 
 	for _, test := range tests {

--- a/pkg/analyze/json_compare_test.go
+++ b/pkg/analyze/json_compare_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_compareUnorderedSlices(t *testing.T) {
+func Test_compareSortedSlices(t *testing.T) {
 	type args struct {
 		actual   []interface{}
 		expected []interface{}
@@ -78,7 +78,7 @@ func Test_compareUnorderedSlices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := compareUnorderedSlices(tt.args.actual, tt.args.expected)
+			got := compareSortedSlices(tt.args.actual, tt.args.expected)
 			assert.Equalf(t, tt.equal, got, "compareSlices() = %v, want %v", got, tt.equal)
 		})
 	}
@@ -694,6 +694,50 @@ func Test_jsonCompare(t *testing.T) {
 				IsFail:  true,
 				Title:   "jsonpath-compare-1-1",
 				Message: "fail",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+			},
+			fileContents: []byte(`{
+				"foo": "bar",
+				"stuff": {
+					"foo": "bar",
+					"bar": true
+				},
+				"morestuff": [
+					{
+						"foo": {
+							"bar": 123
+						}
+					}
+				]
+			}`),
+		},
+		{
+			name: "jsonpath comparison, multiple values",
+			analyzer: troubleshootv1beta2.JsonCompare{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "pass",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+						},
+					},
+				},
+				CollectorName: "jsonpath-compare-2",
+				FileName:      "jsonpath-compare-2.json",
+				JsonPath:      "{$..bar}",
+				Value:         `[true, 123]`,
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  true,
+				IsWarn:  false,
+				IsFail:  false,
+				Title:   "jsonpath-compare-2",
+				Message: "pass",
 				IconKey: "kubernetes_text_analyze",
 				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 			},

--- a/pkg/analyze/json_compare_test.go
+++ b/pkg/analyze/json_compare_test.go
@@ -4,8 +4,85 @@ import (
 	"testing"
 
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_compareUnorderedSlices(t *testing.T) {
+	type args struct {
+		actual   []interface{}
+		expected []interface{}
+	}
+
+	tests := []struct {
+		name  string
+		args  args
+		equal bool
+	}{
+		{
+			name: "empty slices",
+			args: args{
+				actual:   []interface{}{},
+				expected: []interface{}{},
+			},
+			equal: true,
+		},
+		{
+			name: "same order slices",
+			args: args{
+				actual:   []interface{}{"a", "b", "c"},
+				expected: []interface{}{"a", "b", "c"},
+			},
+			equal: true,
+		},
+		{
+			name: "unordered slices",
+			args: args{
+				actual:   []interface{}{"a", "b", "c"},
+				expected: []interface{}{"b", "a", "c"},
+			},
+			equal: true,
+		},
+		{
+			name: "different type and unordered slices",
+			args: args{
+				actual:   []interface{}{1, "a", "c"},
+				expected: []interface{}{"a", 1, "c"},
+			},
+			equal: true,
+		},
+		{
+			name: "unordered slices with map",
+			args: args{
+				actual:   []interface{}{map[string]int{"a": 1}, "a", "c"},
+				expected: []interface{}{"a", map[string]int{"a": 1}, "c"},
+			},
+			equal: true,
+		},
+		{
+			name: "unequal slices with duplicates",
+			args: args{
+				actual:   []interface{}{"a", "a", "a", "c"},
+				expected: []interface{}{"a", "a", "c", "c"},
+			},
+			equal: false,
+		},
+		{
+			name: "unordered slices with boolean and strings",
+			args: args{
+				actual:   []interface{}{true, "a", false, true},
+				expected: []interface{}{"a", true, false, true},
+			},
+			equal: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareUnorderedSlices(tt.args.actual, tt.args.expected)
+			assert.Equalf(t, tt.equal, got, "compareSlices() = %v, want %v", got, tt.equal)
+		})
+	}
+}
 
 func Test_jsonCompare(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description, Motivation and Context

- sort slices first, then use reflect.DeepEqual to compare
- compares two slices of interfaces and returns true if they contain the same values

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes: #1274
## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
