### PR TITLE
fix: use duration strings for http collector timeout

### DIFF
--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -344,12 +344,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -368,12 +366,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -390,12 +386,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:

--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -1261,12 +1261,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1283,12 +1281,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1305,12 +1301,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -1261,12 +1261,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1283,12 +1281,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1305,12 +1301,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1691,12 +1685,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1713,12 +1705,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1735,12 +1725,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -1841,12 +1841,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1865,12 +1863,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1887,12 +1883,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -10470,12 +10464,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -10492,12 +10484,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -10514,12 +10504,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:

--- a/config/crds/troubleshoot.sh_remotecollectors.yaml
+++ b/config/crds/troubleshoot.sh_remotecollectors.yaml
@@ -208,12 +208,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -230,12 +228,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -252,12 +248,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -1872,12 +1872,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1896,12 +1894,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -1918,12 +1914,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -11585,12 +11579,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -11607,12 +11599,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:
@@ -11629,12 +11619,10 @@ spec:
                             insecureSkipVerify:
                               type: boolean
                             timeout:
-                              description: A Duration represents the elapsed time
-                                between two instants as an int64 nanosecond count.
-                                The representation limits the largest representable
-                                duration to approximately 290 years.
-                              format: int64
-                              type: integer
+                              description: Timeout is the time to wait for a server's
+                                response. Its a duration e.g 15s, 2h30m. Missing value
+                                or empty string or means no timeout.
+                              type: string
                             url:
                               type: string
                           required:

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -169,7 +168,9 @@ type Get struct {
 	URL                string            `json:"url" yaml:"url"`
 	InsecureSkipVerify bool              `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
 	Headers            map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Timeout            time.Duration     `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	// Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m.
+	// Missing value or empty string or means no timeout.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 type Post struct {
@@ -177,7 +178,9 @@ type Post struct {
 	InsecureSkipVerify bool              `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
 	Headers            map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Body               string            `json:"body,omitempty" yaml:"body,omitempty"`
-	Timeout            time.Duration     `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	// Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m.
+	// Missing value or empty string or means no timeout.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 type Put struct {
@@ -185,7 +188,9 @@ type Put struct {
 	InsecureSkipVerify bool              `json:"insecureSkipVerify,omitempty" yaml:"insecureSkipVerify,omitempty"`
 	Headers            map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Body               string            `json:"body,omitempty" yaml:"body,omitempty"`
-	Timeout            time.Duration     `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	// Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m.
+	// Missing value or empty string or means no timeout.
+	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 type Database struct {

--- a/pkg/collect/http_test.go
+++ b/pkg/collect/http_test.go
@@ -217,7 +217,7 @@ func TestCollectHTTP_Collect(t *testing.T) {
 					CollectorName: "example-com",
 				},
 				Get: &troubleshootv1beta2.Get{
-					Timeout: 200 * time.Nanosecond,
+					Timeout: "200ms",
 				},
 			},
 			args: args{
@@ -236,7 +236,7 @@ func TestCollectHTTP_Collect(t *testing.T) {
 					CollectorName: "",
 				},
 				Get: &troubleshootv1beta2.Get{
-					Timeout: 3 * time.Millisecond,
+					Timeout: "300ms",
 				},
 			},
 			args: args{
@@ -341,5 +341,38 @@ func (er *ErrorResponse) testCollectHTTP(t *testing.T, tt *CollectorTest, c *Col
 
 	if strings.Contains(strings.TrimSpace(er.Error.Message), "context deadline exceeded") != tt.wantErr {
 		t.Errorf("CollectHTTP.Collect() response = %v, wantErr %v", er.Error.Message, tt.wantErr)
+	}
+}
+
+func Test_parseTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:  "1s timeout",
+			input: "1s",
+			want:  time.Second,
+		},
+		{
+			name:  "empty timeout",
+			input: "",
+			want:  0,
+		},
+		{
+			name:    "negative timeout",
+			input:   "-1s",
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTimeout(tt.input)
+			assert.Equal(t, (err != nil), tt.wantErr)
+			assert.Equal(t, got, tt.want)
+		})
 	}
 }

--- a/pkg/collect/http_test.go
+++ b/pkg/collect/http_test.go
@@ -217,7 +217,7 @@ func TestCollectHTTP_Collect(t *testing.T) {
 					CollectorName: "example-com",
 				},
 				Get: &troubleshootv1beta2.Get{
-					Timeout: "200ms",
+					Timeout: "200ns",
 				},
 			},
 			args: args{

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -477,9 +477,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -508,9 +507,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -536,9 +534,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -2783,9 +2783,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -2814,9 +2813,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -2842,9 +2840,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -9590,9 +9587,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -9618,9 +9614,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -9646,9 +9641,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -2829,9 +2829,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -2860,9 +2859,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -2888,9 +2886,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -11315,9 +11312,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -11343,9 +11339,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"
@@ -11371,9 +11366,8 @@
                         "type": "boolean"
                       },
                       "timeout": {
-                        "description": "A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.",
-                        "type": "integer",
-                        "format": "int64"
+                        "description": "Timeout is the time to wait for a server's response. Its a duration e.g 15s, 2h30m. Missing value or empty string or means no timeout.",
+                        "type": "string"
                       },
                       "url": {
                         "type": "string"


### PR DESCRIPTION
## Description, Motivation and Context

This follows the same format that all other collectors use.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
