### PR TITLE
chore: Do not create package json files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,4 +252,4 @@ watchrsync: npm-install
 .PHONY: npm-install
 npm-install:
 	npm --version 2>&1 >/dev/null || ( echo "npm not installed; install npm to set up watchrsync" && exit 1 )
-	npm list gaze-run-interrupt || npm install install gaze-run-interrupt@~2.0.0
+	npm list gaze-run-interrupt || npm install install --no-save gaze-run-interrupt@~2.0.0


### PR DESCRIPTION
## Description, Motivation and Context

When running `make watch` some npm packages get installed. This PR ensures the unnecessary `package.json` & `package-lock.json` files do not get generated

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
