### PR TITLE
feat: Build and release binaries for Linux RISC-V

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -271,6 +271,8 @@ jobs:
         include:
           - goarch: arm
             goos: linux
+          - goarch: riscv64
+            goos: linux
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -15,6 +15,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - riscv64
     ignore:
       - goos: windows
         goarch: arm
@@ -38,6 +39,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - riscv64
     ignore:
       - goos: windows
         goarch: arm
@@ -61,6 +63,7 @@ builds:
       - amd64
       - arm
       - arm64
+      - riscv64
     ignore:
       - goos: windows
         goarch: arm


### PR DESCRIPTION
## Description, Motivation and Context

I'm currently evaluating k0s on RISC-V (k0sproject/k0s#1919). In case of test failures, the k0s integration tests use `support-bundle` to collect the cluster state for further investigation. It would be neat if there's a precompiled `support-bundle` binary available for RISC-V, so that troubleshooting integration test failures becomes a bit easier.

Things done:

* Add riscv64 to GOARCHes in .goreleaser.yaml
* Add riscv64/linux to goreleaser-test GitHub workflow job

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No