### PR TITLE
Fix mssql and mysql analyzers

### DIFF
--- a/pkg/analyze/mssql.go
+++ b/pkg/analyze/mssql.go
@@ -43,7 +43,7 @@ func (a *AnalyzeMssql) collectorName() string {
 	if a.analyzer.CollectorName != "" {
 		return a.analyzer.CollectorName
 	}
-	return "mysql"
+	return "mssql"
 }
 
 func compareMssqlConditionalToActual(conditional string, result *collect.DatabaseConnection) (bool, error) {

--- a/pkg/analyze/mysql.go
+++ b/pkg/analyze/mysql.go
@@ -40,11 +40,11 @@ func (a *AnalyzeMysql) collectorName() string {
 	if a.analyzer.CollectorName != "" {
 		return a.analyzer.CollectorName
 	}
-	return "mssql"
+	return "mysql"
 }
 
 func (a *AnalyzeMysql) analyzeMysql(analyzer *troubleshootv1beta2.DatabaseAnalyze, getCollectedFileContents func(string) ([]byte, error)) (*AnalyzeResult, error) {
-	fullPath := path.Join("mssql", fmt.Sprintf("%s.json", a.collectorName()))
+	fullPath := path.Join("mysql", fmt.Sprintf("%s.json", a.collectorName()))
 
 	collected, err := getCollectedFileContents(fullPath)
 	if err != nil {
@@ -58,7 +58,7 @@ func (a *AnalyzeMysql) analyzeMysql(analyzer *troubleshootv1beta2.DatabaseAnalyz
 
 	result := &AnalyzeResult{
 		Title:   a.Title(),
-		IconKey: "kubernetes_mssql_analyze",
+		IconKey: "kubernetes_mysql_analyze",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/mysql-analyze.svg",
 	}
 


### PR DESCRIPTION
## Description, Motivation and Context

Fixing a regression where the Mysql analyzer is looking for collected contents in `mssql/*` instead of `mysql/*`

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
