### PR TITLE
fix: Store custom resources in JSON & YAML format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ build:
 	@echo "Build cli binaries"
 	$(MAKE) -j support-bundle preflight analyze collect
 
+mod-tidy:
+	go mod tidy
+
 .PHONY: support-bundle
 support-bundle:
 	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle github.com/replicatedhq/troubleshoot/cmd/troubleshoot
@@ -151,7 +154,7 @@ CONTROLLER_GEN=$(shell which controller-gen)
 .PHONY: client-gen
 client-gen:
 ifeq (, $(shell which client-gen 2>/dev/null))
-	go install k8s.io/code-generator/cmd/client-gen@v0.26.1
+	go install k8s.io/code-generator/cmd/client-gen@v0.28.2
 CLIENT_GEN=$(shell go env GOPATH)/bin/client-gen
 else
 CLIENT_GEN=$(shell which client-gen)

--- a/cmd/collect/cli/run.go
+++ b/cmd/collect/cli/run.go
@@ -50,7 +50,7 @@ func runCollect(v *viper.Viper, arg string) error {
 
 		collectorContent = spec
 	} else if _, err = os.Stat(arg); err == nil {
-		b, err := ioutil.ReadFile(arg)
+		b, err := os.ReadFile(arg)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description, Motivation and Context

Store all custom resources in JSON format for two reasons.
- Storing them in YAML format conflicts with the current format other resources use
- YAML formatted resources that contain redaction masks will end up looking like below. (*NOTE the ip field has no quotes, hence not valid YAML*) This makes marshalling them to JSON in `sbctl` fail. Marshalling these objects to JSON then back to objects is the current approach used to ensure custom resources can be converted to `runtime.Object`s for k8s API to serve back to clients such as `kubectl`.
```yaml
  status:
      ip: ***HIDDEN***
    currentSize: "2147483648"
```

We keep the YAML files as well to maintain backward compatibility to ensure any existing analysers and tools out there (are there any?) do not break. We might need to deprecate this at some point.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1218

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
