### PR TITLE
allow warning when filesystem performance not collected (fio)

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const FILE_NOT_COLLECTED = "fileNotCollected"
+
 type AnalyzeResult struct {
 	IsPass bool
 	IsFail bool

--- a/pkg/analyze/host_filesystem_performance.go
+++ b/pkg/analyze/host_filesystem_performance.go
@@ -44,21 +44,21 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(
 	contents, err := getCollectedFileContents(name)
 	if err != nil {
 		if len(hostAnalyzer.Outcomes) >= 1 {
-			// if the very first outcome is 'fileNotCollected', then use that outcome
+			// if the very first outcome is FILE_NOT_COLLECTED', then use that outcome
 			// otherwise, return the error
-			if hostAnalyzer.Outcomes[0].Fail != nil && hostAnalyzer.Outcomes[0].Fail.When == "fileNotCollected" {
+			if hostAnalyzer.Outcomes[0].Fail != nil && hostAnalyzer.Outcomes[0].Fail.When == FILE_NOT_COLLECTED {
 				result.IsFail = true
 				result.Message = renderFSPerfOutcome(hostAnalyzer.Outcomes[0].Fail.Message, collect.FSPerfResults{})
 				result.URI = hostAnalyzer.Outcomes[0].Fail.URI
 				return []*AnalyzeResult{result}, nil
 			}
-			if hostAnalyzer.Outcomes[0].Warn != nil && hostAnalyzer.Outcomes[0].Warn.When == "fileNotCollected" {
+			if hostAnalyzer.Outcomes[0].Warn != nil && hostAnalyzer.Outcomes[0].Warn.When == FILE_NOT_COLLECTED {
 				result.IsWarn = true
 				result.Message = renderFSPerfOutcome(hostAnalyzer.Outcomes[0].Warn.Message, collect.FSPerfResults{})
 				result.URI = hostAnalyzer.Outcomes[0].Warn.URI
 				return []*AnalyzeResult{result}, nil
 			}
-			if hostAnalyzer.Outcomes[0].Pass != nil && hostAnalyzer.Outcomes[0].Pass.When == "fileNotCollected" {
+			if hostAnalyzer.Outcomes[0].Pass != nil && hostAnalyzer.Outcomes[0].Pass.When == FILE_NOT_COLLECTED {
 				result.IsPass = true
 				result.Message = renderFSPerfOutcome(hostAnalyzer.Outcomes[0].Pass.Message, collect.FSPerfResults{})
 				result.URI = hostAnalyzer.Outcomes[0].Pass.URI
@@ -158,7 +158,7 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(
 }
 
 func compareHostFilesystemPerformanceConditionalToActual(conditional string, fsPerf collect.FSPerfResults) (res bool, err error) {
-	if conditional == "fileNotCollected" {
+	if conditional == FILE_NOT_COLLECTED {
 		return false, nil
 	}
 

--- a/pkg/analyze/host_filesystem_performance.go
+++ b/pkg/analyze/host_filesystem_performance.go
@@ -32,6 +32,10 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(
 ) ([]*AnalyzeResult, error) {
 	hostAnalyzer := a.hostAnalyzer
 
+	result := &AnalyzeResult{
+		Title: a.Title(),
+	}
+
 	collectorName := hostAnalyzer.CollectorName
 	if collectorName == "" {
 		collectorName = "filesystemPerformance"
@@ -39,6 +43,29 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(
 	name := filepath.Join("host-collectors/filesystemPerformance", collectorName+".json")
 	contents, err := getCollectedFileContents(name)
 	if err != nil {
+		if len(hostAnalyzer.Outcomes) >= 1 {
+			// if the very first outcome is 'fileNotCollected', then use that outcome
+			// otherwise, return the error
+			if hostAnalyzer.Outcomes[0].Fail != nil && hostAnalyzer.Outcomes[0].Fail.When == "fileNotCollected" {
+				result.IsFail = true
+				result.Message = renderFSPerfOutcome(hostAnalyzer.Outcomes[0].Fail.Message, collect.FSPerfResults{})
+				result.URI = hostAnalyzer.Outcomes[0].Fail.URI
+				return []*AnalyzeResult{result}, nil
+			}
+			if hostAnalyzer.Outcomes[0].Warn != nil && hostAnalyzer.Outcomes[0].Warn.When == "fileNotCollected" {
+				result.IsWarn = true
+				result.Message = renderFSPerfOutcome(hostAnalyzer.Outcomes[0].Warn.Message, collect.FSPerfResults{})
+				result.URI = hostAnalyzer.Outcomes[0].Warn.URI
+				return []*AnalyzeResult{result}, nil
+			}
+			if hostAnalyzer.Outcomes[0].Pass != nil && hostAnalyzer.Outcomes[0].Pass.When == "fileNotCollected" {
+				result.IsPass = true
+				result.Message = renderFSPerfOutcome(hostAnalyzer.Outcomes[0].Pass.Message, collect.FSPerfResults{})
+				result.URI = hostAnalyzer.Outcomes[0].Pass.URI
+				return []*AnalyzeResult{result}, nil
+			}
+		}
+
 		return nil, errors.Wrapf(err, "failed to get collected file %s", name)
 	}
 
@@ -56,10 +83,6 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(
 	fsPerf := fioWriteLatency.FSPerfResults()
 	if err := json.Unmarshal(contents, &fsPerf); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal filesystem performance results from %s", name)
-	}
-
-	result := &AnalyzeResult{
-		Title: a.Title(),
 	}
 
 	for _, outcome := range hostAnalyzer.Outcomes {
@@ -135,6 +158,10 @@ func (a *AnalyzeHostFilesystemPerformance) Analyze(
 }
 
 func compareHostFilesystemPerformanceConditionalToActual(conditional string, fsPerf collect.FSPerfResults) (res bool, err error) {
+	if conditional == "fileNotCollected" {
+		return false, nil
+	}
+
 	parts := strings.Split(conditional, " ")
 	if len(parts) != 3 {
 		return false, fmt.Errorf("conditional must have exactly 3 parts, got %d", len(parts))


### PR DESCRIPTION
## Description, Motivation and Context

The host filesystem performance collector now relies on an external binary `fio`. This is not always present, and when it is not present the collector will not produce a file.

There should be a way to say "this is not a failure" in the analysis when this file is missing.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. [link](https://github.com/replicatedhq/troubleshoot.sh/pull/527)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
