### PR TITLE
fix: embed troubleshoot version string from module dependency

### DIFF
--- a/cmd/analyze/cli/run.go
+++ b/cmd/analyze/cli/run.go
@@ -18,7 +18,7 @@ func runAnalyzers(v *viper.Viper, bundlePath string) error {
 	specContent := ""
 	var err error
 	if _, err = os.Stat(specPath); err == nil {
-		b, err := ioutil.ReadFile(specPath)
+		b, err := os.ReadFile(specPath)
 		if err != nil {
 			return err
 		}
@@ -26,6 +26,7 @@ func runAnalyzers(v *viper.Viper, bundlePath string) error {
 		specContent = string(b)
 	} else {
 		if !util.IsURL(specPath) {
+			// TODO: Better error message when we do not have a file/url etc
 			return fmt.Errorf("%s is not a URL and was not found (err %s)", specPath, err)
 		}
 


### PR DESCRIPTION
## Description, Motivation and Context

If troubleshoot is used as a dependency (part of your `go.mod`), the version information of the release would be missing at runtime i.e empty string when [`version.Version()`](https://github.com/replicatedhq/troubleshoot/blob/5e280d0652bcdbfe1f2961dfd59be177c96cf698/pkg/version/version.go#L52) is called. This is because the version string is injected to binaries at build time using [linker flags (LD)](https://github.com/replicatedhq/troubleshoot/blob/5e280d0652bcdbfe1f2961dfd59be177c96cf698/Makefile#L28-L34) passed to the compiler. Built binaries such as `support-bundle` and `preflight` will contain a version string, but projects such as [KOTS](https://github.com/replicatedhq/kots) that import troubleshoot as a module will not have a version string set.

This PR utilises information fetched from [`runtime.BuildInfo`](https://pkg.go.dev/runtime/debug#BuildInfo) at runtime to extract the [version info from the troubleshoot module](https://pkg.go.dev/runtime/debug#Module) in the `go.mod` file.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes: #1372

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
