### PR TITLE
fix: Correct how configmap and secrets paths are parsed in the CLI

### DIFF
--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -82,10 +82,13 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 
 	for _, v := range args {
 		if strings.HasPrefix(v, "secret/") {
-			// format secret/namespace-name/secret-name
+			// format secret/namespace-name/secret-name[/data-key]
 			pathParts := strings.Split(v, "/")
-			if len(pathParts) != 3 {
-				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Errorf("secret path %q must have 3 components", v))
+			if len(pathParts) > 4 {
+				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Errorf("secret path %s must have at most 4 components", v))
+			}
+			if len(pathParts) < 3 {
+				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Errorf("secret path %s must have at least 3 components", v))
 			}
 
 			data, err := LoadFromSecret(ctx, client, pathParts[1], pathParts[2])
@@ -93,25 +96,44 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Wrap(err, "failed to get spec from secret"))
 			}
 
-			// Append all data in the secret. Some may not be specs, but that's ok. They will be ignored.
-			for _, spec := range data {
-				rawSpecs = append(rawSpecs, string(spec))
+			// If we have a key defined, then load specs from that key only.
+			if len(pathParts) == 4 {
+				spec, ok := data[pathParts[3]]
+				if ok {
+					rawSpecs = append(rawSpecs, string(spec))
+				}
+			} else {
+				// Append all data in the configmap. Some may not be specs, but that's ok. They will be ignored.
+				for _, spec := range data {
+					rawSpecs = append(rawSpecs, string(spec))
+				}
 			}
 		} else if strings.HasPrefix(v, "configmap/") {
-			// format configmap/namespace-name/configmap-name
+			// format configmap/namespace-name/configmap-name[/data-key]
 			pathParts := strings.Split(v, "/")
-			if len(pathParts) != 3 {
-				return nil, errors.Errorf("configmap path %q must have 3 components", v)
+			if len(pathParts) > 4 {
+				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Errorf("configmap path %s must have at most 4 components", v))
+			}
+			if len(pathParts) < 3 {
+				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Errorf("configmap path %s must have at least 3 components", v))
 			}
 
 			data, err := LoadFromConfigMap(ctx, client, pathParts[1], pathParts[2])
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to get spec from configmap")
+				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Wrap(err, "failed to get spec from configmap"))
 			}
 
-			// Append all data in the configmap. Some may not be specs, but that's ok. They will be ignored.
-			for _, spec := range data {
-				rawSpecs = append(rawSpecs, spec)
+			// If we have a key defined, then load specs from that key only.
+			if len(pathParts) == 4 {
+				spec, ok := data[pathParts[3]]
+				if ok {
+					rawSpecs = append(rawSpecs, spec)
+				}
+			} else {
+				// Append all data in the configmap. Some may not be specs, but that's ok. They will be ignored.
+				for _, spec := range data {
+					rawSpecs = append(rawSpecs, spec)
+				}
 			}
 		} else if _, err := os.Stat(v); err == nil {
 			b, err := os.ReadFile(v)

--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -103,7 +103,7 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 					rawSpecs = append(rawSpecs, string(spec))
 				}
 			} else {
-				// Append all data in the configmap. Some may not be specs, but that's ok. They will be ignored.
+				// Append all data in the secret. Some may not be specs, but that's ok. They will be ignored.
 				for _, spec := range data {
 					rawSpecs = append(rawSpecs, string(spec))
 				}

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -111,3 +111,45 @@ if ! grep "labelled-support-bundle-4 \*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_direct
     echo "Hidden content not found in redacted echo-hi-4 file"
     exit 1
 fi
+
+echo "======= Generating support bundle from k8s secret/<namespace-name>/<secret-name>/<data-key> ======"
+recreate_tmpdir
+kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
+./bin/support-bundle -v1 --interactive=false secret/default/labelled-support-bundle-1/custom-spec-key \
+                    --redactors configmap/default/labelled-redactor-spec-1/customer-redactor-spec \
+                    --output=$tmpdir/$bundle_archive_name
+if [ $? -ne 0 ]; then
+    echo "support-bundle command failed"
+    exit $?
+fi
+
+if ! tar -xvzf $tmpdir/$bundle_archive_name --directory $tmpdir; then
+    echo "A valid support bundle archive was not generated"
+    exit 1
+fi
+
+if ! grep "custom-spec-key \*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_directory_name/echo-hi-3"; then
+    echo "$(cat $tmpdir/$bundle_directory_name/echo-hi-3)"
+    echo "Hidden content not found in redacted echo-hi-3 file"
+    exit 1
+fi
+
+echo "======= Generating support bundle from k8s configmap/<namespace-name>/<configmap-name> ======"
+recreate_tmpdir
+kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
+./bin/support-bundle -v1 --interactive=false configmap/labelled-specs/labelled-support-bundle-2 --output=$tmpdir/$bundle_archive_name
+if [ $? -ne 0 ]; then
+    echo "support-bundle command failed"
+    exit $?
+fi
+
+if ! tar -xvzf $tmpdir/$bundle_archive_name --directory $tmpdir; then
+    echo "A valid support bundle archive was not generated"
+    exit 1
+fi
+
+if ! grep "labelled-support-bundle-2 REDACT" "$tmpdir/$bundle_directory_name/echo-hi-2"; then
+    echo "$(cat $tmpdir/$bundle_directory_name/echo-hi-2)"
+    echo "Hidden content not found in redacted echo-hi-2 file"
+    exit 1
+fi

--- a/testdata/supportbundle/labelled-specs/redact-spec-1.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-1.yaml
@@ -16,3 +16,14 @@ data:
           removals:
             values:
             -  REDACT FIRST TEXT PLEASE
+  customer-redactor-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Redactor
+    metadata:
+      name: labelled-redactor-spec-1
+    spec:
+      redactors:
+        - name: redact-text-1
+          removals:
+            values:
+            -  REDACT FIRST TEXT PLEASE

--- a/testdata/supportbundle/labelled-specs/redact-spec-1.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-1.yaml
@@ -27,3 +27,4 @@ data:
           removals:
             values:
             -  REDACT FIRST TEXT PLEASE
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/redact-spec-2.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-2.yaml
@@ -17,3 +17,4 @@ stringData:
           removals:
             values:
             -  REDACT SECOND TEXT PLEASE
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/redact-spec-3.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-3.yaml
@@ -16,3 +16,4 @@ data:
           removals:
             values:
             -  REDACT FIRST TEXT PLEASE
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/redact-spec-4.yaml
+++ b/testdata/supportbundle/labelled-specs/redact-spec-4.yaml
@@ -17,3 +17,4 @@ stringData:
           removals:
             values:
             -  REDACT SECOND TEXT PLEASE
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/sb-spec-1.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-1.yaml
@@ -25,3 +25,4 @@ stringData:
         - data:
             name: echo-hi-3
             data: "I am custom-spec-key REDACT FIRST TEXT PLEASE"
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/sb-spec-1.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-1.yaml
@@ -15,3 +15,13 @@ stringData:
         - data:
             name: echo-hi-1
             data: "I am labelled-support-bundle-1 REDACT FIRST TEXT PLEASE"
+  custom-spec-key: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: SupportBundle
+    metadata:
+      name: custom-spec-key
+    spec:
+      collectors:
+        - data:
+            name: echo-hi-3
+            data: "I am custom-spec-key REDACT FIRST TEXT PLEASE"

--- a/testdata/supportbundle/labelled-specs/sb-spec-2.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-2.yaml
@@ -16,3 +16,4 @@ data:
         - data:
             name: echo-hi-2
             data: "I am labelled-support-bundle-2 REDACT SECOND TEXT PLEASE"
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/sb-spec-3.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-3.yaml
@@ -15,3 +15,4 @@ stringData:
         - data:
             name: echo-hi-3
             data: "I am labelled-support-bundle-3 REDACT FIRST TEXT PLEASE"
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti

--- a/testdata/supportbundle/labelled-specs/sb-spec-4.yaml
+++ b/testdata/supportbundle/labelled-specs/sb-spec-4.yaml
@@ -16,3 +16,4 @@ data:
         - data:
             name: echo-hi-4
             data: "I am labelled-support-bundle-4 REDACT SECOND TEXT PLEASE"
+  garbagge: MWdRRTlBRi9YNzB3eUE2VEgvWjdhRFVUR1UvRmU3TXdUR3Q4cnE4Nkti


### PR DESCRIPTION
## Description, Motivation and Context

When passing a `secret/<namespace-name>/<secret-name>/<data-key>` or `configmap/<namespace-name>/<configmap-name>/<data-key>`, the `<data-key>` part causes both `preflight` and `support-bundle` applications to error. This is because the `<data-key>` part is not expected due to a recent refactoring change.. This PR fixes that

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1374 

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
