### PR TITLE
Gracefully handle unreachable URIs in loadSupportBundleSpecsFromURIs

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -240,6 +240,7 @@ func loadSupportBundleSpecsFromURIs(ctx context.Context, kinds *loader.Troublesh
 			// We are using LoadSupportBundleSpec function here since it handles prompting
 			// users to accept insecure connections
 			// There is an opportunity to refactor this code in favour of the Loader APIs
+			// TODO: Pass ctx to LoadSupportBundleSpec
 			rawSpec, err := supportbundle.LoadSupportBundleSpec(s.Spec.Uri)
 			if err != nil {
 				// In the event a spec can't be loaded, we'll just skip it and print a warning
@@ -251,7 +252,7 @@ func loadSupportBundleSpecsFromURIs(ctx context.Context, kinds *loader.Troublesh
 	}
 
 	if len(remoteRawSpecs) == 0 {
-		return nil, fmt.Errorf("no support bundles to load")
+		return kinds, nil
 	}
 
 	return loader.LoadSpecs(ctx, loader.LoadOptions{

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -28,7 +28,6 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/loader"
 	"github.com/replicatedhq/troubleshoot/pkg/supportbundle"
 	"github.com/replicatedhq/troubleshoot/pkg/types"
-	"github.com/replicatedhq/vandoor/analyze-api/vendor/k8s.io/klog/v2"
 	"github.com/spf13/viper"
 	spin "github.com/tj/go-spin"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -251,11 +251,8 @@ func loadSupportBundleSpecsFromURIs(ctx context.Context, kinds *loader.Troublesh
 		}
 	}
 
-	// If we don't have any remote specs, return nil as opposed to erroring out
-	// This is to implicitly handle airgap scenarios
 	if len(remoteRawSpecs) == 0 {
-		klog.Warningf("unable to load any support bundles from URIs")
-		return nil, nil
+		return nil, fmt.Errorf("no support bundles to load")
 	}
 
 	return loader.LoadSpecs(ctx, loader.LoadOptions{
@@ -275,9 +272,10 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 	if !viper.GetBool("no-uri") {
 		moreKinds, err := loadSupportBundleSpecsFromURIs(ctx, kinds)
 		if err != nil {
-			return nil, nil, err
+			klog.Warningf("unable to load support bundles from URIs: %v", err)
+		} else {
+			kinds.Add(moreKinds)
 		}
-		kinds.Add(moreKinds)
 	}
 
 	// Check if we have any collectors to run in the troubleshoot specs

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -4,12 +4,28 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/replicatedhq/troubleshoot/pkg/httputil"
 	"github.com/replicatedhq/troubleshoot/pkg/loader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var orig = `
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: sb-1
+spec:
+  uri: $MY_URI
+  collectors:
+    - configMap:
+        name: kube-root-ca.crt
+        namespace: default
+`
 
 func Test_loadSupportBundleSpecsFromURIs(t *testing.T) {
 	// Run a webserver to serve the spec
@@ -25,18 +41,7 @@ spec:
 	}))
 	defer srv.Close()
 
-	orig := `
-apiVersion: troubleshoot.sh/v1beta2
-kind: SupportBundle
-metadata:
-  name: sb-1
-spec:
-  uri: ` + srv.URL + `
-  collectors:
-    - configMap:
-        name: kube-root-ca.crt
-        namespace: default
-`
+	orig := strings.ReplaceAll(orig, "$MY_URI", srv.URL)
 
 	ctx := context.Background()
 	kinds, err := loader.LoadSpecs(ctx, loader.LoadOptions{RawSpec: orig})
@@ -48,4 +53,31 @@ spec:
 
 	require.Len(t, moreKinds.SupportBundlesV1Beta2, 1)
 	assert.NotNil(t, moreKinds.SupportBundlesV1Beta2[0].Spec.Collectors[0].ClusterInfo)
+}
+
+func Test_loadSupportBundleSpecsFromURIs_TimeoutError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second) // this will cause a timeout
+	}))
+	defer srv.Close()
+	ctx := context.Background()
+
+	kinds, err := loader.LoadSpecs(ctx, loader.LoadOptions{
+		RawSpec: strings.ReplaceAll(orig, "$MY_URI", srv.URL),
+	})
+	require.NoError(t, err)
+
+	// Set the timeout on the http client to 10ms
+	// supportbundle.LoadSupportBundleSpec does not yet use the context
+	before := httputil.GetHttpClient().Timeout
+	httputil.GetHttpClient().Timeout = 10 * time.Millisecond
+	defer func() {
+		// Reinstate the original timeout. Its a global var so we need to reset it
+		httputil.GetHttpClient().Timeout = before
+	}()
+
+	kindsAfter, err := loadSupportBundleSpecsFromURIs(ctx, kinds)
+	require.NoError(t, err)
+
+	assert.Equal(t, kinds, kindsAfter)
 }


### PR DESCRIPTION
## Description, Motivation and Context

- If a support bundle URI cannot be reached or fails to load, the function logs a warning and continues to the next URI, instead of returning an error. This is to implicitly support air-gapped environments where external URIs might be inaccessible.

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
