### PR TITLE
Add support for Oracle OKE environment

### DIFF
--- a/examples/preflight/sample-preflight.yaml
+++ b/examples/preflight/sample-preflight.yaml
@@ -72,6 +72,9 @@ spec:
           - pass:
               when: "== k3s"
               message: K3S is a supported distribution
+          - pass:
+              when: "== oke"
+              message: OKE is a supported distribution
           - warn:
               message: Unable to determine the distribution of Kubernetes
     - nodeResources:

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -26,6 +26,7 @@ type providers struct {
 	minikube      bool
 	rke2          bool
 	k3s           bool
+	oke           bool
 }
 
 type Provider int
@@ -45,6 +46,7 @@ const (
 	minikube      Provider = iota
 	rke2          Provider = iota
 	k3s           Provider = iota
+	oke           Provider = iota
 )
 
 type AnalyzeDistribution struct {
@@ -124,6 +126,11 @@ func ParseNodesForProviders(nodes []corev1.Node) (providers, string) {
 			if k == "beta.kubernetes.io/instance-type" && v == "k3s" {
 				foundProviders.k3s = true
 				stringProvider = "k3s"
+			}
+			if k == "oci.oraclecloud.com/fault-domain" {
+				// Based on: https://docs.oracle.com/en-us/iaas/Content/ContEng/Reference/contengsupportedlabelsusecases.htm
+				foundProviders.oke = true
+				stringProvider = "oke"
 			}
 		}
 
@@ -326,6 +333,8 @@ func compareDistributionConditionalToActual(conditional string, actual providers
 		isMatch = actual.rke2
 	case k3s:
 		isMatch = actual.k3s
+	case oke:
+		isMatch = actual.oke
 	}
 
 	switch parts[0] {
@@ -366,6 +375,8 @@ func mustNormalizeDistributionName(raw string) Provider {
 		return rke2
 	case "k3s":
 		return k3s
+	case "oke":
+		return oke
 	}
 
 	return unknown


### PR DESCRIPTION
## Description, Motivation and Context

Adds "OKE" as a distribution type and strings for Oracle Cloud Infrastructure.

Fixed: 4116
## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Please let me know if there are unit tests or documentation I should update; I didn't see anything relevant.
