### PR TITLE
fix: Rename TS_WORKSPACE_DIR to TS_OUTPUT_DIR

### DIFF
--- a/examples/collect/host/run-and-save-output.yaml
+++ b/examples/collect/host/run-and-save-output.yaml
@@ -10,7 +10,7 @@ spec:
         # this is for demonstration purpose only -- you probably don't want to drop your input to the bundle!
         args:
           - "-c"
-          - "cat $TS_INPUT_DIR/dummy.yaml > $TS_WORKSPACE_DIR/dummy_content.yaml"
+          - "cat $TS_INPUT_DIR/dummy.yaml > $TS_OUTPUT_DIR/dummy_content.yaml"
         outputDir: "myCommandOutputs"
         env:
           - AWS_REGION=us-west-1
@@ -23,7 +23,7 @@ spec:
           dummy.conf: |-
             [hello]
             hello = 1
-            
+
             [bye]
             bye = 2
           dummy.yaml: |-

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -80,7 +80,7 @@ func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]
 			return nil, errors.New(fmt.Sprintf("failed to create dir for: %s", runHostCollector.OutputDir))
 		}
 		cmd.Env = append(cmd.Env,
-			fmt.Sprintf("TS_WORKSPACE_DIR=%s", cmdOutputTempDir),
+			fmt.Sprintf("TS_OUTPUT_DIR=%s", cmdOutputTempDir),
 		)
 	}
 

--- a/pkg/collect/host_run_test.go
+++ b/pkg/collect/host_run_test.go
@@ -117,7 +117,7 @@ func TestCollectHostRun_Collect(t *testing.T) {
 						CollectorName: "my-cmd-with-output",
 					},
 					Command: "sh",
-					Args:    []string{"-c", "echo ${TS_INPUT_DIR}/dummy.conf > $TS_WORKSPACE_DIR/input-file.txt"},
+					Args:    []string{"-c", "echo ${TS_INPUT_DIR}/dummy.conf > $TS_OUTPUT_DIR/input-file.txt"},
 					Input: map[string]string{
 						"dummy.conf": "[hello]\nhello = 1",
 					},


### PR DESCRIPTION
## Description, Motivation and Context

Small improvement after reviewing https://github.com/replicatedhq/troubleshoot.sh/pull/530 PR. `TS_OUTPUT_DIR` is a better name compared to `TS_WORKSPACE_DIR` since the purpose of this variable is to hold the directory path for outputs of the command. Its also created when `inputDir` is defined.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
