### PR TITLE
fix: missing omitempty on 2 of the new fields

### DIFF
--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -1389,8 +1389,6 @@ spec:
                       required:
                       - args
                       - command
-                      - ignoreParentEnvs
-                      - inheritEnvs
                       type: object
                     subnetAvailable:
                       properties:

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -1389,8 +1389,6 @@ spec:
                       required:
                       - args
                       - command
-                      - ignoreParentEnvs
-                      - inheritEnvs
                       type: object
                     subnetAvailable:
                       properties:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -11720,8 +11720,6 @@ spec:
                       required:
                       - args
                       - command
-                      - ignoreParentEnvs
-                      - inheritEnvs
                       type: object
                     subnetAvailable:
                       properties:

--- a/examples/collect/host/run-and-save-output.yaml
+++ b/examples/collect/host/run-and-save-output.yaml
@@ -10,7 +10,7 @@ spec:
         # this is for demonstration purpose only -- you probably don't want to drop your input to the bundle!
         args:
           - "-c"
-          - "cat $TS_INPUT_DIR/dummy.yaml > $TS_WORKSPACE_DIR/dummy_content.yaml"
+          - "cat $TS_INPUT_DIR/dummy.yaml > $TS_OUTPUT_DIR/dummy_content.yaml"
         outputDir: "myCommandOutputs"
         env:
           - AWS_REGION=us-west-1
@@ -23,7 +23,7 @@ spec:
           dummy.conf: |-
             [hello]
             hello = 1
-            
+
             [bye]
             bye = 2
           dummy.yaml: |-

--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -185,8 +185,8 @@ type HostRun struct {
 	OutputDir         string            `json:"outputDir,omitempty" yaml:"outputDir,omitempty"`
 	Input             map[string]string `json:"input,omitempty" yaml:"input,omitempty"`
 	Env               []string          `json:"env,omitempty" yaml:"env,omitempty"`
-	InheritEnvs       []string          `json:"inheritEnvs" yaml:"inheritEnvs,omitempty"`
-	IgnoreParentEnvs  bool              `json:"ignoreParentEnvs" yaml:"ignoreParentEnvs,omitempty"`
+	InheritEnvs       []string          `json:"inheritEnvs,omitempty" yaml:"inheritEnvs,omitempty"`
+	IgnoreParentEnvs  bool              `json:"ignoreParentEnvs,omitempty" yaml:"ignoreParentEnvs,omitempty"`
 }
 
 type HostCollect struct {

--- a/pkg/collect/host_run.go
+++ b/pkg/collect/host_run.go
@@ -80,7 +80,7 @@ func (c *CollectHostRun) Collect(progressChan chan<- interface{}) (map[string][]
 			return nil, errors.New(fmt.Sprintf("failed to create dir for: %s", runHostCollector.OutputDir))
 		}
 		cmd.Env = append(cmd.Env,
-			fmt.Sprintf("TS_WORKSPACE_DIR=%s", cmdOutputTempDir),
+			fmt.Sprintf("TS_OUTPUT_DIR=%s", cmdOutputTempDir),
 		)
 	}
 

--- a/pkg/collect/host_run_test.go
+++ b/pkg/collect/host_run_test.go
@@ -117,7 +117,7 @@ func TestCollectHostRun_Collect(t *testing.T) {
 						CollectorName: "my-cmd-with-output",
 					},
 					Command: "sh",
-					Args:    []string{"-c", "echo ${TS_INPUT_DIR}/dummy.conf > $TS_WORKSPACE_DIR/input-file.txt"},
+					Args:    []string{"-c", "echo ${TS_INPUT_DIR}/dummy.conf > $TS_OUTPUT_DIR/input-file.txt"},
 					Input: map[string]string{
 						"dummy.conf": "[hello]\nhello = 1",
 					},

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -11472,9 +11472,7 @@
                 "type": "object",
                 "required": [
                   "args",
-                  "command",
-                  "ignoreParentEnvs",
-                  "inheritEnvs"
+                  "command"
                 ],
                 "properties": {
                   "args": {


### PR DESCRIPTION
## Description, Motivation and Context

missing `omitempty` on `ignoreParentEnvs` and `inheritEnvs`. Without this change it's not backward compatible.

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
