### PR TITLE
fix(collector): Let pgx library parse TLS parameters

### DIFF
--- a/pkg/collect/postgres.go
+++ b/pkg/collect/postgres.go
@@ -52,6 +52,8 @@ func (c *CollectPostgres) createConnectConfig() (*pgx.ConnConfig, error) {
 
 		// Drop the TLS params to files and set the paths to their
 		// respective environment variables
+		// The environment variables are unset after the connection config
+		// is created. Their respective files are deleted as well.
 		tmpdir, err := os.MkdirTemp("", "ts-postgres-collector")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create temp dir to store postgres collector TLS files")


### PR DESCRIPTION
## Description, Motivation and Context

This allows the collector to respect the sslmode parameters

**Reviewer notes**
For the postgres collector, we let pgx library parse TLS parameters via its [ParseConfig](https://github.com/jackc/pgx/blob/df5d00eb608ce36f269009dba61607a0507a802e/pgconn/config.go#L166) function instead of the collector's default implementation of construction a [tls.Config instance for secure connections](https://github.com/replicatedhq/troubleshoot/blob/bc4856869e5a1c70b7742c0f06011ac6c1c20dd2/pkg/collect/util.go#L148). `pgx` [respects the sslmode](https://github.com/jackc/pgx/blob/df5d00eb608ce36f269009dba61607a0507a802e/pgconn/config.go#L628) parameters when constructing a tls.Config instance. Troubleshoot does not need to do this.

We drop the TLS param files to a file and pass them to the library as environment variables, then cleanup after ourselves.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fix: #1163

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
