### PR TITLE
fix(support-bundle): add Replicated user-agent header to the correct URLs

### DIFF
--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -170,22 +170,26 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 					return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, fmt.Errorf("%s is not a URL and was not found (err %s)", v, err))
 				}
 
-				// Download preflight specs
-				rawSpec, err := downloadFromHttpURL(ctx, v, map[string]string{"User-Agent": "Replicated_Preflight/v1beta2"})
+				parsedURL, err := url.ParseRequestURI(v)
 				if err != nil {
-					return nil, err
+					return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
 				}
-				rawSpecs = append(rawSpecs, rawSpec)
-
-				// Download support bundle specs
-				rawSpec, err = downloadFromHttpURL(ctx, v, map[string]string{
-					"User-Agent":         "Replicated_Troubleshoot/v1beta1",
-					"Bundle-Upload-Host": fmt.Sprintf("%s://%s", u.Scheme, u.Host),
-				})
-				if err != nil {
-					return nil, err
+				if parsedURL.Host == "kots.io" {
+					// To download specs from kots.io, we need to set the User-Agent header
+					rawSpec, err := downloadFromHttpURL(ctx, v, map[string]string{
+						"User-Agent": "Replicated_Troubleshoot/v1beta1",
+					})
+					if err != nil {
+						return nil, err
+					}
+					rawSpecs = append(rawSpecs, rawSpec)
+				} else {
+					rawSpec, err := downloadFromHttpURL(ctx, v, nil)
+					if err != nil {
+						return nil, err
+					}
+					rawSpecs = append(rawSpecs, rawSpec)
 				}
-				rawSpecs = append(rawSpecs, rawSpec)
 			}
 		}
 	}


### PR DESCRIPTION
## Description, Motivation and Context

When requesting to download troubleshoot specs from Replicated URLs, ensure the ones that expect `Replicated_Troubleshoot/v1beta1` user agent header. So far https://kots.io only expects this header.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1395 

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
