### PR TITLE
bump github actions/download-artifact

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -92,7 +92,7 @@ jobs:
         shell: bash
       - uses: actions/checkout@v4
       - run: make generate preflight
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: preflight
           path: bin/preflight
@@ -106,7 +106,7 @@ jobs:
         with:
           version: v1.23.6-k3s1
       - name: Download preflight binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: preflight
           path: bin/
@@ -155,7 +155,7 @@ jobs:
         with:
           version: v1.23.6-k3s1
       - name: Download preflight binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: preflight
           path: bin/
@@ -181,7 +181,7 @@ jobs:
         shell: bash
       - uses: actions/checkout@v4
       - run: make generate support-bundle
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: support-bundle
           path: bin/support-bundle
@@ -196,7 +196,7 @@ jobs:
         with:
           version: v1.23.6-k3s1
       - name: Download support-bundle binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: support-bundle
           path: bin/
@@ -215,7 +215,7 @@ jobs:
         with:
           version: v1.23.6-k3s1
       - name: Download support bundle binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: support-bundle
           path: bin/
@@ -236,7 +236,7 @@ jobs:
         shell: bash
       - uses: actions/checkout@v4
       - name: Download support bundle binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: support-bundle
           path: bin/
@@ -256,7 +256,7 @@ jobs:
         shell: bash
       - uses: actions/checkout@v4
       - run: make generate collect
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: collect
           path: bin/collect

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -30,7 +30,7 @@ jobs:
         run: trivy fs --scanners license --skip-dirs ".github" . | tee license-report.txt
 
       - name: Upload license report artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: license-report
           path: license-report.txt


### PR DESCRIPTION
## Description, Motivation and Context

Update for Github actions/upload-artifact and actions/download-artifact to v4.

Completed the two together as they are both incompatible with v3 of each other.