### PR TITLE
fix (supportbundle): Add default collectors when expected

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -315,11 +315,12 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 		mainBundle.Spec.HostCollectors = util.Append(mainBundle.Spec.HostCollectors, hc.Spec.Collectors)
 	}
 
-	if mainBundle.Spec.Collectors != nil || mainBundle.Spec.Analyzers != nil {
-		// If we have in-cluster collectors, ensure cluster info and cluster resources
-		// collectors are in the merged spec. We need to add them here so when we --dry-run,
-		// these collectors are included. supportbundle.runCollectors duplicates this bit.
-		// We'll need to refactor it out later when its clearer what other code depends on this logic e.g KOTS
+	if !(len(mainBundle.Spec.HostCollectors) > 0 && len(mainBundle.Spec.Collectors) == 0) {
+		// Always add default collectors unless we only have host collectors
+		// We need to add them here so when we --dry-run, these collectors
+		// are included. supportbundle.runCollectors duplicates this bit.
+		// We'll need to refactor it out later when its clearer what other
+		// code depends on this logic e.g KOTS
 		mainBundle.Spec.Collectors = collect.EnsureCollectorInList(
 			mainBundle.Spec.Collectors,
 			troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}},

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -315,7 +315,7 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 		mainBundle.Spec.HostCollectors = util.Append(mainBundle.Spec.HostCollectors, hc.Spec.Collectors)
 	}
 
-	if mainBundle.Spec.Collectors != nil {
+	if mainBundle.Spec.Collectors != nil || mainBundle.Spec.Analyzers != nil {
 		// If we have in-cluster collectors, ensure cluster info and cluster resources
 		// collectors are in the merged spec. We need to add them here so when we --dry-run,
 		// these collectors are included. supportbundle.runCollectors duplicates this bit.

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -169,9 +169,55 @@ spec:
 			},
 		},
 		{
-			name:     "empty support bundle spec remains empty",
-			args:     []string{testutils.TestFixtureFilePath(t, "supportbundle/empty.yaml")},
-			expected: troubleshootv1beta2.SupportBundleSpec{},
+			name: "empty support bundle spec adds default collectors",
+			args: []string{testutils.ServeFromFilePath(t, `
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+`)},
+			expected: troubleshootv1beta2.SupportBundleSpec{
+				Collectors: []*troubleshootv1beta2.Collect{
+					{
+						ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+					},
+					{
+						ClusterResources: &troubleshootv1beta2.ClusterResources{},
+					},
+				},
+			},
+		},
+		{
+			name: "sb spec with host collectors does not add default collectors",
+			args: []string{testutils.ServeFromFilePath(t, `
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+spec:
+  hostCollectors:
+  - cpu: {}
+`)},
+			expected: troubleshootv1beta2.SupportBundleSpec{
+				HostCollectors: []*troubleshootv1beta2.HostCollect{
+					{
+						CPU: &troubleshootv1beta2.CPU{},
+					},
+				},
+			},
+		},
+		{
+			name: "host collector spec with collectors does not add default collectors",
+			args: []string{testutils.ServeFromFilePath(t, `
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostCollector
+spec:
+  collectors:
+  - cpu: {}
+`)},
+			expected: troubleshootv1beta2.SupportBundleSpec{
+				HostCollectors: []*troubleshootv1beta2.HostCollect{
+					{
+						CPU: &troubleshootv1beta2.CPU{},
+					},
+				},
+			},
 		},
 	}
 

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -105,8 +105,6 @@ func Test_loadSupportBundleSpecs(t *testing.T) {
 			args: []string{testutils.ServeFromFilePath(t, `
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
-metadata:
-  name: spec
 spec:
   collectors: []
 `)},
@@ -126,8 +124,6 @@ spec:
 			args: []string{testutils.ServeFromFilePath(t, `
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
-metadata:
-  name: spec
 spec:
   analyzers: []
 `)},
@@ -148,8 +144,6 @@ spec:
 			args: []string{testutils.ServeFromFilePath(t, `
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
-metadata:
-  name: spec
 spec:
   collectors:
   - logs: {}
@@ -217,6 +211,55 @@ spec:
 						CPU: &troubleshootv1beta2.CPU{},
 					},
 				},
+			},
+		},
+		{
+			name: "sb spec with host and in-cluster collectors adds default collectors",
+			args: []string{testutils.ServeFromFilePath(t, `
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+spec:
+  hostCollectors:
+  - cpu: {}
+  collectors:
+  - logs: {}
+`)},
+			expected: troubleshootv1beta2.SupportBundleSpec{
+				HostCollectors: []*troubleshootv1beta2.HostCollect{
+					{
+						CPU: &troubleshootv1beta2.CPU{},
+					},
+				},
+				Collectors: []*troubleshootv1beta2.Collect{
+					{
+						Logs: &troubleshootv1beta2.Logs{},
+					},
+					{
+						ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+					},
+					{
+						ClusterResources: &troubleshootv1beta2.ClusterResources{},
+					},
+				},
+			},
+		},
+		{
+			name: "sb spec with host collectors and empty in-cluster collectors does not default collectors",
+			args: []string{testutils.ServeFromFilePath(t, `
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+spec:
+  hostCollectors:
+  - cpu: {}
+  collectors: []
+`)},
+			expected: troubleshootv1beta2.SupportBundleSpec{
+				HostCollectors: []*troubleshootv1beta2.HostCollect{
+					{
+						CPU: &troubleshootv1beta2.CPU{},
+					},
+				},
+				Collectors: []*troubleshootv1beta2.Collect{},
 			},
 		},
 	}

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -183,7 +183,6 @@ spec:
 			sb, _, err := loadSpecs(ctx, test.args, client)
 			require.NoError(t, err)
 
-			testutils.LogJSON(t, sb.Spec)
 			assert.Equal(t, test.expected, sb.Spec)
 		})
 	}

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -41,9 +41,13 @@ func FileDir() string {
 
 // Generates a temporary filename
 func TempFilename(prefix string) string {
+	return filepath.Join(os.TempDir(), generateTempName(prefix))
+}
+
+func generateTempName(prefix string) string {
 	randBytes := make([]byte, 16)
 	rand.Read(randBytes)
-	return filepath.Join(os.TempDir(), fmt.Sprintf("%s_%s", prefix, hex.EncodeToString(randBytes)))
+	return fmt.Sprintf("%s_%s", prefix, hex.EncodeToString(randBytes))
 }
 
 func CreateTestFile(t *testing.T, path string) {
@@ -77,4 +81,12 @@ func AsJSON(t *testing.T, v interface{}) string {
 	} else {
 		return string(b)
 	}
+}
+
+func ServeFromFilePath(t *testing.T, data string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), generateTempName("testfile"))
+	CreateTestFileWithData(t, path, data)
+	return path
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -54,13 +54,9 @@ func EstimateNumberOfLines(text string) int {
 }
 
 // Append appends elements in src to target.
-// We have this function because of how append()
-// treats nil slices the same as empty slices.
-// An empty array in YAML like below is not the
-// same as when the array is not specified.
-//
-//	 spec:
-//		  collectors: []
+// We have this function because of how the
+// builtin append() function works. It treats
+// target nil slices the same as empty slices.
 func Append[T any](target []T, src []T) []T {
 	// Do nothing only if src is nil
 	if src == nil {

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/troubleshoot/internal/traces"
+	"github.com/replicatedhq/troubleshoot/internal/util"
 	analyzer "github.com/replicatedhq/troubleshoot/pkg/analyze"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
@@ -276,11 +277,11 @@ func ConcatSpec(target *troubleshootv1beta2.SupportBundle, source *troubleshootv
 		newBundle = source
 	} else {
 		newBundle = target.DeepCopy()
-		newBundle.Spec.Collectors = append(target.Spec.Collectors, source.Spec.Collectors...)
-		newBundle.Spec.AfterCollection = append(target.Spec.AfterCollection, source.Spec.AfterCollection...)
-		newBundle.Spec.HostCollectors = append(target.Spec.HostCollectors, source.Spec.HostCollectors...)
-		newBundle.Spec.HostAnalyzers = append(target.Spec.HostAnalyzers, source.Spec.HostAnalyzers...)
-		newBundle.Spec.Analyzers = append(target.Spec.Analyzers, source.Spec.Analyzers...)
+		newBundle.Spec.Collectors = util.Append(target.Spec.Collectors, source.Spec.Collectors)
+		newBundle.Spec.AfterCollection = util.Append(target.Spec.AfterCollection, source.Spec.AfterCollection)
+		newBundle.Spec.HostCollectors = util.Append(target.Spec.HostCollectors, source.Spec.HostCollectors)
+		newBundle.Spec.HostAnalyzers = util.Append(target.Spec.HostAnalyzers, source.Spec.HostAnalyzers)
+		newBundle.Spec.Analyzers = util.Append(target.Spec.Analyzers, source.Spec.Analyzers)
 		// TODO: What to do with the Uri field?
 	}
 	return newBundle


### PR DESCRIPTION
## Description, Motivation and Context

Ensure default collectors (`clusterInfo` and `clusterResources`) are added by default whenever required when running `support-bundle`. Below are specs representing possible combinations

- Defaults added
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
spec:
  collectors: []
```

- Defaults added
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
spec:
  collectors:
  - logs: {}
```

- Defaults added (similar to when `spec: {}` is present. `spec` is not mandatory. This depicts the minimum spec one can create)
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
```

- Defaults **NOT** added
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
spec:
  hostCollectors:
  - cpu: {}
```

- Defaults **NOT** added in the resulting merged spec
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: HostCollector
spec:
  collectors:
  - cpu: {}
```

- Defaults added
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
spec:
  hostCollectors:
  - cpu: {}
  collectors:
  - logs: {}
```

- Defaults **NOT** added. `collectors: []` is treated as if its absent
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
spec:
  hostCollectors:
  - cpu: {}
  collectors: []
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1417

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
