### PR TITLE
feat: add --add-default-collectors flag to preflight

### DIFF
--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -22,14 +22,15 @@ import (
 )
 
 type CollectOpts struct {
-	Namespace              string
-	IgnorePermissionErrors bool
-	KubernetesRestConfig   *rest.Config
-	Image                  string
-	PullPolicy             string
-	LabelSelector          string
-	Timeout                time.Duration
-	ProgressChan           chan interface{}
+	Namespace                string
+	IgnorePermissionErrors   bool
+	KubernetesRestConfig     *rest.Config
+	Image                    string
+	PullPolicy               string
+	LabelSelector            string
+	Timeout                  time.Duration
+	ProgressChan             chan interface{}
+	IncludeDefaultCollectors bool
 }
 
 type CollectProgress struct {
@@ -158,12 +159,15 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 	if p != nil && p.Spec.Collectors != nil {
 		collectSpecs = append(collectSpecs, p.Spec.Collectors...)
 	}
-	collectSpecs = collect.EnsureCollectorInList(
-		collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}},
-	)
-	collectSpecs = collect.EnsureCollectorInList(
-		collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}},
-	)
+
+	if opts.IncludeDefaultCollectors {
+		collectSpecs = collect.EnsureCollectorInList(
+			collectSpecs, troubleshootv1beta2.Collect{ClusterInfo: &troubleshootv1beta2.ClusterInfo{}},
+		)
+		collectSpecs = collect.EnsureCollectorInList(
+			collectSpecs, troubleshootv1beta2.Collect{ClusterResources: &troubleshootv1beta2.ClusterResources{}},
+		)
+	}
 	collectSpecs = collect.DedupCollectors(collectSpecs)
 	collectSpecs = collect.EnsureClusterResourcesFirst(collectSpecs)
 

--- a/pkg/preflight/flags.go
+++ b/pkg/preflight/flags.go
@@ -16,6 +16,7 @@ const (
 	flagSince                     = "since"
 	flagOutput                    = "output"
 	flagDebug                     = "debug"
+	flagAddDefaultCollectors      = "add-default-collectors"
 )
 
 type PreflightFlags struct {
@@ -29,6 +30,7 @@ type PreflightFlags struct {
 	Since                     *string
 	Output                    *string
 	Debug                     *bool
+	AddDefaultCollectors      *bool
 }
 
 var preflightFlags *PreflightFlags
@@ -45,6 +47,7 @@ func NewPreflightFlags() *PreflightFlags {
 		Since:                     utilpointer.String(""),
 		Output:                    utilpointer.String("o"),
 		Debug:                     utilpointer.Bool(false),
+		AddDefaultCollectors:      utilpointer.Bool(true),
 	}
 }
 
@@ -92,5 +95,8 @@ func (f *PreflightFlags) addFlags(flags *flag.FlagSet) {
 	}
 	if f.Debug != nil {
 		flags.BoolVar(f.Debug, flagDebug, *f.Debug, "enable debug logging")
+	}
+	if f.AddDefaultCollectors != nil {
+		flags.BoolVar(f.AddDefaultCollectors, flagAddDefaultCollectors, *f.AddDefaultCollectors, "add default collectors to the preflight spec")
 	}
 }

--- a/pkg/preflight/flags_test.go
+++ b/pkg/preflight/flags_test.go
@@ -89,7 +89,13 @@ func TestAddFlagsBool(t *testing.T) {
 		flag:    "debug",
 		want:    false,
 		wantErr: false,
-	}}
+	}, {
+		name:    "expect add-default-collectors=true, err=nil when add-default-collectors flag is set",
+		flag:    "add-default-collectors",
+		want:    true,
+		wantErr: false,
+	},
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -247,10 +247,11 @@ func collectInCluster(ctx context.Context, preflightSpec *troubleshootv1beta2.Pr
 	}
 
 	collectOpts := CollectOpts{
-		Namespace:              v.GetString("namespace"),
-		IgnorePermissionErrors: v.GetBool("collect-without-permissions"),
-		ProgressChan:           progressCh,
-		KubernetesRestConfig:   restConfig,
+		Namespace:                v.GetString("namespace"),
+		IgnorePermissionErrors:   v.GetBool("collect-without-permissions"),
+		ProgressChan:             progressCh,
+		KubernetesRestConfig:     restConfig,
+		IncludeDefaultCollectors: v.GetBool("add-default-collectors"),
 	}
 
 	if v.GetString("since") != "" || v.GetString("since-time") != "" {


### PR DESCRIPTION
For the `preflight` binary, add a `--add-default-collectors` flag, default true.

If set to false, do not add cluster-resources and cluster-info to the list of collectors in a preflight.

Fixes: #1447

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
