### PR TITLE
Add workaround for EKS version string

### DIFF
--- a/pkg/analyze/cluster_version.go
+++ b/pkg/analyze/cluster_version.go
@@ -42,13 +42,7 @@ func analyzeClusterVersion(analyzer *troubleshootv1beta2.ClusterVersion, getColl
 		return nil, errors.Wrap(err, "failed to parse cluster_version.json")
 	}
 
-	// Workaround for https://github.com/aws/containers-roadmap/issues/1404
-	// for EKS, replace pre-release gitVersion string with the release version
-	if strings.Contains(collectorClusterVersion.String, "-eks-") {
-		collectorClusterVersion.String = strings.Split(collectorClusterVersion.String, "-")[0]
-	}
-
-	k8sVersion, err := semver.Make(strings.TrimLeft(collectorClusterVersion.String, "v"))
+	k8sVersion, err := parseVersionString(collectorClusterVersion.String)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse semver from cluster_version.json")
 	}
@@ -62,6 +56,16 @@ func title(checkName string) string {
 	}
 
 	return checkName
+}
+
+func parseVersionString(version string) (semver.Version, error) {
+	// Workaround for https://github.com/aws/containers-roadmap/issues/1404
+	// for EKS, replace pre-release gitVersion string with the release version
+	if strings.Contains(version, "-eks-") {
+		version = strings.Split(version, "-")[0]
+	}
+
+	return semver.Make(strings.TrimLeft(version, "v"))
 }
 
 func analyzeClusterVersionResult(k8sVersion semver.Version, outcomes []*troubleshootv1beta2.Outcome, checkName string) (*AnalyzeResult, error) {

--- a/pkg/analyze/cluster_version.go
+++ b/pkg/analyze/cluster_version.go
@@ -42,7 +42,7 @@ func analyzeClusterVersion(analyzer *troubleshootv1beta2.ClusterVersion, getColl
 		return nil, errors.Wrap(err, "failed to parse cluster_version.json")
 	}
 
-	k8sVersion, err := parseVersionString(collectorClusterVersion.String)
+	k8sVersion, err := parseK8sVersionString(collectorClusterVersion.String)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse semver from cluster_version.json")
 	}
@@ -58,7 +58,7 @@ func title(checkName string) string {
 	return checkName
 }
 
-func parseVersionString(version string) (semver.Version, error) {
+func parseK8sVersionString(version string) (semver.Version, error) {
 	// Workaround for https://github.com/aws/containers-roadmap/issues/1404
 	// for EKS, replace pre-release gitVersion string with the release version
 	if strings.Contains(version, "-eks-") {

--- a/pkg/analyze/cluster_version.go
+++ b/pkg/analyze/cluster_version.go
@@ -42,6 +42,12 @@ func analyzeClusterVersion(analyzer *troubleshootv1beta2.ClusterVersion, getColl
 		return nil, errors.Wrap(err, "failed to parse cluster_version.json")
 	}
 
+	// Workaround for https://github.com/aws/containers-roadmap/issues/1404
+	// for EKS, replace pre-release gitVersion string with the release version
+	if strings.Contains(collectorClusterVersion.String, "-eks-") {
+		collectorClusterVersion.String = strings.Split(collectorClusterVersion.String, "-")[0]
+	}
+
 	k8sVersion, err := semver.Make(strings.TrimLeft(collectorClusterVersion.String, "v"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse semver from cluster_version.json")

--- a/pkg/analyze/cluster_version_test.go
+++ b/pkg/analyze/cluster_version_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_analyzeClusterVersionResult(t *testing.T) {
@@ -100,6 +101,44 @@ func Test_analyzeClusterVersionResult(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("analyzeClusterVersionResult() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_parseVersionString(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawVersion string
+		want       semver.Version
+		wantErr    bool
+	}{
+		{
+			name:       "valid version",
+			rawVersion: "1.17.0",
+			want:       semver.MustParse("1.17.0"),
+		},
+		{
+			name:       "valid version with v prefix",
+			rawVersion: "v1.17.0",
+			want:       semver.MustParse("1.17.0"),
+		},
+		{
+			name:       "invalid version",
+			rawVersion: "v1.17",
+			want:       semver.Version{},
+			wantErr:    true,
+		},
+		{
+			name:       "EKS version",
+			rawVersion: "v1.25.16-eks-8cb36c9",
+			want:       semver.MustParse("1.25.16"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVersionString(tt.rawVersion)
+			assert.Equal(t, tt.wantErr, err != nil, "parseVersionString() error = %v, wantErr %v", err, tt.wantErr)
+			assert.Equal(t, tt.want, got, "parseVersionString() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/pkg/analyze/cluster_version_test.go
+++ b/pkg/analyze/cluster_version_test.go
@@ -136,7 +136,7 @@ func Test_parseVersionString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseVersionString(tt.rawVersion)
+			got, err := parseK8sVersionString(tt.rawVersion)
 			assert.Equal(t, tt.wantErr, err != nil, "parseVersionString() error = %v, wantErr %v", err, tt.wantErr)
 			assert.Equal(t, tt.want, got, "parseVersionString() = %v, want %v", got, tt.want)
 		})


### PR DESCRIPTION
## Description, Motivation and Context


The EKS version string returned is not semver compliant.  To work around this, we remove the suffix for version strings that contain -eks-.

Fixes #1441


## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
