### PR TITLE
fix: Correct selector used to find installer specs when redacting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ E2EPATHS = ./test/e2e/...
 TESTFLAGS ?= -v -coverprofile cover.out
 
 .DEFAULT_GOAL := all
-all: build test
+all: clean build test
 
 .PHONY: ffi
 ffi: fmt vet

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -456,7 +456,7 @@ func getRedactors(path string) ([]Redactor, error) {
 
 	uniqueCRs := map[string]bool{}
 	for _, cr := range customResources {
-		fileglob := fmt.Sprintf("%s/%s/%s/*", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, cr.resource)
+		fileglob := fmt.Sprintf("%s/%s/%s/*.yaml", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, cr.resource)
 		redactors = append(redactors, NewYamlRedactor(cr.yamlPath, fileglob, ""))
 
 		// redact kubectl last applied annotation once for each resource since it contains copies of

--- a/pkg/redact/yaml.go
+++ b/pkg/redact/yaml.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -50,7 +49,7 @@ func (r *YamlRedactor) Redact(input io.Reader, path string) io.Reader {
 		reader := bufio.NewReader(input)
 
 		var doc []byte
-		doc, err = ioutil.ReadAll(reader)
+		doc, err = io.ReadAll(reader)
 		var yamlInterface interface{}
 		err = yaml.Unmarshal(doc, &yamlInterface)
 		if err != nil {
@@ -84,8 +83,6 @@ func (r *YamlRedactor) Redact(input io.Reader, path string) io.Reader {
 			File:              path,
 			IsDefaultRedactor: r.isDefault,
 		})
-
-		return
 	}()
 	return reader
 }


### PR DESCRIPTION
## Description, Motivation and Context

Fix the file glob selector used to pick the installer spec to redact.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1455

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
