### PR TITLE
fix: improve flaky goldpinger test

### DIFF
--- a/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
+++ b/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
@@ -81,12 +81,9 @@ func Test_GoldpingerCollector(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check that we analysed collected goldpinger results.
-			// There won't be any ping results because goldpinger would not have run yet.
-			// The test is fine since this checks that we query the goldpinger results correctly
-			// and the analyser is working.
+			// We should expect a single analysis result for goldpinger.
 			require.Equal(t, 1, len(analysisResults))
 			assert.True(t, strings.HasPrefix(analysisResults[0].Name, "missing.ping.results.for.goldpinger."))
-			assert.Equal(t, convert.SeverityWarn, analysisResults[0].Severity)
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {


### PR DESCRIPTION
## Description, Motivation and Context

We do not need to check if goldpinger pinged or not. At times it would have successful pings that lead to test failures. Its enough to just check that we have analysis results

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: [#414](https://github.com/replicatedhq/troubleshoot/issues/1434)
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
