### PR TITLE
Add delay between approving and merging PR in the automated PRs manager

### DIFF
--- a/.github/workflows/automated-prs-manager.yaml
+++ b/.github/workflows/automated-prs-manager.yaml
@@ -74,8 +74,8 @@ jobs:
               echo "All tests passed. Approving and merging."
               echo -e "LGTM :thumbsup: \n\nThis PR was automatically approved and merged by the [automated-prs-manager](https://github.com/replicatedhq/troubleshoot/blob/main/.github/workflows/automated-prs-manager.yaml) GitHub action" > body.txt
               gh pr review --approve "${{ matrix.pr.url }}" --body-file body.txt
-              gh pr merge --auto --squash "${{ matrix.pr.url }}"
               sleep 10
+              gh pr merge --auto --squash "${{ matrix.pr.url }}"
               exit 0
             else
               echo "Some checks did not pass. Skipping."


### PR DESCRIPTION
## Description, Motivation and Context

Merging PRs occasionally fails due to some race condition. I believe this might fix the issue.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
