### PR TITLE
fix panic in Velero analyzer when there's no Velero deployment found

### DIFF
--- a/pkg/analyze/velero.go
+++ b/pkg/analyze/velero.go
@@ -653,7 +653,10 @@ func getVeleroVersion(excludedFiles []string, findFiles getChildCollectedFileCon
 	veleroDeploymentDir := "cluster-resources/deployments"
 	veleroVersion := ""
 	veleroDeploymentGlob := filepath.Join(veleroDeploymentDir, "velero.json")
-	veleroDeploymentJson, _ := findFiles(veleroDeploymentGlob, excludedFiles)
+	veleroDeploymentJson, err := findFiles(veleroDeploymentGlob, excludedFiles)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find Velero deployment")
+	}
 	if len(veleroDeploymentJson) == 0 {
 		return "", errors.Errorf("could not find Velero deployment in %s", veleroDeploymentDir)
 	}


### PR DESCRIPTION
## Description, Motivation and Context

https://github.com/replicatedhq/troubleshoot/pull/1366 introduces a panic when there's no Velero Deployment found.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x2f71931]

goroutine 1 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	/home/runner/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.23.0/trace/span.go:405 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc000ee8480, {0x0, 0x0, 0x106a36b?})
	/home/runner/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.23.0/trace/span.go:443 +0xa3b
panic({0x3301020?, 0x55ce110?})
	/opt/hostedtoolcache/go/1.21.6/x64/src/runtime/panic.go:914 +0x21f
github.com/replicatedhq/troubleshoot/pkg/analyze.getVeleroVersion({0x5660860, 0x0, 0x0}, 0xc000f29b60)
	/home/runner/work/troubleshoot/troubleshoot/pkg/analyze/velero.go:669 +0x1f1
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
