### PR TITLE
fix: flaky goldpinger e2e test

### DIFF
--- a/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
+++ b/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
@@ -45,7 +45,7 @@ func Test_GoldpingerCollector(t *testing.T) {
 				helm.WithNamespace(c.Namespace()),
 				helm.WithChart(testutils.TestFixtureFilePath(t, "charts/goldpinger-6.0.1.tgz")),
 				helm.WithWait(),
-				helm.WithTimeout("1m"),
+				helm.WithTimeout("2m"),
 			)
 			require.NoError(t, err)
 			return ctx
@@ -82,8 +82,15 @@ func Test_GoldpingerCollector(t *testing.T) {
 
 			// Check that we analysed collected goldpinger results.
 			// We should expect a single analysis result for goldpinger.
-			require.Equal(t, 1, len(analysisResults))
+			assert.Equal(t, 1, len(analysisResults))
+			if t.Failed() {
+				t.Logf("Analysis results: %s\n", analysisJSON)
+				t.Logf("Stdout: %s\n", out.String())
+				t.Logf("Stderr: %s\n", stdErr.String())
+				t.FailNow()
+			}
 			assert.True(t, strings.HasPrefix(analysisResults[0].Name, "missing.ping.results.for.goldpinger."))
+
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {

--- a/test/e2e/support-bundle/main_e2e_test.go
+++ b/test/e2e/support-bundle/main_e2e_test.go
@@ -45,13 +45,13 @@ func TestMain(m *testing.M) {
 }
 
 func getClusterFromContext(t *testing.T, ctx context.Context, clusterName string) *kind.Cluster {
-	provider, ok := envfuncs.GetClusterFromContext(ctx, ClusterName)
+	provider, ok := envfuncs.GetClusterFromContext(ctx, clusterName)
 	if !ok {
-		t.Fatalf("Failed to extract kind cluster %s from context", ClusterName)
+		t.Fatalf("Failed to extract kind cluster %s from context", clusterName)
 	}
 	cluster, ok := provider.(*kind.Cluster)
 	if !ok {
-		t.Fatalf("Failed to cast kind cluster %s from provider", ClusterName)
+		t.Fatalf("Failed to cast kind cluster %s from provider", clusterName)
 	}
 
 	return cluster


### PR DESCRIPTION
## Description, Motivation and Context

Installing the chart at times takes too long. We'll increase the wait time to `2m` for the application to be healthy

Here is a failing test result from https://github.com/replicatedhq/troubleshoot/actions/runs/8155128183/job/22290082789 action run

```sh
=== RUN   Test_GoldpingerCollector/Goldpinger_collector_and_analyser/collect_and_analyse_goldpinger_pings
    goldpinger_collector_e2e_test.go:85: 
        	Error Trace:	/home/runner/work/troubleshoot/troubleshoot/test/e2e/support-bundle/goldpinger_collector_e2e_test.go:85
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.3.0/pkg/env/env.go:428
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.3.0/pkg/env/env.go:466
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 0
        	Test:       	Test_GoldpingerCollector/Goldpinger_collector_and_analyser/collect_and_analyse_goldpinger_pings
--- FAIL: Test_GoldpingerCollector (95.87s)
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
