### PR TITLE
fix: Parse v1beta1 troubleshoot specs when using loader API

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -79,6 +79,7 @@ const (
 
 	// Troubleshoot spec constants
 	Troubleshootv1beta2Kind = "troubleshoot.sh/v1beta2"
+	Troubleshootv1beta1Kind = "troubleshoot.replicated.com/v1beta1"
 
 	// TermUI Display Constants
 	MESSAGE_TEXT_PADDING                = 4

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -196,7 +196,7 @@ func (l *specLoader) loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, er
 			default:
 				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, errors.Errorf("%T type is not a Secret or ConfigMap", v))
 			}
-		} else if parsed.APIVersion == constants.Troubleshootv1beta2Kind {
+		} else if parsed.APIVersion == constants.Troubleshootv1beta2Kind || parsed.APIVersion == constants.Troubleshootv1beta1Kind {
 			// If it's not a configmap or secret, just append it to the splitdocs
 			splitdocs = append(splitdocs, rawDoc)
 		} else {

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -371,6 +371,38 @@ func TestLoadingMultidocsWithTroubleshootSpecs(t *testing.T) {
 	}, kinds.SupportBundlesV1Beta2)
 }
 
+func TestLoadingV1Beta1CollectorSpec(t *testing.T) {
+	kinds, err := LoadSpecs(context.Background(), LoadOptions{RawSpec: `kind: Collector
+apiVersion: troubleshoot.replicated.com/v1beta1
+metadata:
+  name: collector-sample
+spec:
+  collectors:
+    - clusterInfo: {}
+`})
+	require.NoError(t, err)
+	require.NotNil(t, kinds)
+
+	assert.Equal(t, []troubleshootv1beta2.Collector{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Collector",
+				APIVersion: "troubleshoot.sh/v1beta2",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "collector-sample",
+			},
+			Spec: troubleshootv1beta2.CollectorSpec{
+				Collectors: []*troubleshootv1beta2.Collect{
+					{
+						ClusterInfo: &troubleshootv1beta2.ClusterInfo{},
+					},
+				},
+			},
+		},
+	}, kinds.CollectorsV1Beta2)
+}
+
 func TestLoadingConfigMapWithMultipleSpecs_PreflightSupportBundleAndRedactorDataKeys(t *testing.T) {
 	s := testutils.GetTestFixture(t, "yamldocs/multidoc-spec-2.yaml")
 	l := specLoader{}


### PR DESCRIPTION
## Description, Motivation and Context

Parsing `troubleshoot.replicated.com/v1beta1` specs in troubleshoot fails when collecting support bundles.

spec.yaml
```
kind: Collector
apiVersion: troubleshoot.replicated.com/v1beta1
spec:
  collectors:
  - clusterInfo: {}
```

run before fix
```sh
[evans] $ support-bundle spec.yaml --v=2
I0311 17:40:41.663099   48425 loader.go:203] Skip loading "Collector" kind
I0311 17:40:41.663120   48425 loader.go:258] No troubleshoot specs were loaded
...
```

run after fix
```sh
[evans] $ support-bundle spec.yaml --v=2
I0311 17:43:08.129636   48866 loader.go:260] Loaded troubleshoot specs successfully

I0311 17:43:08.129903   48866 supportbundle.go:70] Support bundle created in temporary directory: /var/folders/19/bp6c9chj0sgcpcxmxxl69s040000gn/T/supportbundle492182392
....
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1502

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
