### PR TITLE
Quick fix to prevent panic on nil collector result

### DIFF
--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -72,6 +72,9 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (result Collect
 	}
 
 	defer func() {
+		if err != nil {
+			return
+		}
 		result, err = savePodDetails(ctx, client, result, c.BundlePath, c.ClientConfig, pod, c.Collector)
 		if err != nil {
 			klog.Errorf("failed to save pod details: %v", err)
@@ -410,9 +413,6 @@ func RunPodLogs(ctx context.Context, client v1.CoreV1Interface, podSpec *corev1.
 }
 
 func savePodDetails(ctx context.Context, client *kubernetes.Clientset, output CollectorResult, bundlePath string, clientConfig *rest.Config, pod *corev1.Pod, runPodCollector *troubleshootv1beta2.RunPod) (CollectorResult, error) {
-	if output == nil {
-		return nil, errors.New("unable to save pod details")
-	}
 	podStatus, err := client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod")

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -410,6 +410,9 @@ func RunPodLogs(ctx context.Context, client v1.CoreV1Interface, podSpec *corev1.
 }
 
 func savePodDetails(ctx context.Context, client *kubernetes.Clientset, output CollectorResult, bundlePath string, clientConfig *rest.Config, pod *corev1.Pod, runPodCollector *troubleshootv1beta2.RunPod) (CollectorResult, error) {
+	if output == nil {
+		return nil, errors.New("unable to save pod details")
+	}
 	podStatus, err := client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod")


### PR DESCRIPTION
## Description, Motivation and Context

Fixes: https://github.com/replicatedhq/troubleshoot/issues/1442

Quick fix before we can refractor the collector, I think we should not mutate the result in defer block.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
