### PR TITLE
chore: Update CLI prompt to run command as root

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -113,9 +113,8 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 
 	if interactive {
 		if len(mainBundle.Spec.HostCollectors) > 0 && !util.IsRunningAsRoot() {
-			msg := "Some host collectors may require elevated privileges to run.\nDo you want to exit and rerun the command as a privileged user?"
 			fmt.Print(cursor.Show())
-			if util.PromptYesNo(msg) {
+			if util.PromptYesNo(util.HOST_COLLECTORS_RUN_AS_ROOT_PROMPT) {
 				fmt.Println("Exiting...")
 				return nil
 			}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/text/language"
 )
 
+const HOST_COLLECTORS_RUN_AS_ROOT_PROMPT = "Some host collectors need to be run as root.\nDo you want to exit and rerun the command using sudo?"
+
 func HomeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h

--- a/pkg/preflight/run.go
+++ b/pkg/preflight/run.go
@@ -50,7 +50,7 @@ func RunPreflights(interactive bool, output string, format string, args []string
 	if interactive {
 		if len(specs.HostPreflightsV1Beta2) > 0 && !util.IsRunningAsRoot() {
 			fmt.Print(cursor.Show())
-			if util.PromptYesNo("Some host collectors may require elevated privileges to run.\nDo you want to exit and rerun the command as a privileged user?") {
+			if util.PromptYesNo(util.HOST_COLLECTORS_RUN_AS_ROOT_PROMPT) {
 				fmt.Println("Exiting...")
 				return nil
 			}


### PR DESCRIPTION
## Description, Motivation and Context

Minor fix to prompt printed for users to have them run `support-bundle` or `preflight` as root

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
