### PR TITLE
feat: distribution analyzer support for kind

### DIFF
--- a/examples/preflight/sample-preflight.yaml
+++ b/examples/preflight/sample-preflight.yaml
@@ -75,6 +75,9 @@ spec:
           - pass:
               when: "== oke"
               message: OKE is a supported distribution
+          - pass:
+              when: "== kind"
+              message: Kind is a supported distribution
           - warn:
               message: Unable to determine the distribution of Kubernetes
     - nodeResources:

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -27,6 +27,7 @@ type providers struct {
 	rke2          bool
 	k3s           bool
 	oke           bool
+	kind          bool
 }
 
 type Provider int
@@ -47,6 +48,7 @@ const (
 	rke2          Provider = iota
 	k3s           Provider = iota
 	oke           Provider = iota
+	kind          Provider = iota
 )
 
 type AnalyzeDistribution struct {
@@ -161,6 +163,10 @@ func ParseNodesForProviders(nodes []corev1.Node) (providers, string) {
 		if strings.HasPrefix(node.Spec.ProviderID, "ibm:") {
 			foundProviders.ibm = true
 			stringProvider = "ibm"
+		}
+		if strings.HasPrefix(node.Spec.ProviderID, "kind:") {
+			foundProviders.kind = true
+			stringProvider = "kind"
 		}
 	}
 
@@ -335,6 +341,8 @@ func compareDistributionConditionalToActual(conditional string, actual providers
 		isMatch = actual.k3s
 	case oke:
 		isMatch = actual.oke
+	case kind:
+		isMatch = actual.kind
 	}
 
 	switch parts[0] {
@@ -377,6 +385,8 @@ func mustNormalizeDistributionName(raw string) Provider {
 		return k3s
 	case "oke":
 		return oke
+	case "kind":
+		return kind
 	}
 
 	return unknown

--- a/pkg/analyze/distribution_test.go
+++ b/pkg/analyze/distribution_test.go
@@ -39,6 +39,14 @@ func Test_compareDistributionConditionalToActual(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:        "== kind when kind is found",
+			conditional: "== kind",
+			input: providers{
+				kind: true,
+			},
+			expected: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Description, Motivation and Context

Adds support for kind to the distribution analyzer, a CMX supported distro.

<img width="1059" alt="Screenshot 2024-04-05 at 3 08 17 PM" src="https://github.com/replicatedhq/troubleshoot/assets/371319/d7be3135-479f-4401-9cd1-226e7db9c88b">

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

[sc-102282]

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

https://github.com/replicatedhq/troubleshoot.sh/pull/553

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
