### PR TITLE
feat: Detect EC as a distribution

### DIFF
--- a/docs/design/proposal-standard-interface.md
+++ b/docs/design/proposal-standard-interface.md
@@ -42,7 +42,7 @@ An initially unintended benefit of using the Aggregation Layer is that any HostC
 * [microk8s implementation](https://github.com/canonical/microk8s/blob/master/build-scripts/patches/0000-Kubelite-integration.patch) - bundles slightly modified binaries
 * [k0s uses upstream binaries statically compiled](https://docs.k0sproject.io/v1.23.8+k0s.0/architecture/) - bundles statically compiled binaries that self extract and uses a process monitor to run them
 
-2. Can you in fact push metadat like "Status" into an api-server or do we have to write directly to etcd?
+2. Can you in fact push metadata like "Status" into an api-server or do we have to write directly to etcd?
 
 * If we can't push to the api-server is just writing the information directly into etcd something we can do and have a reasonable expectation of compatibility?
 

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -13,44 +13,46 @@ import (
 )
 
 type providers struct {
-	microk8s      bool
-	dockerDesktop bool
-	eks           bool
-	gke           bool
-	digitalOcean  bool
-	openShift     bool
-	tanzu         bool
-	kurl          bool
-	aks           bool
-	ibm           bool
-	minikube      bool
-	rke2          bool
-	k3s           bool
-	oke           bool
-	kind          bool
-	k0s           bool
+	microk8s        bool
+	dockerDesktop   bool
+	eks             bool
+	gke             bool
+	digitalOcean    bool
+	openShift       bool
+	tanzu           bool
+	kurl            bool
+	aks             bool
+	ibm             bool
+	minikube        bool
+	rke2            bool
+	k3s             bool
+	oke             bool
+	kind            bool
+	k0s             bool
+	embeddedCluster bool
 }
 
 type Provider int
 
 const (
-	unknown       Provider = iota
-	microk8s      Provider = iota
-	dockerDesktop Provider = iota
-	eks           Provider = iota
-	gke           Provider = iota
-	digitalOcean  Provider = iota
-	openShift     Provider = iota
-	tanzu         Provider = iota
-	kurl          Provider = iota
-	aks           Provider = iota
-	ibm           Provider = iota
-	minikube      Provider = iota
-	rke2          Provider = iota
-	k3s           Provider = iota
-	oke           Provider = iota
-	kind          Provider = iota
-	k0s           Provider = iota
+	unknown         Provider = iota
+	microk8s        Provider = iota
+	dockerDesktop   Provider = iota
+	eks             Provider = iota
+	gke             Provider = iota
+	digitalOcean    Provider = iota
+	openShift       Provider = iota
+	tanzu           Provider = iota
+	kurl            Provider = iota
+	aks             Provider = iota
+	ibm             Provider = iota
+	minikube        Provider = iota
+	rke2            Provider = iota
+	k3s             Provider = iota
+	oke             Provider = iota
+	kind            Provider = iota
+	k0s             Provider = iota
+	embeddedCluster Provider = iota
 )
 
 type AnalyzeDistribution struct {
@@ -139,6 +141,11 @@ func ParseNodesForProviders(nodes []corev1.Node) (providers, string) {
 			if k == "node.k0sproject.io/role" {
 				foundProviders.k0s = true
 				stringProvider = "k0s"
+			}
+
+			if k == "kots.io/embedded-cluster-role" {
+				foundProviders.embeddedCluster = true
+				stringProvider = "embedded-cluster"
 			}
 		}
 
@@ -351,6 +358,8 @@ func compareDistributionConditionalToActual(conditional string, actual providers
 		isMatch = actual.kind
 	case k0s:
 		isMatch = actual.k0s
+	case embeddedCluster:
+		isMatch = actual.embeddedCluster
 	}
 
 	switch parts[0] {
@@ -397,6 +406,8 @@ func mustNormalizeDistributionName(raw string) Provider {
 		return kind
 	case "k0s":
 		return k0s
+	case "embeddedcluster":
+		return embeddedCluster
 	}
 
 	return unknown

--- a/pkg/analyze/distribution_test.go
+++ b/pkg/analyze/distribution_test.go
@@ -55,6 +55,14 @@ func Test_compareDistributionConditionalToActual(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:        "== embedded-cluster when embedded-cluster is found",
+			conditional: "== embedded-cluster",
+			input: providers{
+				embeddedCluster: true,
+			},
+			expected: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -87,6 +95,66 @@ func Test_mustNormalizeDistributionName(t *testing.T) {
 		},
 		{
 			raw:      "Docker-Desktop",
+			expected: dockerDesktop,
+		},
+		{
+			raw:      "embedded-cluster",
+			expected: embeddedCluster,
+		},
+		{
+			raw:      "k0s",
+			expected: k0s,
+		},
+		{
+			raw:      "kind",
+			expected: kind,
+		},
+		{
+			raw:      "k3s",
+			expected: k3s,
+		},
+		{
+			raw:      "ibm",
+			expected: ibm,
+		},
+		{
+			raw:      "ibmcloud",
+			expected: ibm,
+		},
+		{
+			raw:      "ibm cloud",
+			expected: ibm,
+		},
+		{
+			raw:      "gke",
+			expected: gke,
+		},
+		{
+			raw:      "aks",
+			expected: aks,
+		},
+		{
+			raw:      "eks",
+			expected: eks,
+		},
+		{
+			raw:      "oke",
+			expected: oke,
+		},
+		{
+			raw:      "rke2",
+			expected: rke2,
+		},
+		{
+			raw:      "dockerdesktop",
+			expected: dockerDesktop,
+		},
+		{
+			raw:      "docker desktop",
+			expected: dockerDesktop,
+		},
+		{
+			raw:      "docker-desktop",
 			expected: dockerDesktop,
 		},
 	}


### PR DESCRIPTION
## Description, Motivation and Context

Detect [Replicated's embedded cluster](https://docs.replicated.com/vendor/embedded-overview) as a k8s distribution

Docs PR: https://github.com/replicatedhq/troubleshoot.sh/pull/557

Using this spec
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: Analyzer
spec:
  analyzers:
    - distribution:
        outcomes:
          - pass:
              when: "== embedded-cluster"
              message: embedded-cluster is supported
          - fail:
              message: There is no supported distribution
```

I get these results from a support bundle collected from EC
```sh
analyze --analyzers spec.yaml support-bundle-2024-04-25T14_24_51.tar.gz
Pass: Kubernetes Distribution
 embedded-cluster is supported
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
