### PR TITLE
fix(collector): fix helm collector with a nil error return to error list

### DIFF
--- a/pkg/collect/helm.go
+++ b/pkg/collect/helm.go
@@ -105,6 +105,9 @@ func helmReleaseHistoryCollector(releaseName string, namespace string, collectVa
 			return nil, []error{err}
 		}
 		versionInfo, err := getVersionInfo(actionConfig, r.Name, r.Namespace, collectValues)
+		if err != nil {
+			return nil, []error{err}
+		}
 		results = append(results, ReleaseInfo{
 			ReleaseName:  r.Name,
 			Chart:        r.Chart.Metadata.Name,
@@ -113,7 +116,7 @@ func helmReleaseHistoryCollector(releaseName string, namespace string, collectVa
 			Namespace:    r.Namespace,
 			VersionInfo:  versionInfo,
 		})
-		return results, []error{err}
+		return results, nil
 	}
 
 	// If releaseName is not specified, get the history of all releases


### PR DESCRIPTION
## Description, Motivation and Context
- this is a bug in our current code which cause Helm Collector return nil pointer exception when generating a Support Bundle

In this [code](https://github.com/replicatedhq/troubleshoot/blob/f4384670034c481fe96a07eed08b6ed1d6aeb196/pkg/collect/helm.go#L107) 
```
		versionInfo, err := getVersionInfo(actionConfig, r.Name, r.Namespace, collectValues)
		results = append(results, ReleaseInfo{
			ReleaseName:  r.Name,
			Chart:        r.Chart.Metadata.Name,
			ChartVersion: r.Chart.Metadata.Version,
			AppVersion:   r.Chart.Metadata.AppVersion,
			Namespace:    r.Namespace,
			VersionInfo:  versionInfo,
		})
		return results, []error{err}
```
it is possible that return a nil error in []error{}

which will break the [code](https://github.com/replicatedhq/troubleshoot/blob/f4384670034c481fe96a07eed08b6ed1d6aeb196/pkg/collect/helm.go#L64) 
```
	releaseInfos, err := helmReleaseHistoryCollector(c.Collector.ReleaseName, c.Collector.Namespace, c.Collector.CollectValues)
	if err != nil {
		errsToMarhsal := []string{}
		for _, e := range err {
			errsToMarhsal = append(errsToMarhsal, e.Error())
		}
```
with `nil.Error()`


<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
[sc-103881](https://app.shortcut.com/replicated/story/103881/helm-collector-return-nil-pointer-exception-when-generating-a-support-bundle)

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
