### PR TITLE
feat: [sc-103119] URI is not replacing the spec but merging instead

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -273,7 +273,8 @@ func loadSupportBundleSpecsFromURIs(ctx context.Context, kinds *loader.Troublesh
 		return err
 	}
 
-	kinds.Add(moreKinds)
+	// uri spec replaces the original spec
+	*kinds = *moreKinds
 	return nil
 }
 

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -57,8 +57,9 @@ spec:
 	err = loadSupportBundleSpecsFromURIs(ctx, kinds)
 	require.NoError(t, err)
 
-	require.Len(t, kinds.SupportBundlesV1Beta2, 2)
-	assert.NotNil(t, kinds.SupportBundlesV1Beta2[1].Spec.Collectors[0].ClusterInfo)
+	// valid uri spec will replace the original spec
+	require.Len(t, kinds.SupportBundlesV1Beta2, 1)
+	assert.NotNil(t, kinds.SupportBundlesV1Beta2[0].Spec.Collectors[0].ClusterInfo)
 }
 
 func Test_loadSupportBundleSpecsFromURIs_TimeoutError(t *testing.T) {


### PR DESCRIPTION
## Description, Motivation and Context

Fixes: https://github.com/replicatedhq/troubleshoot/issues/1486
Demo: https://asciinema.org/a/ejHWTp8liwS7p1JOCfzkp917U

## Checklist

- [X] New and existing tests pass locally with introduced changes.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

This will change existing behavior where user is running `support-bundle` binary directly on their spec. Instead of merging uri and original spec, now only `uri` spec will be used. But it is aligning with our [document](https://troubleshoot.sh/docs/support-bundle/supportbundle/#uri)