### PR TITLE
feat(analyzer): make sure ReplicaSetStatus has valid result

### DIFF
--- a/pkg/analyze/replicaset_status.go
+++ b/pkg/analyze/replicaset_status.go
@@ -47,7 +47,9 @@ func (a *AnalyzeReplicaSetStatus) Analyze(getFile getCollectedFileContents, find
 		return nil, err
 	}
 	for i := range results {
-		results[i].Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+		if results[i] != nil {
+			results[i].Strict = a.analyzer.Strict.BoolOrDefaultFalse()
+		}
 	}
 	return results, nil
 }

--- a/pkg/analyze/replicaset_status.go
+++ b/pkg/analyze/replicaset_status.go
@@ -103,6 +103,10 @@ func analyzeOneReplicaSetStatus(analyzer *troubleshootv1beta2.ReplicaSetStatus, 
 		}
 	}
 
+	if result == nil {
+		return nil, nil
+	}
+
 	return []*AnalyzeResult{result}, nil
 }
 

--- a/pkg/analyze/replicaset_status.go
+++ b/pkg/analyze/replicaset_status.go
@@ -47,9 +47,7 @@ func (a *AnalyzeReplicaSetStatus) Analyze(getFile getCollectedFileContents, find
 		return nil, err
 	}
 	for i := range results {
-		if results[i] != nil {
-			results[i].Strict = a.analyzer.Strict.BoolOrDefaultFalse()
-		}
+		results[i].Strict = a.analyzer.Strict.BoolOrDefaultFalse()
 	}
 	return results, nil
 }


### PR DESCRIPTION
## Description, Motivation and Context

- check result of analyzeReplicaSetStatus to be nil or not
- add missing nil result check for `analyzeOneReplicaSetStatus`

According user, we have another issue
```
  • Listing releases
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x3 pc=0x2ca2d13]

goroutine 1484 [running]:
github.com/replicatedhq/troubleshoot/pkg/analyze.(*AnalyzeReplicaSetStatus).Analyze(0xc001454ec0, 0x7323368?, 0xc001a1b2f0?)
	/var/cache/melange/gomodcache/github.com/replicatedhq/troubleshoot@v0.88.0/pkg/analyze/replicaset_status.go:50 +0x53
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
