### PR TITLE
Revert "feat: URI is not replacing the spec but merging instead (#1537)

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -273,8 +273,7 @@ func loadSupportBundleSpecsFromURIs(ctx context.Context, kinds *loader.Troublesh
 		return err
 	}
 
-	// uri spec replaces the original spec
-	*kinds = *moreKinds
+	kinds.Add(moreKinds)
 	return nil
 }
 

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -57,9 +57,8 @@ spec:
 	err = loadSupportBundleSpecsFromURIs(ctx, kinds)
 	require.NoError(t, err)
 
-	// valid uri spec will replace the original spec
-	require.Len(t, kinds.SupportBundlesV1Beta2, 1)
-	assert.NotNil(t, kinds.SupportBundlesV1Beta2[0].Spec.Collectors[0].ClusterInfo)
+	require.Len(t, kinds.SupportBundlesV1Beta2, 2)
+	assert.NotNil(t, kinds.SupportBundlesV1Beta2[1].Spec.Collectors[0].ClusterInfo)
 }
 
 func Test_loadSupportBundleSpecsFromURIs_TimeoutError(t *testing.T) {


### PR DESCRIPTION
## Description, Motivation and Context

Revert cause of https://github.com/replicatedhq/troubleshoot/issues/1540 regression which has been released in https://github.com/replicatedhq/troubleshoot/releases/tag/v0.91.0

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
