### PR TITLE
feat: Prefer embedded-cluster over k0s when detecting distro

### DIFF
--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -191,6 +191,11 @@ func ParseNodesForProviders(nodes []corev1.Node) (providers, string) {
 		}
 	}
 
+	// If k0s and embedded-cluster are both found, prefer embedded-cluster
+	if foundProviders.k0s && foundProviders.embeddedCluster {
+		stringProvider = "embedded-cluster"
+	}
+
 	return foundProviders, stringProvider
 }
 

--- a/pkg/analyze/distribution_test.go
+++ b/pkg/analyze/distribution_test.go
@@ -172,10 +172,10 @@ func Test_mustNormalizeDistributionName(t *testing.T) {
 
 func TestParseNodesForProviders(t *testing.T) {
 	tests := []struct {
-		name  string
-		nodes []corev1.Node
-		want  providers
-		want1 string
+		name               string
+		nodes              []corev1.Node
+		wantProviders      providers
+		wantProviderString string
 	}{
 		{
 			name: "embedded-cluster",
@@ -198,15 +198,19 @@ func TestParseNodesForProviders(t *testing.T) {
 					},
 				},
 			},
-			want:  providers{embeddedCluster: true},
-			want1: "embedded-cluster",
+			wantProviders:      providers{embeddedCluster: true, k0s: true},
+			wantProviderString: "embedded-cluster",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider, stringProvider := ParseNodesForProviders(tt.nodes)
-			assert.Equalf(t, tt.want, provider, "ParseNodesForProviders() got = %v, provider %v", provider, tt.want)
-			assert.Equalf(t, tt.want1, stringProvider, "ParseNodesForProviders() got1 = %v, stringProvider %v", stringProvider, tt.want1)
+			providers, stringProvider := ParseNodesForProviders(tt.nodes)
+			assert.Equalf(t, tt.wantProviders, providers,
+				"ParseNodesForProviders() gotProviders = %v, providers %v", providers, tt.wantProviders,
+			)
+			assert.Equalf(t, tt.wantProviderString, stringProvider,
+				"ParseNodesForProviders() gotStringProvider = %v, stringProvider %v", stringProvider, tt.wantProviderString,
+			)
 		})
 	}
 }


### PR DESCRIPTION
## Description, Motivation and Context

Prefer `embedded-cluster` over `k0s` when detecting distribution whenever running analysis against an EC node using the distribution analyser

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
