### PR TITLE
feat(analyzer): let cluster resource case insensitive to fix name inconsistent

### DIFF
--- a/pkg/analyze/files/support-bundle/cluster-resources/configmaps/kube-public.json
+++ b/pkg/analyze/files/support-bundle/cluster-resources/configmaps/kube-public.json
@@ -1,0 +1,47 @@
+{
+  "kind": "ConfigMapList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "4825753"
+  },
+  "items": [
+    {
+      "kind": "ConfigMap",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "kube-root-ca.crt",
+        "namespace": "kube-public",
+        "uid": "37a912b2-a666-480f-a1a8-05ab012432e4",
+        "resourceVersion": "332",
+        "creationTimestamp": "2023-05-29T23:33:07Z",
+        "annotations": {
+          "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
+        },
+        "managedFields": [
+          {
+            "manager": "kube-controller-manager",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2023-05-29T23:33:07Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:data": {
+                ".": {},
+                "f:ca.crt": {}
+              },
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubernetes.io/description": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "data": {
+        "ca.crt": "-----BEGIN CERTIFICATE-----\nMIIDBjCCAe6gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p\na3ViZUNBMB4XDTIzMDUyODIzMzIzOVoXDTMzMDUyNjIzMzIzOVowFTETMBEGA1UE\nAxMKbWluaWt1YmVDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOpU\nswd15tD+QCelgYlu5MRB260+Ke63gEDTkXIyAr+mR+TjW/v9TPPIP9iidvTUg+jq\nryrf1PwURVx3EUSZWtd9NpAEDT1ov/ggx16xxj2El7KLen0SXQutSF28zjCFXxYG\nMkPxXu+qYsn2mLJX5i1kaCZNffyToCJ0n2bxxx83rOS+fgz11JntAwcgC8V3Mtq6\nIv+2Xb9PSxPs38ef7r15j5KSTOrmWCR5texPFz/WU/YbZ3W42pj9T/EiuGwamfmI\ngevuwv7AxlfjKutp5UQEth5GhY6V4kJyVIUExN3ddEsTPLQD9zvdsP4DlkGpZmiR\n/Ip3rXY/ldxeeGZ0HUUCAwEAAaNhMF8wDgYDVR0PAQH/BAQDAgKkMB0GA1UdJQQW\nMBQGCCsGAQUFBwMCBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW\nBBS0XUXhCu/DOH8/0W5L0n4BOw9b6zANBgkqhkiG9w0BAQsFAAOCAQEAHrXOxKdy\n+DvPtvgfzzV3qqmIvTuuFyW0BdZdXV8yo1tZajkEO0B0HvLUyn8ljKgoK5YtCQcr\nzSj6QEewgP+JCBTsWCKzbOhMcDKw1pa6bSeLcQWwMxox+1Zcj7edMPlPcQ3SVLxZ\n6y7fD7BArTKRBKCr8Uwudwox5Vm0URWLRAvb+8jPv9BDuC/uMPJ4UrexL/Q2QQs8\nQkyWYeSk4mBCM3qAahQhYc0WSHbk+a/5iua/y+VUaa208CUbm5glBoAroHDk5eTN\nYstOSLUQAlzTdr4kCEVi+a3+NgmuvzYXWubAdy/PT860aFBJlmVNuDhy8V/bGpnS\nKxmG7B3yJmbmzg==\n-----END CERTIFICATE-----\n"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/kube_resource.go
+++ b/pkg/analyze/kube_resource.go
@@ -28,6 +28,7 @@ var Filemap = map[string]string{
 	"persistentvolumeclaim": constants.CLUSTER_RESOURCES_PVCS,
 	"pvc":                   constants.CLUSTER_RESOURCES_PVCS,
 	"replicaset":            constants.CLUSTER_RESOURCES_REPLICASETS,
+	"configmap":             constants.CLUSTER_RESOURCES_CONFIGMAPS,
 	"namespace":             fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NAMESPACES),
 	"persistentvolume":      fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_PVS),
 	"pv":                    fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_PVS),

--- a/pkg/analyze/kube_resource.go
+++ b/pkg/analyze/kube_resource.go
@@ -17,22 +17,22 @@ import (
 )
 
 var Filemap = map[string]string{
-	"Deployment":            constants.CLUSTER_RESOURCES_DEPLOYMENTS,
-	"StatefulSet":           constants.CLUSTER_RESOURCES_STATEFULSETS,
-	"NetworkPolicy":         constants.CLUSTER_RESOURCES_NETWORK_POLICY,
-	"Pod":                   constants.CLUSTER_RESOURCES_PODS,
-	"Ingress":               constants.CLUSTER_RESOURCES_INGRESS,
-	"Service":               constants.CLUSTER_RESOURCES_SERVICES,
-	"ResourceQuota":         constants.CLUSTER_RESOURCES_RESOURCE_QUOTA,
-	"Job":                   constants.CLUSTER_RESOURCES_JOBS,
-	"PersistentVolumeClaim": constants.CLUSTER_RESOURCES_PVCS,
+	"deployment":            constants.CLUSTER_RESOURCES_DEPLOYMENTS,
+	"statefulset":           constants.CLUSTER_RESOURCES_STATEFULSETS,
+	"networkpolicy":         constants.CLUSTER_RESOURCES_NETWORK_POLICY,
+	"pod":                   constants.CLUSTER_RESOURCES_PODS,
+	"ingress":               constants.CLUSTER_RESOURCES_INGRESS,
+	"service":               constants.CLUSTER_RESOURCES_SERVICES,
+	"resourcequota":         constants.CLUSTER_RESOURCES_RESOURCE_QUOTA,
+	"job":                   constants.CLUSTER_RESOURCES_JOBS,
+	"persistentvolumeclaim": constants.CLUSTER_RESOURCES_PVCS,
 	"pvc":                   constants.CLUSTER_RESOURCES_PVCS,
-	"ReplicaSet":            constants.CLUSTER_RESOURCES_REPLICASETS,
-	"Namespace":             fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NAMESPACES),
-	"PersistentVolume":      fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_PVS),
+	"replicaset":            constants.CLUSTER_RESOURCES_REPLICASETS,
+	"namespace":             fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NAMESPACES),
+	"persistentvolume":      fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_PVS),
 	"pv":                    fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_PVS),
-	"Node":                  fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NODES),
-	"StorageClass":          fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_STORAGE_CLASS),
+	"node":                  fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_NODES),
+	"storageclass":          fmt.Sprintf("%s.json", constants.CLUSTER_RESOURCES_STORAGE_CLASS),
 }
 
 type AnalyzeClusterResource struct {
@@ -65,6 +65,9 @@ func (a *AnalyzeClusterResource) Analyze(getFile getCollectedFileContents, findF
 func FindResource(kind string, clusterScoped bool, namespace string, name string, getFileContents getCollectedFileContents) (interface{}, error) {
 
 	var datapath string
+
+	// lowercase the kind to avoid case sensitivity
+	kind = strings.ToLower(kind)
 
 	resourceLocation, ok := Filemap[kind]
 

--- a/pkg/analyze/kube_resource_test.go
+++ b/pkg/analyze/kube_resource_test.go
@@ -21,13 +21,13 @@ func Test_findResource(t *testing.T) {
 			resourceExists: true,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
-				Kind:          "Deployment",
+				Kind:          "deployment",
 				Namespace:     "kube-system",
 				Name:          "coredns",
 			},
 		},
 		{
-			name:           "check default fallthrough",
+			name:           "check default fallthrough with case insensitivity",
 			resourceExists: true,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
@@ -40,7 +40,7 @@ func Test_findResource(t *testing.T) {
 			resourceExists: true,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
-				Kind:          "Node",
+				Kind:          "node",
 				ClusterScoped: true,
 				Name:          "repldev-marc",
 			},
@@ -50,7 +50,7 @@ func Test_findResource(t *testing.T) {
 			resourceExists: false,
 			analyzer: troubleshootv1beta2.ClusterResource{
 				CollectorName: "Check namespaced resource",
-				Kind:          "Node",
+				Kind:          "node",
 				ClusterScoped: true,
 				Name:          "resource-does-not-exist",
 			},

--- a/pkg/analyze/kube_resource_test.go
+++ b/pkg/analyze/kube_resource_test.go
@@ -55,6 +55,16 @@ func Test_findResource(t *testing.T) {
 				Name:          "resource-does-not-exist",
 			},
 		},
+		{
+			name:           "configmap does exist",
+			resourceExists: true,
+			analyzer: troubleshootv1beta2.ClusterResource{
+				CollectorName: "Check namespaced resource",
+				Kind:          "configmap",
+				Namespace:     "kube-public",
+				Name:          "kube-root-ca.crt",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description, Motivation and Context
- align all the names of kind to lower case 
- avoiding name inconsistent
- add support for configmap

Demo:
```
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: default
spec:
  collectors:
    - cluster-resources: {}
  analyzers:
    - clusterResource:
        checkName: check-access-mode
        kind: deployment
        namespace: default
        name: strapi-db
        yamlPath: "spec.replicas"
        regex: "1"
        outcomes:
          - fail:
              when: "false"
              message: is not ReadWriteOnce
          - pass:
              when: "true"
              message: is ReadWriteOnce
    - clusterResource:
        checkName: check-cm-confg
        kind: configmap
        namespace: kube-public
        name: kube-root-ca.crt
        yamlPath: "metadata.name"
        regex: "kube-root-ca.crt"
        outcomes:
          - fail:
              when: "false"
              message: is not kube-root-ca
          - pass:
              when: "true"
              message: is kube-root-ca

```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes : #1523 

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
