### PR TITLE
fix: Use correct cron job kind when discovering API versions

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -801,7 +801,7 @@ func jobs(ctx context.Context, client *kubernetes.Clientset, namespaces []string
 }
 
 func cronJobs(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
-	ok, err := discovery.HasResource(client, "batch/v1", "CronJobs")
+	ok, err := discovery.HasResource(client, "batch/v1", "CronJob")
 	if err != nil {
 		return nil, map[string]string{"": err.Error()}
 	}

--- a/test/e2e/support-bundle/cluster_resources_e2e_test.go
+++ b/test/e2e/support-bundle/cluster_resources_e2e_test.go
@@ -26,7 +26,6 @@ func TestClusterResources(t *testing.T) {
 				"pvs.json",
 				"pod-disruption-budgets-errors.json",
 				"resources.json",
-				"cronjobs-errors.json",
 				"custom-resource-definitions.json",
 				"groups.json",
 				"priorityclasses.json",
@@ -38,6 +37,7 @@ func TestClusterResources(t *testing.T) {
 		},
 		{
 			paths: []string{
+				"cronjobs",
 				"limitranges",
 				"daemonsets",
 				"deployments",


### PR DESCRIPTION
## Description, Motivation and Context

Use correct cron job kind when discovering API versions

Fixes: https://github.com/replicatedhq/troubleshoot/issues/1553

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
