### PR TITLE
feat: [sc-106927] Allow kernelConfig analyser to check kernel capability is either built in or loaded for EC host preflights

### DIFF
--- a/pkg/analyze/host_kernel_configs.go
+++ b/pkg/analyze/host_kernel_configs.go
@@ -40,7 +40,7 @@ func (a *AnalyzeHostKernelConfigs) Analyze(
 	}
 
 	var configsNotFound []string
-	kConfigRegex := regexp.MustCompile("^(CONFIG_[A-Z0-9_]+)=([ymn])$")
+	kConfigRegex := regexp.MustCompile("^(CONFIG_[A-Z0-9_]+)=([ymn]+)$")
 	for _, config := range hostAnalyzer.SelectedConfigs {
 		matches := kConfigRegex.FindStringSubmatch(config)
 		// zero tolerance for invalid kernel config
@@ -49,7 +49,7 @@ func (a *AnalyzeHostKernelConfigs) Analyze(
 		}
 
 		key := matches[1]
-		value := matches[2]
+		values := matches[2] // values can contain multiple values in any order y, m, n
 
 		// check if the kernel config exists
 		if _, ok := kConfigs[key]; !ok {
@@ -57,8 +57,8 @@ func (a *AnalyzeHostKernelConfigs) Analyze(
 			continue
 		}
 		// check if the kernel config value matches
-		if kConfigs[key] != value {
-			klog.V(2).Infof("collected kernel config %s=%s does not match expected value %s", key, kConfigs[key], value)
+		if !strings.Contains(values, kConfigs[key]) {
+			klog.V(2).Infof("collected kernel config %s=%s does not in expected values %s", key, kConfigs[key], values)
 			configsNotFound = append(configsNotFound, config)
 		}
 	}

--- a/pkg/analyze/host_kernel_configs_test.go
+++ b/pkg/analyze/host_kernel_configs_test.go
@@ -12,6 +12,7 @@ func TestAnalyzeKernelConfigs(t *testing.T) {
 	kConfigs := collect.KConfigs{
 		"CONFIG_CGROUP_FREEZER":    "y",
 		"CONFIG_NETFILTER_XTABLES": "m",
+		"CONFIG_BRIDGE":            "y",
 	}
 
 	tests := []struct {
@@ -88,13 +89,33 @@ func TestAnalyzeKernelConfigs(t *testing.T) {
 			selectedConfigs: []string{"foobar=n"},
 			expectErr:       true,
 		},
+		{
+			name:            "select multiple kernel config values",
+			kConfigs:        kConfigs,
+			selectedConfigs: []string{"CONFIG_BRIDGE=my"},
+			outcomes: []*troubleshootv1beta2.Outcome{
+				{
+					Pass: &troubleshootv1beta2.SingleOutcome{
+						Message: "required kernel configs are available",
+					},
+				},
+			},
+			results: []*AnalyzeResult{
+				{
+					Title:   "Kernel Configs",
+					IsPass:  true,
+					Message: "required kernel configs are available",
+				},
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			fn := func(_ string) ([]byte, error) {
-				return []byte(`{"CONFIG_CGROUP_FREEZER": "y", "CONFIG_NETFILTER_XTABLES": "m"}`), nil
+				return []byte(`{"CONFIG_CGROUP_FREEZER": "y", "CONFIG_NETFILTER_XTABLES": "m", "CONFIG_BRIDGE": "y"}`), nil
 			}
 
 			analyzer := AnalyzeHostKernelConfigs{


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/106927
Fixes: https://github.com/replicatedhq/troubleshoot/issues/1563