### PR TITLE
feat: Allow checking kernel versions only in host os analyzer

### DIFF
--- a/pkg/analyze/host_os_info.go
+++ b/pkg/analyze/host_os_info.go
@@ -111,7 +111,6 @@ func analyzeOSVersionResult(osInfo collect.HostOSInfo, outcomes []*troubleshootv
 			if whenRange(toleratedKernelVer) {
 				return []*AnalyzeResult{&result}, nil
 			}
-			return []*AnalyzeResult{}, nil
 		}
 
 		// Match the platform version and and kernel version passed in as

--- a/pkg/analyze/host_os_info.go
+++ b/pkg/analyze/host_os_info.go
@@ -128,8 +128,8 @@ func analyzeOSVersionResult(osInfo collect.HostOSInfo, outcomes []*troubleshootv
 					return []*AnalyzeResult{&result}, nil
 				}
 			}
-		// Match the platform version
-		// e.g "centos == 8.2"
+			// Match the platform version
+			// e.g "centos == 8.2"
 		} else if platform == osInfo.Platform {
 			fixedDistVer := fixVersion(osInfo.PlatformVersion)
 			toleratedDistVer, err := semver.ParseTolerant(fixedDistVer)

--- a/pkg/analyze/host_os_info_test.go
+++ b/pkg/analyze/host_os_info_test.go
@@ -319,6 +319,34 @@ func TestAnalyzeHostOS(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "test kernelVersion >= 6.4.9-abc",
+			hostInfo: collect.HostOSInfo{
+				Name:            "my-host",
+				KernelVersion:   "6.5.0-1024-gcp",
+				PlatformVersion: "22.04",
+				Platform:        "ubuntu",
+			},
+			hostAnalyzer: &troubleshootv1beta2.HostOSAnalyze{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "kernelVersion >= 6.4.9-abc",
+							Message: "supported kernel version >= 6.4.9-abc",
+						},
+					},
+				},
+			},
+
+			result: []*AnalyzeResult{
+				{
+					Title:   "Host OS Info",
+					IsPass:  true,
+					Message: "supported kernel version >= 6.4.9-abc",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Description, Motivation and Context

Add the ability to assert `kernelVersion` values only without needing to provide the OS distribution. This is will support cases where users want to have a preflight check that checks linux kernel versions regardless of the operating system.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
