### PR TITLE
Log non-existentent analyzers instead of adding to analyzer results

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -119,11 +119,8 @@ func Analyze(
 
 	analyzerInst := getAnalyzer(analyzer)
 	if analyzerInst == nil {
-		return []*AnalyzeResult{{
-			IsFail:  true,
-			Title:   "nonexistent analyzer",
-			Message: "Analyzer not found",
-		}}, nil
+		klog.Info("Non-existent analyzer found in the spec. Please double-check the spelling and indentation of the analyzers in the spec.")
+		return nil, nil
 	}
 
 	_, span := otel.Tracer(constants.LIB_TRACER_NAME).Start(ctx, analyzerInst.Title())

--- a/sample-troubleshoot.yaml
+++ b/sample-troubleshoot.yaml
@@ -1,5 +1,5 @@
 apiVersion: troubleshoot.sh/v1beta2
-kind: Collector
+kind: SupportBundle
 metadata:
   name: my-application-name
 spec:


### PR DESCRIPTION
## Description, Motivation and Context

To reduce the amount of noise in the analyzer results where there is an invalid analyzers inside of the spec, we should instead simply log these occurrences behind the debug flag.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
