### PR TITLE
feat(support-bundle): add text that explains where support bundle to share

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -200,7 +200,7 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 
 	if len(response.AnalyzerResults) > 0 {
 		if interactive {
-			if err := showInteractiveResults(mainBundle.Name, response.AnalyzerResults); err != nil {
+			if err := showInteractiveResults(mainBundle.Name, response.AnalyzerResults, response.ArchivePath); err != nil {
 				interactive = false
 			}
 		} else {
@@ -227,7 +227,7 @@ the %s Admin Console to begin analysis.`
 			return nil
 		}
 
-		fmt.Printf("\n%s\n", response.ArchivePath)
+		fmt.Printf("\nA support bundle was generated and saved at %s. Please send this file to your software vendor for support.\n", response.ArchivePath)
 		return nil
 	}
 


### PR DESCRIPTION
## Description, Motivation and Context

- after saved support bundle, it will show extra text to explain the exact support bundle to share.

Demo:

1. saved message box
<img width="960" alt="Screenshot 2024-08-15 at 5 41 50 PM" src="https://github.com/user-attachments/assets/9a14847e-7bb7-4bed-9399-0329dfc57a66">

2. After quit the command
<img width="1248" alt="Screenshot 2024-08-15 at 5 42 02 PM" src="https://github.com/user-attachments/assets/88a9188c-b44a-47e8-8dd9-2028291044f2">

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
[sc-109743](https://app.shortcut.com/replicated/story/109743/log-location-of-created-support-bundle-in-support-bundle-command#activity-110609)

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
