### PR TITLE
fix(e2e): race condition causes tests to fail

### DIFF
--- a/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
+++ b/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/convert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -48,6 +48,7 @@ func Test_GoldpingerCollector(t *testing.T) {
 	feature := features.New("Goldpinger collector and analyser").
 		Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			cluster := getClusterFromContext(t, ctx, ClusterName)
+
 			manager := helm.New(cluster.GetKubeconfig())
 			err := manager.RunInstall(
 				helm.WithName(releaseName),
@@ -57,19 +58,14 @@ func Test_GoldpingerCollector(t *testing.T) {
 				helm.WithTimeout("2m"),
 			)
 			require.NoError(t, err)
+
 			client, err := c.NewClient()
 			require.NoError(t, err)
-			pods := &v1.PodList{}
 
 			// Lets wait for the goldpinger pods to be running
-			err = client.Resources().WithNamespace(c.Namespace()).List(ctx, pods,
-				resources.WithLabelSelector("app.kubernetes.io/name=goldpinger"),
-			)
-			require.NoError(t, err)
-			require.Len(t, pods.Items, 1)
-
+			ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "goldpinger", Namespace: c.Namespace()}}
 			err = wait.For(
-				conditions.New(client.Resources()).PodRunning(&pods.Items[0]),
+				conditions.New(client.Resources()).DaemonSetReady(ds),
 				wait.WithTimeout(time.Second*30),
 			)
 			require.NoError(t, err)
@@ -121,7 +117,8 @@ func Test_GoldpingerCollector(t *testing.T) {
 		Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			cluster := getClusterFromContext(t, ctx, ClusterName)
 			manager := helm.New(cluster.GetKubeconfig())
-			manager.RunUninstall(helm.WithName(releaseName), helm.WithNamespace(c.Namespace()))
+			err := manager.RunUninstall(helm.WithName(releaseName), helm.WithNamespace(c.Namespace()))
+			require.NoError(t, err)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
+++ b/test/e2e/support-bundle/goldpinger_collector_e2e_test.go
@@ -69,6 +69,10 @@ func Test_GoldpingerCollector(t *testing.T) {
 				wait.WithTimeout(time.Second*30),
 			)
 			require.NoError(t, err)
+
+			// HACK: wait for goldpinger to do its thing
+			time.Sleep(time.Second * 30)
+
 			return ctx
 		}).
 		Assess("collect and analyse goldpinger pings", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
@@ -104,7 +108,7 @@ func Test_GoldpingerCollector(t *testing.T) {
 			// Check that we analysed collected goldpinger results.
 			// We should expect a single analysis result for goldpinger.
 			assert.Equal(t, 1, len(analysisResults))
-			assert.True(t, strings.HasPrefix(analysisResults[0].Name, "missing.ping.results.for.goldpinger."))
+			assert.True(t, strings.HasPrefix(analysisResults[0].Name, "pings.to.goldpinger."))
 			if t.Failed() {
 				t.Logf("Analysis results: %s\n", analysisJSON)
 				t.Logf("Stdout: %s\n", out.String())


### PR DESCRIPTION
## Description, Motivation and Context

E2e tests are failing because podlist returns 0 pods as daemonset is not available. Causes cascading failures in tests.

https://github.com/replicatedhq/troubleshoot/actions/runs/10517322980/job/29142176121

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
