### PR TITLE
feat(analyzer): allow templating for Node Resources Analyzer

### DIFF
--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -1166,9 +1166,9 @@ spec:
                           type: BoolString
                         filters:
                           properties:
-                            architecture:
-                              type: string
                             cpuAllocatable:
+                              type: string
+                            cpuArchitecture:
                               type: string
                             cpuCapacity:
                               type: string

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -1166,9 +1166,9 @@ spec:
                           type: BoolString
                         filters:
                           properties:
-                            architecture:
-                              type: string
                             cpuAllocatable:
+                              type: string
+                            cpuArchitecture:
                               type: string
                             cpuCapacity:
                               type: string

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -1197,9 +1197,9 @@ spec:
                           type: BoolString
                         filters:
                           properties:
-                            architecture:
-                              type: string
                             cpuAllocatable:
+                              type: string
+                            cpuArchitecture:
                               type: string
                             cpuCapacity:
                               type: string

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -120,7 +120,7 @@ type NodeResources struct {
 }
 
 type NodeResourceFilters struct {
-	Architecture                string                 `json:"cpuArchitecture,omitempty" yaml:"cpuArchitecture,omitempty"`
+	CPUArchitecture             string                 `json:"cpuArchitecture,omitempty" yaml:"cpuArchitecture,omitempty"`
 	CPUCapacity                 string                 `json:"cpuCapacity,omitempty" yaml:"cpuCapacity,omitempty"`
 	CPUAllocatable              string                 `json:"cpuAllocatable,omitempty" yaml:"cpuAllocatable,omitempty"`
 	MemoryCapacity              string                 `json:"memoryCapacity,omitempty" yaml:"memoryCapacity,omitempty"`

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -120,7 +120,7 @@ type NodeResources struct {
 }
 
 type NodeResourceFilters struct {
-	Architecture                string                 `json:"architecture,omitempty" yaml:"cpuArchitecture,omitempty"`
+	Architecture                string                 `json:"cpuArchitecture,omitempty" yaml:"cpuArchitecture,omitempty"`
 	CPUCapacity                 string                 `json:"cpuCapacity,omitempty" yaml:"cpuCapacity,omitempty"`
 	CPUAllocatable              string                 `json:"cpuAllocatable,omitempty" yaml:"cpuAllocatable,omitempty"`
 	MemoryCapacity              string                 `json:"memoryCapacity,omitempty" yaml:"memoryCapacity,omitempty"`

--- a/schemas/analyzer-troubleshoot-v1beta2.json
+++ b/schemas/analyzer-troubleshoot-v1beta2.json
@@ -1755,10 +1755,10 @@
                   "filters": {
                     "type": "object",
                     "properties": {
-                      "architecture": {
+                      "cpuAllocatable": {
                         "type": "string"
                       },
-                      "cpuAllocatable": {
+                      "cpuArchitecture": {
                         "type": "string"
                       },
                       "cpuCapacity": {

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -1755,10 +1755,10 @@
                   "filters": {
                     "type": "object",
                     "properties": {
-                      "architecture": {
+                      "cpuAllocatable": {
                         "type": "string"
                       },
-                      "cpuAllocatable": {
+                      "cpuArchitecture": {
                         "type": "string"
                       },
                       "cpuCapacity": {

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -1801,10 +1801,10 @@
                   "filters": {
                     "type": "object",
                     "properties": {
-                      "architecture": {
+                      "cpuAllocatable": {
                         "type": "string"
                       },
-                      "cpuAllocatable": {
+                      "cpuArchitecture": {
                         "type": "string"
                       },
                       "cpuCapacity": {


### PR DESCRIPTION
## Description, Motivation and Context
- align Architecture to CPUArchitecture
- allow message templating with troubleshootv1beta2.NodeResourceFilters and NodeCount
- add test

test support bundle yaml
- multiple filter
```
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: sample
spec:
  collectors:
    - clusterInfo: {}
  analyzers:
    - nodeResources:
        filters:
          cpuArchitecture: arm64
          cpuCapacity: "2"        
        checkName: Must have at least 3 nodes in the cluster
        outcomes:
          - fail:
              when: "count() < 3"
              message: "This application requires at least 3 nodes. {{ .CPUArchitecture }}-{{ .CPUCapacity }}, it should only return the {{ .NodeCount }} nodes that match that filter"
          - warn:
              when: "count() < 5"
              message: This application recommends at last 5 nodes.
          - pass:
              message: This cluster has enough nodes.

```
<img width="1815" alt="Screenshot 2024-08-30 at 3 07 29 PM" src="https://github.com/user-attachments/assets/41fb1788-bf5d-459e-8967-2e762b1b5b15">

- simple filter
```
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: sample
spec:
  collectors:
    - clusterInfo: {}
  analyzers:
    - nodeResources:
        filters:
          cpuArchitecture: arm64 
        checkName: Must have at least 3 nodes in the cluster
        outcomes:
          - fail:
              when: "count() < 3"
              message: "This application requires at least 3 nodes. {{ .CPUArchitecture }}, it should only return the {{ .NodeCount }} nodes that match that filter"
          - warn:
              when: "count() < 5"
              message: This application recommends at last 5 nodes.
          - pass:
              message: This cluster has enough nodes.

```
<img width="1282" alt="Screenshot 2024-08-30 at 3 08 00 PM" src="https://github.com/user-attachments/assets/22a9354f-53ef-46f0-9ca8-bcdaa08e73a7">


<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
[sc-110574](https://app.shortcut.com/replicated/story/110574/allow-templating-of-outcome-messages-for-the-node-resources-analyzer)

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
