### PR TITLE
feat: [sc-110727] troubleshoot: collector/analyzer for wildcard dns

### DIFF
--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -300,6 +300,8 @@ spec:
                           type: BoolString
                         image:
                           type: string
+                        nonResolvable:
+                          type: string
                         timeout:
                           type: string
                       type: object

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -298,6 +298,8 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                        image:
+                          type: string
                         timeout:
                           type: string
                       type: object

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -2029,6 +2029,8 @@ spec:
                           type: BoolString
                         image:
                           type: string
+                        nonResolvable:
+                          type: string
                         timeout:
                           type: string
                       type: object

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -2027,6 +2027,8 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                        image:
+                          type: string
                         timeout:
                           type: string
                       type: object

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -2060,6 +2060,8 @@ spec:
                           type: BoolString
                         image:
                           type: string
+                        nonResolvable:
+                          type: string
                         timeout:
                           type: string
                       type: object

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -2058,6 +2058,8 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                        image:
+                          type: string
                         timeout:
                           type: string
                       type: object

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -298,6 +298,7 @@ type DNS struct {
 	CollectorMeta `json:",inline" yaml:",inline"`
 	Timeout       string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	Image         string `json:"image,omitempty" yaml:"image,omitempty"`
+	NonResolvable string `json:"nonResolvable,omitempty" yaml:"nonResolvable,omitempty"`
 }
 
 type Etcd struct {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -297,6 +297,7 @@ type Sonobuoy struct {
 type DNS struct {
 	CollectorMeta `json:",inline" yaml:",inline"`
 	Timeout       string `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Image         string `json:"image,omitempty" yaml:"image,omitempty"`
 }
 
 type Etcd struct {

--- a/pkg/collect/dns.go
+++ b/pkg/collect/dns.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	dnsUtilsImage       = "registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3"
+	dnsUtilsImage       = "registry.k8s.io/e2e-test-images/agnhost:2.39"
 	nonResolvableDomain = "non-existent-domain"
 )
 

--- a/pkg/collect/dns.go
+++ b/pkg/collect/dns.go
@@ -41,12 +41,12 @@ type DNSTroubleshootResult struct {
 	PodResolvConf       string `json:"podResolvConf"`
 	Query               struct {
 		Kubernetes struct {
-			Name          string `json:"name"`
-			AddressResult string `json:"address_result"`
+			Name    string `json:"name"`
+			Address string `json:"address"`
 		} `json:"kubernetes"`
 		NonResolvableDomain struct {
-			Name          string `json:"name"`
-			AddressResult string `json:"address_result"`
+			Name    string `json:"name"`
+			Address string `json:"address"`
 		} `json:"nonResolvableDomain"`
 	} `json:"query"`
 	KubeDNSPods      []string `json:"kubeDNSPods"`
@@ -350,9 +350,9 @@ func extractDNSQueriesFromPodLog(podLog string, dnsDebug *DNSTroubleshootResult)
 				dnsDebug.PodResolvConf += line + "\n"
 			case "kubernetes":
 				dnsDebug.Query.Kubernetes.Name = "kubernetes"
-				dnsDebug.Query.Kubernetes.AddressResult = line
+				dnsDebug.Query.Kubernetes.Address = line
 			case "nonResolvableDomain":
-				dnsDebug.Query.NonResolvableDomain.AddressResult = line
+				dnsDebug.Query.NonResolvableDomain.Address = line
 			}
 		}
 	}

--- a/pkg/collect/dns_test.go
+++ b/pkg/collect/dns_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -38,4 +39,44 @@ func TestGetKubernetesClusterIP(t *testing.T) {
 	if clusterIP != k8sSvcIp {
 		t.Errorf("expected %s, got %s", k8sSvcIp, clusterIP)
 	}
+}
+
+func TestExtractDNSQueriesFromPodLog(t *testing.T) {
+	podLog := `
+=== /etc/resolv.conf ===
+search default.svc.cluster.local svc.cluster.local cluster.local
+nameserver 10.43.0.10
+options ndots:5
+=== dig kubernetes ===
+10.43.0.1
+=== dig non-existent-domain ===`
+
+	expectedResolvConf := `search default.svc.cluster.local svc.cluster.local cluster.local
+nameserver 10.43.0.10
+options ndots:5
+`
+
+	expectedKubernetesQuery := struct {
+		Name    string `json:"name"`
+		Address string `json:"address"`
+	}{
+		Name:    "kubernetes",
+		Address: "10.43.0.1",
+	}
+
+	expectedNonResolvableDomainQuery := struct {
+		Name    string `json:"name"`
+		Address string `json:"address"`
+	}{
+		Name:    "",
+		Address: "",
+	}
+
+	dnsDebug := &DNSTroubleshootResult{}
+	err := extractDNSQueriesFromPodLog(podLog, dnsDebug)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedResolvConf, dnsDebug.PodResolvConf)
+	assert.Equal(t, expectedKubernetesQuery, dnsDebug.Query.Kubernetes)
+	assert.Equal(t, expectedNonResolvableDomainQuery, dnsDebug.Query.NonResolvableDomain)
 }

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -399,6 +399,9 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
+                  "image": {
+                    "type": "string"
+                  },
                   "timeout": {
                     "type": "string"
                   }

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -402,6 +402,9 @@
                   "image": {
                     "type": "string"
                   },
+                  "nonResolvable": {
+                    "type": "string"
+                  },
                   "timeout": {
                     "type": "string"
                   }

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3066,6 +3066,9 @@
                   "image": {
                     "type": "string"
                   },
+                  "nonResolvable": {
+                    "type": "string"
+                  },
                   "timeout": {
                     "type": "string"
                   }

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3063,6 +3063,9 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
+                  "image": {
+                    "type": "string"
+                  },
                   "timeout": {
                     "type": "string"
                   }

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -3112,6 +3112,9 @@
                   "image": {
                     "type": "string"
                   },
+                  "nonResolvable": {
+                    "type": "string"
+                  },
                   "timeout": {
                     "type": "string"
                   }

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -3109,6 +3109,9 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
+                  "image": {
+                    "type": "string"
+                  },
                   "timeout": {
                     "type": "string"
                   }


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/110727

Demo: https://asciinema.org/a/C9TJdETq9Hn21jefJaxSnWyga

## Updates in existing DNS collector
- use `dig` instead of `nslookup`
- test DNS resolution for a non resolvable domain
- make DNS utility `image` configurable, default to `registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3`
- add `nonResolveable` config for non-resolvable domain, defaulted to `non-existent-domain`

Current JSON output that can be used with others analyzer such as JSON analyzer

```json
{
  "kubernetesClusterIP": "10.43.0.1",
  "podResolvConf": "search default.svc.cluster.local svc.cluster.local cluster.local\nnameserver 10.43.0.10\noptions ndots:5\n",
  "query": {
    "kubernetes": {
      "name": "kubernetes",
      "address": "10.43.0.1"
    },
    "nonResolvableDomain": {
      "name": "foo.bar.xyz",
      "address": ""
    }
  },
  "kubeDNSPods": [
    "coredns-77ccd57875-76dt4"
  ],
  "kubeDNSService": "10.43.0.10",
  "kubeDNSEndpoints": "10.42.0.6:53"
}
```

Sample YAML spec

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: support-bundle
spec:
  collectors:
    - clusterResources:
        exclude: true
    - dns:
        image: registry.k8s.io/e2e-test-images/jessie-dnsutils:1.3
        nonResolvable: foo.bar.xyz 
  analyzers:
    - jsonCompare:
        checkName: Check for wildcard DNS config
        fileName: dns/debug.json
        path: "query.nonResolvableDomain.address"
        value: |
          ""
        outcomes:
          - fail:
              when: "false"
              message: Possible wildcard DNS configured. Non-existent domain resolved to {{ .query.nonResolvableDomain.address }}.
          - pass:
              when: "true"
              message: Confirmed that non-existent domain not resolved.
```