### PR TITLE
fix: --redactors flag is dropped if no spec provided

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -289,7 +289,7 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 		err     error
 	)
 
-	if len(args) < 1 {
+	if len(allArgs) < 1 {
 		fmt.Println("\r\033[36mNo specs provided, attempting to load from cluster...\033[m")
 		kinds, err = specs.LoadFromCluster(ctx, client, vp.GetStringSlice("selector"), vp.GetString("namespace"))
 		if err != nil {


### PR DESCRIPTION
## Description, Motivation and Context

When running the support-bundle command with no spec or the `--load-cluster-spec` flag, the arguments provided to `--redactors` are dropped.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
