### PR TITLE
feat: allow to specify dial interface

### DIFF
--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -1693,6 +1693,8 @@ spec:
                       properties:
                         collectorName:
                           type: string
+                        dialInterface:
+                          type: string
                         exclude:
                           type: BoolString
                         interface:

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -1693,6 +1693,8 @@ spec:
                       properties:
                         collectorName:
                           type: string
+                        dialInterface:
+                          type: string
                         exclude:
                           type: BoolString
                         interface:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -20307,6 +20307,8 @@ spec:
                       properties:
                         collectorName:
                           type: string
+                        dialInterface:
+                          type: string
                         exclude:
                           type: BoolString
                         interface:

--- a/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go
@@ -36,6 +36,7 @@ type HTTPLoadBalancer struct {
 type TCPPortStatus struct {
 	HostCollectorMeta `json:",inline" yaml:",inline"`
 	Interface         string `json:"interface,omitempty"`
+	DialInterface     string `json:"dialInterface,omitempty"`
 	Port              int    `json:"port"`
 }
 

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -19471,6 +19471,9 @@
                   "collectorName": {
                     "type": "string"
                   },
+                  "dialInterface": {
+                    "type": "string"
+                  },
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },


### PR DESCRIPTION
## Description, Motivation and Context

by default the tcp port status collector listen on all interfaces but selects the first interface found to issue the request. this commit makes the collector to accept an interface to which it should call.

for example:

```yaml
  collectors:
  - tcpPortStatus:
      collectorName: test
      port: 10248
      dialInterface: lo
```

this definition will make the collector listen on all interface but call 127.0.0.1:10248 to test. other example could be:

```yaml
  collectors:
  - tcpPortStatus:
      collectorName: test
      port: 10248
      dialInterface: eth0
```

this again will make the collector listen in all interfaces but it will use the ip found on eth0 to issue the call.

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
