### PR TITLE
have makefile detect src code changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,17 +102,17 @@ clean:
 tidy:
 	go mod tidy
 
-bin/support-bundle:
-	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle github.com/replicatedhq/troubleshoot/cmd/troubleshoot
+bin/support-bundle: $(shell find cmd/troubleshoot/ -name '*.go') $(shell find pkg/ -name '*.go')
+		go build ${BUILDFLAGS} ${LDFLAGS} -o bin/support-bundle github.com/replicatedhq/troubleshoot/cmd/troubleshoot
 
-bin/preflight:
-	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/preflight github.com/replicatedhq/troubleshoot/cmd/preflight
+bin/preflight: $(shell find cmd/preflight/ -name '*.go') $(shell find pkg/ -name '*.go')
+		go build ${BUILDFLAGS} ${LDFLAGS} -o bin/preflight github.com/replicatedhq/troubleshoot/cmd/preflight
 
-bin/analyze:
-	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/analyze github.com/replicatedhq/troubleshoot/cmd/analyze
+bin/analyze: $(shell find cmd/analyze/ -name '*.go') $(shell find pkg/ -name '*.go')
+		go build ${BUILDFLAGS} ${LDFLAGS} -o bin/analyze github.com/replicatedhq/troubleshoot/cmd/analyze
 
-bin/collect:
-	go build ${BUILDFLAGS} ${LDFLAGS} -o bin/collect github.com/replicatedhq/troubleshoot/cmd/collect
+bin/collect: $(shell find cmd/collect/ -name '*.go') $(shell find pkg/ -name '*.go')
+		go build ${BUILDFLAGS} ${LDFLAGS} -o bin/collect github.com/replicatedhq/troubleshoot/cmd/collect
 
 build-linux: tidy
 	@echo "Build cli binaries for Linux"
@@ -146,9 +146,9 @@ openapischema: controller-gen
 
 check-schemas: generate schemas
 	@if [ -n "$(shell git status --short)" ]; then \
-    	echo -e "\033[31mThe git repo is dirty :( Ensure all generated files are committed e.g CRD schema files\033[0;m"; \
-    	git status --short; \
-    	exit 1; \
+			echo -e "\033[31mThe git repo is dirty :( Ensure all generated files are committed e.g CRD schema files\033[0;m"; \
+			git status --short; \
+			exit 1; \
 	fi
 
 .PHONY: schemas


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

Add dependencies to the makefile recipes to build support-bundle binaries.  Makefile should now detect changes correctly, so `make watchrsync` can re-build and re-rsync binaries on changes correctly.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
