### PR TITLE
bug: Remove duplicate results in preflights

### DIFF
--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -122,7 +122,7 @@ func Analyze(
 		return nil, errors.New("nil analyzer")
 	}
 
-	analyzerInst := getAnalyzer(analyzer)
+	analyzerInst := GetAnalyzer(analyzer)
 	if analyzerInst == nil {
 		klog.Info("Non-existent analyzer found in the spec. Please double-check the spelling and indentation of the analyzers in the spec.")
 		return nil, nil
@@ -188,7 +188,7 @@ type Analyzer interface {
 	Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error)
 }
 
-func getAnalyzer(analyzer *troubleshootv1beta2.Analyze) Analyzer {
+func GetAnalyzer(analyzer *troubleshootv1beta2.Analyze) Analyzer {
 	switch {
 	case analyzer.ClusterVersion != nil:
 		return &AnalyzeClusterVersion{analyzer: analyzer.ClusterVersion}

--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -10,6 +10,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 type providers struct {
@@ -75,7 +76,8 @@ func (a *AnalyzeDistribution) IsExcluded() (bool, error) {
 func (a *AnalyzeDistribution) Analyze(getFile getCollectedFileContents, findFiles getChildCollectedFileContents) ([]*AnalyzeResult, error) {
 	result, err := a.analyzeDistribution(a.analyzer, getFile)
 	if err != nil {
-		return nil, err
+		klog.Errorf("failed to analyze distribution: %v", err)
+		return nil, errors.Wrapf(err, "failed to analyze distribution")
 	}
 	result.Strict = a.analyzer.Strict.BoolOrDefaultFalse()
 	return []*AnalyzeResult{result}, nil

--- a/pkg/preflight/analyze.go
+++ b/pkg/preflight/analyze.go
@@ -103,11 +103,17 @@ func doAnalyze(
 				klog.Errorf("failed to determine if analyzer %v is strict: %s", analyzer, strictErr)
 			}
 
+			title := "Analyzer Failed"
+			analyzerInst := analyze.GetAnalyzer(analyzer)
+			if analyzerInst != nil {
+				title = analyzerInst.Title()
+			}
+
 			analyzeResult = []*analyze.AnalyzeResult{
 				{
 					Strict:  strict,
 					IsFail:  true,
-					Title:   "Analyzer Failed",
+					Title:   title,
 					Message: err.Error(),
 				},
 			}


### PR DESCRIPTION
## Description, Motivation and Context

Change to stop re-analysing preflight results when `uploadResultsTo` is present

**Before**
https://asciinema.org/a/Bo9k5KxeAjXTKGkdLzDKYJGj7

**After**
https://asciinema.org/a/XXflLFUP5mv1r90KB1Ae9V3cF

Fixes: https://github.com/replicatedhq/troubleshoot/issues/1625

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
