### PR TITLE
feat: add CPU micro architecture support

### DIFF
--- a/pkg/analyze/host_cpu.go
+++ b/pkg/analyze/host_cpu.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"encoding/json"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -9,6 +10,18 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
 )
+
+// microarchs holds a list of features present in each microarchitecture.
+// ref: https://gitlab.com/x86-psABIs/x86-64-ABI
+// ref: https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level
+var microarchs = map[string][]string{
+	"x86-64-v2": {"cx16", "lahf_lm", "popcnt", "ssse3", "sse4_1", "sse4_2", "ssse3"},
+	"x86-64-v3": {"avx", "avx2", "bmi1", "bmi2", "f16c", "fma", "lzcnt", "movbe", "xsave"},
+	"x86-64-v4": {"avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl"},
+}
+
+// x8664BaseFeatures are the features that are present in all x86-64 microarchitectures.
+var x8664BaseFeatures = []string{"cmov", "cx8", "fpu", "fxsr", "mmx", "syscall", "sse", "sse2"}
 
 type AnalyzeHostCPU struct {
 	hostAnalyzer *troubleshootv1beta2.CPUAnalyze
@@ -52,7 +65,7 @@ func (a *AnalyzeHostCPU) Analyze(
 				return []*AnalyzeResult{&result}, nil
 			}
 
-			isMatch, err := compareHostCPUConditionalToActual(outcome.Fail.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount)
+			isMatch, err := compareHostCPUConditionalToActual(outcome.Fail.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount, cpuInfo.Flags)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to compare")
 			}
@@ -73,7 +86,7 @@ func (a *AnalyzeHostCPU) Analyze(
 				return []*AnalyzeResult{&result}, nil
 			}
 
-			isMatch, err := compareHostCPUConditionalToActual(outcome.Warn.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount)
+			isMatch, err := compareHostCPUConditionalToActual(outcome.Warn.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount, cpuInfo.Flags)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to compare")
 			}
@@ -94,7 +107,7 @@ func (a *AnalyzeHostCPU) Analyze(
 				return []*AnalyzeResult{&result}, nil
 			}
 
-			isMatch, err := compareHostCPUConditionalToActual(outcome.Pass.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount)
+			isMatch, err := compareHostCPUConditionalToActual(outcome.Pass.When, cpuInfo.LogicalCount, cpuInfo.PhysicalCount, cpuInfo.Flags)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to compare")
 			}
@@ -112,7 +125,25 @@ func (a *AnalyzeHostCPU) Analyze(
 	return []*AnalyzeResult{&result}, nil
 }
 
-func compareHostCPUConditionalToActual(conditional string, logicalCount int, physicalCount int) (res bool, err error) {
+func doCompareHostCPUMicroArchitecture(microarch string, flags []string) (res bool, err error) {
+	specifics, ok := microarchs[microarch]
+	if !ok && microarch != "x86-64" {
+		return false, errors.Errorf("troubleshoot does not yet support microarchitecture %q", microarch)
+	}
+	expectedFlags := x8664BaseFeatures
+	if len(specifics) > 0 {
+		expectedFlags = append(expectedFlags, specifics...)
+	}
+	for _, flag := range expectedFlags {
+		if slices.Contains(flags, flag) {
+			continue
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func compareHostCPUConditionalToActual(conditional string, logicalCount int, physicalCount int, flags []string) (res bool, err error) {
 	compareLogical := false
 	comparePhysical := false
 	compareUnspecified := false
@@ -135,6 +166,11 @@ func compareHostCPUConditionalToActual(conditional string, logicalCount int, phy
 		compareUnspecified = true
 		comparator = parts[0]
 		desired = parts[1]
+	}
+
+	// analyze if the cpu supports a specific set of features, aka as micrarchitecture.
+	if strings.ToLower(comparator) == "supports" {
+		return doCompareHostCPUMicroArchitecture(desired, flags)
 	}
 
 	if !compareLogical && !comparePhysical && !compareUnspecified {

--- a/pkg/analyze/host_cpu_test.go
+++ b/pkg/analyze/host_cpu_test.go
@@ -81,6 +81,7 @@ func Test_compareHostCPUConditionalToActual(t *testing.T) {
 		when          string
 		logicalCount  int
 		physicalCount int
+		flags         []string
 		expected      bool
 	}{
 		{
@@ -139,12 +140,24 @@ func Test_compareHostCPUConditionalToActual(t *testing.T) {
 			physicalCount: 4,
 			expected:      true,
 		},
+		{
+			name:     "supports x86-64-v2 microarchitecture",
+			when:     "supports x86-64-v2",
+			flags:    []string{""},
+			expected: false,
+		},
+		{
+			name:     "supports x86-64-v2 microarchitecture",
+			when:     "supports x86-64-v2",
+			flags:    []string{"cmov", "cx8", "fpu", "fxsr", "mmx", "syscall", "sse", "sse2", "cx16", "lahf_lm", "popcnt", "ssse3", "sse4_1", "sse4_2", "ssse3"},
+			expected: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
 
-			actual, err := compareHostCPUConditionalToActual(test.when, test.logicalCount, test.physicalCount)
+			actual, err := compareHostCPUConditionalToActual(test.when, test.logicalCount, test.physicalCount, test.flags)
 			req.NoError(err)
 
 			assert.Equal(t, test.expected, actual)

--- a/pkg/collect/host_cpu_test.go
+++ b/pkg/collect/host_cpu_test.go
@@ -20,12 +20,13 @@ func TestCollectHostCPU_Collect(t *testing.T) {
 	require.Contains(t, got, "host-collectors/system/cpu.json")
 	values := got["host-collectors/system/cpu.json"]
 
-	var m map[string]int
+	var m map[string]interface{}
 	err = json.Unmarshal(values, &m)
 	require.NoError(t, err)
 
 	// Check if values exist. They will be different on different machines.
-	assert.Equal(t, 2, len(m))
+	assert.Equal(t, 3, len(m))
 	assert.Contains(t, m, "logicalCount")
 	assert.Contains(t, m, "physicalCount")
+	assert.Contains(t, m, "flags")
 }


### PR DESCRIPTION
## Description, Motivation and Context

allows troubleshoot to collect and analyze CPU x86-64 micro architecture. this is an usage example:

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: HostPreflight
metadata:
  name: ec-cluster-preflight
spec:
  collectors:
  - cpu: {}
  analyzers:
  - cpu:
      checkName: CPU
      outcomes:
        - pass:
            when: 'supports x86-64-v2'
            message: CPU supports x86-64-v2
        - fail:
            message: CPU does not support x86-64-v2
```

this pr adds micro architecture analysis for the following cpus:

```
x86-64
x86-64-v2
x86-64-v3
x86-64-v4
```

for the analysis the reserved word `supports` has been chosen so the following rules are valid:

```
supports x86-64 (analyse only the basic set of features for x86-64)
supports x86-64-v2 (basic set of features for x86-64 + v2 features)
supports x86-64-v3 (basic set of features for x86-64 + v3 features)
supports x86-64-v4 (basic set of features for x86-64 + v4 features)
```

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
