### PR TITLE
change resolvedFromSearch content

### DIFF
--- a/pkg/collect/host_dns.go
+++ b/pkg/collect/host_dns.go
@@ -177,7 +177,7 @@ func queryDNS(name, query, server string) DNSEntry {
 
 		// remember the search domain that resolved the query
 		// e.g. foo.test.com -> test.com
-		entry.Search = strings.Replace(query, name, "", 1)
+		entry.Search = extractSearchFromFQDN(query, name)
 
 		// populate record detail
 		switch rec {
@@ -206,4 +206,14 @@ func queryDNS(name, query, server string) DNSEntry {
 
 func (c *CollectHostDNS) RemoteCollect(progressChan chan<- interface{}) (map[string][]byte, error) {
 	return nil, ErrRemoteCollectorNotImplemented
+}
+
+func extractSearchFromFQDN(fqdn, name string) string {
+	// no search domain
+	if fqdn == name {
+		return ""
+	}
+	search := strings.TrimPrefix(fqdn, name+".") // remove name
+	search = strings.TrimSuffix(search, ".")     // remove root dot
+	return search
 }

--- a/pkg/collect/host_dns_test.go
+++ b/pkg/collect/host_dns_test.go
@@ -1,0 +1,26 @@
+package collect
+
+import (
+	"testing"
+)
+
+func TestExtractSearchFromFQDN(t *testing.T) {
+	tests := []struct {
+		fqdn     string
+		name     string
+		expected string
+	}{
+		{"foo.com.", "foo.com", ""},
+		{"bar.com", "bar.com", ""},
+		{"*.foo.testcluster.net.", "*", "foo.testcluster.net"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.fqdn, func(t *testing.T) {
+			result := extractSearchFromFQDN(test.fqdn, test.name)
+			if result != test.expected {
+				t.Errorf("extractSearchFromFQDN(%q, %q) = %q; want %q", test.fqdn, test.name, result, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
Fixes: https://github.com/replicatedhq/embedded-cluster/pull/1210

Changed content of `.resolvedFromSearch`. E.g. from `.foo.testcluster.net.` to `foo.testcluster.net`

```json
{
  "query": {
    "*": [
      {
        "server": "127.0.0.53:53",
        "search": "foo.testcluster.net",
        "name": "*.foo.testcluster.net.",
        "answer": "*.foo.testcluster.net.\t60\tIN\tA\t192.1.2.3",
        "record": "192.1.2.3"
      },
      {
        "server": "127.0.0.53:53",
        "search": "",
        "name": "*.c.replicated-qa.internal.",
        "answer": "",
        "record": ""
      },
      {
        "server": "127.0.0.53:53",
        "search": "",
        "name": "*.google.internal.",
        "answer": "",
        "record": ""
      },
      {
        "server": "127.0.0.53:53",
        "search": "",
        "name": "*.",
        "answer": "",
        "record": ""
      }
    ]
  },
  "resolvedFromSearch": "foo.testcluster.net"
}
``` 

```json
[
    {
        "name": "detect.wildcard.dns",
        "labels": {
            "desiredPosition": "1",
            "iconKey": "kubernetes_text_analyze",
            "iconUri": "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg"
        },
        "insight": {
            "name": "detect.wildcard.dns",
            "labels": {
                "iconKey": "kubernetes_text_analyze",
                "iconUri": "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg"
            },
            "primary": "Detect wildcard DNS",
            "detail": "Wildcard DNS entry foo.testcluster.net detected. Remove the wildcard DNS entry or the foo.testcluster.net search domain from resolv.conf.",
            "severity": "error"
        },
        "severity": "error",
        "analyzerSpec": "",
        "error": "Wildcard DNS entry foo.testcluster.net detected. Remove the wildcard DNS entry or the foo.testcluster.net search domain from resolv.conf."
    }
]
```

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
