### PR TITLE
feat: [sc-113128] Create node list file before running remote host collector

### DIFF
--- a/pkg/analyze/host_os_info.go
+++ b/pkg/analyze/host_os_info.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
 )
 
 type AnalyzeHostOS struct {
@@ -39,8 +40,8 @@ func (a *AnalyzeHostOS) Analyze(
 	// check if the host os info file exists (local mode)
 	contents, err := getCollectedFileContents(collect.HostOSInfoPath)
 	if err != nil {
-		//check if the node list file exists (remote mode)
-		contents, err := getCollectedFileContents(collect.NODE_LIST_FILE)
+		// check if the node list file exists (remote mode)
+		contents, err := getCollectedFileContents(constants.NODE_LIST_FILE)
 		if err != nil {
 			return []*AnalyzeResult{&result}, errors.Wrap(err, "failed to get collected file")
 		}

--- a/pkg/collect/collect.go
+++ b/pkg/collect/collect.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const NODE_LIST_FILE = "host-collectors/system/node_list.json"
-
 var (
 	// ErrCollectorNotFound is returned when an undefined host collector is
 	// specified by the user.

--- a/pkg/collect/host_os_info.go
+++ b/pkg/collect/host_os_info.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -95,7 +94,6 @@ func (c *CollectHostOS) RemoteCollect(progressChan chan<- interface{}) (map[stri
 	}
 
 	output := NewResult()
-	nodes := []string{}
 
 	// save the first result we find in the node and save it
 	for node, result := range results.AllCollectedData {
@@ -114,20 +112,9 @@ func (c *CollectHostOS) RemoteCollect(progressChan chan<- interface{}) (map[stri
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to marshal host os info")
 			}
-			nodes = append(nodes, node)
 			output.SaveResult(c.BundlePath, fmt.Sprintf("host-collectors/system/%s/%s", node, HostInfoFileName), bytes.NewBuffer(b))
 		}
 	}
 
-	// check if NODE_LIST_FILE exists
-	_, err = os.Stat(NODE_LIST_FILE)
-	// if it not exists, save the nodes list
-	if err != nil {
-		nodesBytes, err := json.MarshalIndent(HostOSInfoNodes{Nodes: nodes}, "", " ")
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal host os info nodes")
-		}
-		output.SaveResult(c.BundlePath, NODE_LIST_FILE, bytes.NewBuffer(nodesBytes))
-	}
 	return output, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -109,4 +109,7 @@ const (
 	OUTCOME_PASS = "pass"
 	OUTCOME_WARN = "warn"
 	OUTCOME_FAIL = "fail"
+
+	// List of remote nodes to collect data from in a support bundle
+	NODE_LIST_FILE = "host-collectors/system/node_list.json"
 )

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -161,16 +161,12 @@ func CollectSupportBundleFromSpec(
 	}
 
 	// merge in-cluster and host collectors results
-	if files != nil {
-		for k, v := range files {
-			result[k] = v
-		}
+	for k, v := range files {
+		result[k] = v
 	}
 
-	if hostFiles != nil {
-		for k, v := range hostFiles {
-			result[k] = v
-		}
+	for k, v := range hostFiles {
+		result[k] = v
 	}
 
 	if len(result) == 0 {

--- a/pkg/supportbundle/supportbundle_test.go
+++ b/pkg/supportbundle/supportbundle_test.go
@@ -79,6 +79,7 @@ func Test_getNodeList(t *testing.T) {
 	tests := []struct {
 		name        string
 		clientset   kubernetes.Interface
+		opts        SupportBundleCreateOpts
 		expected    *NodeList
 		expectError bool
 	}{
@@ -92,6 +93,7 @@ func Test_getNodeList(t *testing.T) {
 					},
 				},
 			),
+			opts: SupportBundleCreateOpts{},
 			expected: &NodeList{
 				Nodes: []string{"node1", "node2"},
 			},
@@ -101,7 +103,7 @@ func Test_getNodeList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nodeList, err := getNodeList(tt.clientset)
+			nodeList, err := getNodeList(tt.clientset, tt.opts)
 			if (err != nil) != tt.expectError {
 				t.Errorf("getNodeList() error = %v, expectError %v", err, tt.expectError)
 				return


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/113128
Demo: https://asciinema.org/a/cdsvfOWnwOwdZcdpyz6QocEnp

If `RunHostCollectorsInPod` is set, we will create a file `host-collectors/system/node_list.json` containing list of node names to be used for remote collect/analyze later.

E.g.

```json
{
  "nodes": [
    "multinode",
    "multinode-m02"
  ]
}
```

