### PR TITLE
chore(support-bundle): respect using load-cluster-specs=false

### DIFF
--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -77,7 +77,7 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 	cmd.Flags().Bool("interactive", true, "enable/disable interactive mode")
 	cmd.Flags().Bool("collect-without-permissions", true, "always generate a support bundle, even if it some require additional permissions")
 	cmd.Flags().StringSliceP("selector", "l", []string{"troubleshoot.sh/kind=support-bundle"}, "selector to filter on for loading additional support bundle specs found in secrets within the cluster")
-	cmd.Flags().Bool("load-cluster-specs", false, "enable/disable loading additional troubleshoot specs found within the cluster. This is the default behavior if no spec is provided as an argument")
+	cmd.Flags().Bool("load-cluster-specs", true, "enable/disable loading additional troubleshoot specs found within the cluster. This is the default behavior if no spec is provided as an argument")
 	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 	cmd.Flags().StringP("output", "o", "", "specify the output file path for the support bundle")

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -44,12 +44,11 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			// If there are not locations to load specs passed in the cli args, we should
+			// If there are no locations to load specs from passed in the cli args, we should
 			// load them from the cluster by setting "load-cluster-specs=true". If the caller
-			// provided "--load-cluster-specs" cli option, we should respect that.
+			// provided "--load-cluster-specs" cli option, we should respect it.
 			if len(args) == 0 {
-				// Check if --load-cluster-specs was set by the cli caller by
-				// checking if the flag was not changed from the default value
+				// Check if --load-cluster-specs was set by the cli caller to avoid overriding it
 				flg := cmd.Flags().Lookup("load-cluster-specs")
 				if flg != nil && !flg.Changed {
 					// Load specs from the cluster if no spec(s) is(are) provided in the cli args

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -311,7 +311,10 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 	if len(kinds.CollectorsV1Beta2) == 0 &&
 		len(kinds.HostCollectorsV1Beta2) == 0 &&
 		len(kinds.SupportBundlesV1Beta2) == 0 {
-		return nil, nil, types.NewExitCodeError(constants.EXIT_CODE_CATCH_ALL, errors.Wrap(err, "no collectors specified to run. Use --debug and/or -v=2 to see more information"))
+		return nil, nil, types.NewExitCodeError(
+			constants.EXIT_CODE_CATCH_ALL,
+			fmt.Errorf("no collectors specified to run. Use --debug and/or -v=2 to see more information"),
+		)
 	}
 
 	// Merge specs

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -297,14 +297,6 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 		return nil, nil, errors.Wrap(err, "failed to load specs from CLI args")
 	}
 
-	if len(redactors) > 0 {
-		additionalKinds, err := specs.LoadFromCLIArgs(ctx, client, allArgs, vp)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to load redactors from CLI args")
-		}
-		kinds.RedactorsV1Beta2 = append(kinds.RedactorsV1Beta2, additionalKinds.RedactorsV1Beta2...)
-	}
-
 	// Load additional specs from support bundle URIs
 	// only when no-uri flag is not set and no URLs are provided in the args
 	if !viper.GetBool("no-uri") {

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -313,7 +313,7 @@ func loadSpecs(ctx context.Context, args []string, client kubernetes.Interface) 
 		len(kinds.SupportBundlesV1Beta2) == 0 {
 		return nil, nil, types.NewExitCodeError(
 			constants.EXIT_CODE_CATCH_ALL,
-			fmt.Errorf("no collectors specified to run. Use --debug and/or -v=2 to see more information"),
+			errors.New("no collectors specified to run. Use --debug and/or -v=2 to see more information"),
 		)
 	}
 

--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -268,6 +268,8 @@ func downloadFromHttpURL(ctx context.Context, url string, headers map[string]str
 // to list & read secrets and configmaps from all namespaces, we will fallback to trying each
 // namespace individually, and eventually default to the configured kubeconfig namespace.
 func LoadFromCluster(ctx context.Context, client kubernetes.Interface, selectors []string, ns string) (*loader.TroubleshootKinds, error) {
+	klog.V(1).Infof("Load troubleshoot specs from the cluster using selectors: %v", selectors)
+
 	if reflect.DeepEqual(selectors, []string{"troubleshoot.sh/kind=support-bundle"}) {
 		// Its the default selector so we append troubleshoot.io/kind=support-bundle to it due to backwards compatibility
 		selectors = append(selectors, "troubleshoot.io/kind=support-bundle")

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -83,14 +83,18 @@ type TroubleshootKinds struct {
 }
 
 func (kinds *TroubleshootKinds) IsEmpty() bool {
-	return len(kinds.AnalyzersV1Beta2) == 0 &&
-		len(kinds.CollectorsV1Beta2) == 0 &&
-		len(kinds.HostCollectorsV1Beta2) == 0 &&
-		len(kinds.HostPreflightsV1Beta2) == 0 &&
-		len(kinds.PreflightsV1Beta2) == 0 &&
-		len(kinds.RedactorsV1Beta2) == 0 &&
-		len(kinds.RemoteCollectorsV1Beta2) == 0 &&
-		len(kinds.SupportBundlesV1Beta2) == 0
+	return kinds.Len() == 0
+}
+
+func (kinds *TroubleshootKinds) Len() int {
+	return len(kinds.AnalyzersV1Beta2) +
+		len(kinds.CollectorsV1Beta2) +
+		len(kinds.HostCollectorsV1Beta2) +
+		len(kinds.HostPreflightsV1Beta2) +
+		len(kinds.PreflightsV1Beta2) +
+		len(kinds.RedactorsV1Beta2) +
+		len(kinds.RemoteCollectorsV1Beta2) +
+		len(kinds.SupportBundlesV1Beta2)
 }
 
 func (kinds *TroubleshootKinds) Add(other *TroubleshootKinds) {
@@ -200,7 +204,7 @@ func (l *specLoader) loadFromStrings(rawSpecs ...string) (*TroubleshootKinds, er
 			// If it's not a configmap or secret, just append it to the splitdocs
 			splitdocs = append(splitdocs, rawDoc)
 		} else {
-			klog.V(1).Infof("Skip loading %q kind", parsed.Kind)
+			klog.V(2).Infof("Skip loading %q kind", parsed.Kind)
 		}
 	}
 
@@ -254,11 +258,7 @@ func (l *specLoader) loadFromSplitDocs(splitdocs []string) (*TroubleshootKinds, 
 		}
 	}
 
-	if kinds.IsEmpty() {
-		klog.V(1).Info("No troubleshoot specs were loaded")
-	} else {
-		klog.V(1).Info("Loaded troubleshoot specs successfully")
-	}
+	klog.V(2).Infof("Loaded %d troubleshoot specs successfully", kinds.Len())
 
 	return kinds, nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,6 +20,7 @@ type ExitError interface {
 type ExitCodeError struct {
 	Msg  string
 	Code int
+	Err error
 }
 
 type ExitCodeWarning struct {
@@ -28,6 +29,10 @@ type ExitCodeWarning struct {
 
 func (e *ExitCodeError) Error() string {
 	return e.Msg
+}
+
+func (e *ExitCodeError) Unwrap() error {
+	return e.Err
 }
 
 func (e *ExitCodeError) ExitStatus() int {
@@ -39,7 +44,7 @@ func NewExitCodeError(exitCode int, theErr error) *ExitCodeError {
 	if theErr != nil {
 		useErr = theErr.Error()
 	}
-	return &ExitCodeError{Msg: useErr, Code: exitCode}
+	return &ExitCodeError{Msg: useErr, Code: exitCode, Err: theErr}
 }
 
 func NewExitCodeWarning(theErrMsg string) *ExitCodeWarning {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,7 +20,7 @@ type ExitError interface {
 type ExitCodeError struct {
 	Msg  string
 	Code int
-	Err error
+	Err  error
 }
 
 type ExitCodeWarning struct {

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -78,7 +78,7 @@ if ! grep "\*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_directory_name/static-hi.log"; t
     exit 1
 fi
 
-echo "======= Generating support bundle from k8s cluster using default --load-cluster-specs ======"
+echo "======= Generating support bundle from k8s cluster using --load-cluster-specs ======"
 recreate_tmpdir
 kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
 ./bin/support-bundle -v1 --interactive=false --load-cluster-specs --output=$tmpdir/$bundle_archive_name

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -23,6 +23,7 @@ recreate_tmpdir
 ./bin/support-bundle --debug \
                      --interactive=false \
                      examples/support-bundle/e2e.yaml \
+                     --load-cluster-specs=false \
                      --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"
@@ -77,7 +78,7 @@ if ! grep "\*\*\*HIDDEN\*\*\*" "$tmpdir/$bundle_directory_name/static-hi.log"; t
     exit 1
 fi
 
-echo "======= Generating support bundle from k8s cluster using --load-cluster-specs ======"
+echo "======= Generating support bundle from k8s cluster using default --load-cluster-specs ======"
 recreate_tmpdir
 kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
 ./bin/support-bundle -v1 --interactive=false --load-cluster-specs --output=$tmpdir/$bundle_archive_name
@@ -193,6 +194,7 @@ recreate_tmpdir
 kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
 ./bin/support-bundle -v1 --interactive=false secret/default/labelled-support-bundle-1/custom-spec-key \
                     --redactors configmap/default/labelled-redactor-spec-1/customer-redactor-spec \
+                    --load-cluster-specs=false \
                     --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"
@@ -217,6 +219,7 @@ kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
 ./bin/support-bundle -v1 \
                      --interactive=false \
                      configmap/labelled-specs/labelled-support-bundle-2 \
+                     --load-cluster-specs=false \
                      --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"

--- a/test/validate-support-bundle-e2e.sh
+++ b/test/validate-support-bundle-e2e.sh
@@ -23,7 +23,6 @@ recreate_tmpdir
 ./bin/support-bundle --debug \
                      --interactive=false \
                      examples/support-bundle/e2e.yaml \
-                     --load-cluster-specs=false \
                      --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"
@@ -194,7 +193,6 @@ recreate_tmpdir
 kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
 ./bin/support-bundle -v1 --interactive=false secret/default/labelled-support-bundle-1/custom-spec-key \
                     --redactors configmap/default/labelled-redactor-spec-1/customer-redactor-spec \
-                    --load-cluster-specs=false \
                     --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"
@@ -219,7 +217,6 @@ kubectl apply -f "$PRJ_ROOT/testdata/supportbundle/labelled-specs"
 ./bin/support-bundle -v1 \
                      --interactive=false \
                      configmap/labelled-specs/labelled-support-bundle-2 \
-                     --load-cluster-specs=false \
                      --output=$tmpdir/$bundle_archive_name
 if [ $? -ne 0 ]; then
     echo "support-bundle command failed"


### PR DESCRIPTION
## Description, Motivation and Context

Using `./support-bundle --load-cluster-specs=false` still leads to loading support bundle specs from the cluster.

Fixes: https://github.com/replicatedhq/troubleshoot/issues/1638

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
