### PR TITLE
Allow goldpinger / goldpinger util images to be set in collector spec 

### DIFF
--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -354,6 +354,8 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                        image:
+                          type: string
                         namespace:
                           type: string
                         podLaunchOptions:

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -380,6 +380,8 @@ spec:
                           type: object
                         serviceAccountName:
                           type: string
+                        utilImage:
+                          type: string
                       type: object
                     helm:
                       properties:

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -380,8 +380,6 @@ spec:
                           type: object
                         serviceAccountName:
                           type: string
-                        utilImage:
-                          type: string
                       type: object
                     helm:
                       properties:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -2109,6 +2109,8 @@ spec:
                           type: object
                         serviceAccountName:
                           type: string
+                        utilImage:
+                          type: string
                       type: object
                     helm:
                       properties:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -2083,6 +2083,8 @@ spec:
                           type: string
                         exclude:
                           type: BoolString
+                        image:
+                          type: string
                         namespace:
                           type: string
                         podLaunchOptions:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -2109,8 +2109,6 @@ spec:
                           type: object
                         serviceAccountName:
                           type: string
-                        utilImage:
-                          type: string
                       type: object
                     helm:
                       properties:

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -279,6 +279,7 @@ type Helm struct {
 type Goldpinger struct {
 	CollectorMeta      `json:",inline" yaml:",inline"`
 	Namespace          string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Image              string            `json:"image,omitempty" yaml:"image,omitempty"`
 	ServiceAccountName string            `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
 	CollectDelay       string            `json:"collectDelay,omitempty" yaml:"collectDelay,omitempty"`
 	PodLaunchOptions   *PodLaunchOptions `json:"podLaunchOptions,omitempty" yaml:"podLaunchOptions,omitempty"`

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -280,6 +280,7 @@ type Goldpinger struct {
 	CollectorMeta      `json:",inline" yaml:",inline"`
 	Namespace          string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Image              string            `json:"image,omitempty" yaml:"image,omitempty"`
+	UtilImage          string            `json:"utilImage,omitempty" yaml:"utilImage,omitempty"`
 	ServiceAccountName string            `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
 	CollectDelay       string            `json:"collectDelay,omitempty" yaml:"collectDelay,omitempty"`
 	PodLaunchOptions   *PodLaunchOptions `json:"podLaunchOptions,omitempty" yaml:"podLaunchOptions,omitempty"`

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -280,7 +280,6 @@ type Goldpinger struct {
 	CollectorMeta      `json:",inline" yaml:",inline"`
 	Namespace          string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Image              string            `json:"image,omitempty" yaml:"image,omitempty"`
-	UtilImage          string            `json:"utilImage,omitempty" yaml:"utilImage,omitempty"`
 	ServiceAccountName string            `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
 	CollectDelay       string            `json:"collectDelay,omitempty" yaml:"collectDelay,omitempty"`
 	PodLaunchOptions   *PodLaunchOptions `json:"podLaunchOptions,omitempty" yaml:"podLaunchOptions,omitempty"`

--- a/pkg/collect/goldpinger.go
+++ b/pkg/collect/goldpinger.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var GoldpingerImage = "bloomberg/goldpinger:3.10.1"
+var goldpingerImage = "bloomberg/goldpinger:3.10.1"
 
 // Collect goldpinger results from goldpinger service running in a cluster
 // The results are stored in goldpinger/check_all.json since we use

--- a/pkg/collect/goldpinger.go
+++ b/pkg/collect/goldpinger.go
@@ -485,9 +485,6 @@ func (c *CollectGoldpinger) runPodAndCollectGPResults(url string, progressChan c
 	namespace := "default"
 	serviceAccountName := ""
 	image := constants.GP_DEFAULT_IMAGE
-	if c.Collector.UtilImage != "" {
-		image = c.Collector.UtilImage
-	}
 
 	var imagePullSecret *troubleshootv1beta2.ImagePullSecrets
 

--- a/pkg/collect/goldpinger.go
+++ b/pkg/collect/goldpinger.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+var GoldpingerImage = "bloomberg/goldpinger:3.10.1"
+
 // Collect goldpinger results from goldpinger service running in a cluster
 // The results are stored in goldpinger/check_all.json since we use
 // the /check_all endpoint
@@ -56,6 +58,10 @@ func (c *CollectGoldpinger) Collect(progressChan chan<- interface{}) (CollectorR
 	namespace := "default"
 	if c.Collector.Namespace != "" {
 		namespace = c.Collector.Namespace
+	}
+
+	if c.Collector.Image != "" {
+		GoldpingerImage = c.Collector.Image
 	}
 
 	url, resources, err := c.DiscoverOrCreateGoldpinger(namespace)
@@ -320,7 +326,7 @@ func (c *CollectGoldpinger) createGoldpingerDaemonSet(ns, svcAccName string) (*a
 				Containers: []corev1.Container{
 					{
 						Name:            "goldpinger-daemon",
-						Image:           "bloomberg/goldpinger:3.10.1",
+						Image:           GoldpingerImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Env: []corev1.EnvVar{
 							{

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -523,6 +523,9 @@
                   },
                   "serviceAccountName": {
                     "type": "string"
+                  },
+                  "utilImage": {
+                    "type": "string"
                   }
                 }
               },

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -484,6 +484,9 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
+                  "image": {
+                    "type": "string"
+                  },
                   "namespace": {
                     "type": "string"
                   },

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -523,9 +523,6 @@
                   },
                   "serviceAccountName": {
                     "type": "string"
-                  },
-                  "utilImage": {
-                    "type": "string"
                   }
                 }
               },

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3148,6 +3148,9 @@
                   "exclude": {
                     "oneOf": [{"type": "string"},{"type": "boolean"}]
                   },
+                  "image": {
+                    "type": "string"
+                  },
                   "namespace": {
                     "type": "string"
                   },

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3187,9 +3187,6 @@
                   },
                   "serviceAccountName": {
                     "type": "string"
-                  },
-                  "utilImage": {
-                    "type": "string"
                   }
                 }
               },

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3187,6 +3187,9 @@
                   },
                   "serviceAccountName": {
                     "type": "string"
+                  },
+                  "utilImage": {
+                    "type": "string"
                   }
                 }
               },


### PR DESCRIPTION
## Description, Motivation and Context

Allow goldpinger / goldpinger util images to be set in collector spec 
this allows us to pin it for use in EC airgap

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
