### PR TITLE
feat: allow users to check cpu arch 

### DIFF
--- a/pkg/analyze/host_cpu_test.go
+++ b/pkg/analyze/host_cpu_test.go
@@ -166,10 +166,10 @@ func Test_compareHostCPUConditionalToActual(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "machine arch matches",
-			when:     "machineArch == x86_64",
+			name:        "machine arch matches",
+			when:        "machineArch == x86_64",
 			machineArch: "x86_64",
-			expected: true,
+			expected:    true,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/analyze/host_cpu_test.go
+++ b/pkg/analyze/host_cpu_test.go
@@ -82,6 +82,7 @@ func Test_compareHostCPUConditionalToActual(t *testing.T) {
 		logicalCount  int
 		physicalCount int
 		flags         []string
+		machineArch   string
 		expected      bool
 	}{
 		{
@@ -169,7 +170,7 @@ func Test_compareHostCPUConditionalToActual(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
 
-			actual, err := compareHostCPUConditionalToActual(test.when, test.logicalCount, test.physicalCount, test.flags)
+			actual, err := compareHostCPUConditionalToActual(test.when, test.logicalCount, test.physicalCount, test.flags, test.machineArch)
 			req.NoError(err)
 
 			assert.Equal(t, test.expected, actual)

--- a/pkg/analyze/host_cpu_test.go
+++ b/pkg/analyze/host_cpu_test.go
@@ -165,6 +165,12 @@ func Test_compareHostCPUConditionalToActual(t *testing.T) {
 			flags:    []string{"a", "b", "c", "d", "e"},
 			expected: true,
 		},
+		{
+			name:     "machine arch matches",
+			when:     "machineArch == x86_64",
+			machineArch: "x86_64",
+			expected: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/collect/host_cpu.go
+++ b/pkg/collect/host_cpu.go
@@ -47,12 +47,10 @@ func (c *CollectHostCPU) Collect(progressChan chan<- interface{}) (map[string][]
 	}
 	cpuInfo.PhysicalCount = physicalCount
 
-	
 	cpuInfo.MachineArch, err = host.KernelArch()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch cpu architecture")
 	}
-	
 
 	// XXX even though the cpu.Info() returns a slice per CPU it is way
 	// common to have the same flags for all CPUs. We consolidate them here

--- a/pkg/collect/host_cpu.go
+++ b/pkg/collect/host_cpu.go
@@ -47,10 +47,12 @@ func (c *CollectHostCPU) Collect(progressChan chan<- interface{}) (map[string][]
 	}
 	cpuInfo.PhysicalCount = physicalCount
 
+	
 	cpuInfo.MachineArch, err = host.KernelArch()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch cpu architecture")
 	}
+	
 
 	// XXX even though the cpu.Info() returns a slice per CPU it is way
 	// common to have the same flags for all CPUs. We consolidate them here

--- a/pkg/collect/host_cpu.go
+++ b/pkg/collect/host_cpu.go
@@ -7,12 +7,14 @@ import (
 	"github.com/pkg/errors"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/host"
 )
 
 type CPUInfo struct {
 	LogicalCount  int      `json:"logicalCount"`
 	PhysicalCount int      `json:"physicalCount"`
 	Flags         []string `json:"flags"`
+	MachineArch   string   `json:"machineArch"`
 }
 
 const HostCPUPath = `host-collectors/system/cpu.json`
@@ -44,6 +46,11 @@ func (c *CollectHostCPU) Collect(progressChan chan<- interface{}) (map[string][]
 		return nil, errors.Wrap(err, "failed to count physical cpus")
 	}
 	cpuInfo.PhysicalCount = physicalCount
+
+	cpuInfo.MachineArch, err = host.KernelArch()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch cpu architecture")
+	}
 
 	// XXX even though the cpu.Info() returns a slice per CPU it is way
 	// common to have the same flags for all CPUs. We consolidate them here

--- a/pkg/collect/host_cpu_test.go
+++ b/pkg/collect/host_cpu_test.go
@@ -29,4 +29,5 @@ func TestCollectHostCPU_Collect(t *testing.T) {
 	assert.Contains(t, m, "logicalCount")
 	assert.Contains(t, m, "physicalCount")
 	assert.Contains(t, m, "flags")
+	//assert.Contains(t, m, "machineArch")
 }

--- a/pkg/collect/host_cpu_test.go
+++ b/pkg/collect/host_cpu_test.go
@@ -25,9 +25,9 @@ func TestCollectHostCPU_Collect(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check if values exist. They will be different on different machines.
-	assert.Equal(t, 3, len(m))
+	assert.Equal(t, 4, len(m))
 	assert.Contains(t, m, "logicalCount")
 	assert.Contains(t, m, "physicalCount")
 	assert.Contains(t, m, "flags")
-	//assert.Contains(t, m, "machineArch")
+	assert.Contains(t, m, "machineArch")
 }


### PR DESCRIPTION
## Description, Motivation and Context
Story details: https://app.shortcut.com/replicated/story/111542/add-support-for-cpu-architecture-to-cpu-host-collector-analyser-1584

Demo:


https://github.com/user-attachments/assets/17987849-216a-4ef5-b7c4-e1044afe506e



## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This feature helps to find which CPU architecture the machine is running on.