### PR TITLE
chore: Explicitly run make lint

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -22,30 +22,27 @@ concurrency:
 jobs:
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
         run: exit 1
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-
-      - name: setup env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - uses: actions/checkout@v4
-
-      - run: make test
+      - name: Run linters
+        run: make install-golangci-lint lint
+      - name: Run tests
+        run: make test
 
   test-integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+      - name: setup env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
       - name: Run linters
         run: make install-golangci-lint lint
       - name: Run tests

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -14,15 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21
-
-      - name: Install Go deps
-        run: go mod download
-
       - name: Install trivy
         run: |
           wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,7 @@
 
 run:
   allow-parallel-runners: true
-  timeout: 30s
+  timeout: 10m
 
 linters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ VERSION_PACKAGE = github.com/replicatedhq/troubleshoot/pkg/version
 VERSION ?=`git describe --tags --dirty`
 DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 RUN?=""
+GOLANGCI_LINT_VERSION ?= "v1.61.0"
 
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
 ifneq "$(GIT_TREE)" ""
@@ -152,7 +153,7 @@ check-schemas: generate schemas
 	fi
 
 .PHONY: schemas
-schemas: fmt vet openapischema bin/schemagen
+schemas: openapischema bin/schemagen
 	./bin/schemagen --output-dir ./schemas
 
 bin/schemagen:
@@ -236,12 +237,16 @@ scan:
 		./
 
 .PHONY: lint
-lint:
+lint: vet
 	golangci-lint run --new -c .golangci.yaml ${BUILDPATHS}
 
-.PHONY: fmt lint-and-fix
-lint-and-fix:
+.PHONY: lint-and-fix
+lint-and-fix: fmt vet
 	golangci-lint run --new --fix -c .golangci.yaml ${BUILDPATHS}
+
+.PHONY: install-golangci-lint
+install-golangci-lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 .PHONY: watch
 watch: npm-install

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ define LDFLAGS
 "
 endef
 
-BUILDFLAGS = -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -installsuffix netgo
+BUILDTAGS = "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp"
+BUILDFLAGS = -tags ${BUILDTAGS} -installsuffix netgo
 BUILDPATHS = ./pkg/... ./cmd/... ./internal/...
 E2EPATHS = ./test/e2e/...
 TESTFLAGS ?= -v -coverprofile cover.out
@@ -238,11 +239,11 @@ scan:
 
 .PHONY: lint
 lint: vet
-	golangci-lint run --new -c .golangci.yaml ${BUILDPATHS}
+	golangci-lint run --new -c .golangci.yaml --build-tags ${BUILDTAGS} ${BUILDPATHS}
 
 .PHONY: lint-and-fix
 lint-and-fix: fmt vet
-	golangci-lint run --new --fix -c .golangci.yaml ${BUILDPATHS}
+	golangci-lint run --new --fix -c .golangci.yaml --build-tags ${BUILDTAGS} ${BUILDPATHS}
 
 .PHONY: install-golangci-lint
 install-golangci-lint:


### PR DESCRIPTION
## Description, Motivation and Context

- Add an explicit `lint` CI job to let people know clearly why there is a CI failure
- Remove `fmt` make target from `check-schemas` target so as not to mislead people of CI failures

This change was driven by the need to fix misleading CI job failures such as https://github.com/replicatedhq/troubleshoot/actions/runs/11256373119, where `ensure-schemas-are-generated` job fails if there are formatting linter errors.

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
