### PR TITLE
fix(make): make sure github action can check schemas change

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -81,7 +81,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: make check-schemas
+          path: github.com/replicatedhq/troubleshoot
+      - run: |
+          cd github.com/replicatedhq/troubleshoot
+          make check-schemas
 
   compile-preflight:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ openapischema: controller-gen
 	controller-gen crd +output:dir=./config/crds  paths=./pkg/apis/troubleshoot/v1beta2
 
 check-schemas: generate schemas
-	@if [ -n "$(shell git status --short)" ]; then \
+	cp -r ./../../../github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset ./pkg/client/
+	@if [ -n "$$(git status --short)" ]; then \
     	echo -e "\033[31mThe git repo is dirty :( Ensure all generated files are committed e.g CRD schema files\033[0;m"; \
     	git status --short; \
     	exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ generate: controller-gen client-gen
 	$(CONTROLLER_GEN) \
 		object:headerFile=./hack/boilerplate.go.txt paths=./pkg/apis/...
 	$(CLIENT_GEN) \
-		--output-base=./../../../ \
+		--output-base=$$(pwd)/../../../ \
 		--output-package=github.com/replicatedhq/troubleshoot/pkg/client \
 		--clientset-name troubleshootclientset \
 		--input-base github.com/replicatedhq/troubleshoot/pkg/apis \
@@ -147,7 +147,6 @@ openapischema: controller-gen
 	controller-gen crd +output:dir=./config/crds  paths=./pkg/apis/troubleshoot/v1beta2
 
 check-schemas: generate schemas
-	cp -r ./../../../github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset ./pkg/client/
 	@if [ -n "$$(git status --short)" ]; then \
     	echo -e "\033[31mThe git repo is dirty :( Ensure all generated files are committed e.g CRD schema files\033[0;m"; \
     	git status --short; \


### PR DESCRIPTION
## Description, Motivation and Context
- fix ensure-schemas-are-generated task not detect schema change by `git status --short`
- change to dynamic path `--output-base=$$(pwd)/../../../ \`

Here is an example. 
current non-working one https://github.com/replicatedhq/troubleshoot/actions/runs/11336833376/job/31527432789?pr=1648#step:7:76
you can find that result of `git status -short` was not picked by github action.

In fixed one https://github.com/replicatedhq/troubleshoot/actions/runs/11355501407/job/31584952502?pr=1648

it has been picked up.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
