### PR TITLE
chore: Remove preempted deprecation warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/vmware-tanzu/velero v1.14.1
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
+	go.opentelemetry.io/otel/trace v1.31.0
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/mod v0.21.0
 	golang.org/x/sync v0.8.0
@@ -123,7 +124,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
-	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect

--- a/pkg/supportbundle/load.go
+++ b/pkg/supportbundle/load.go
@@ -38,7 +38,7 @@ func GetSupportBundleFromURI(bundleURI string) (*troubleshootv1beta2.SupportBund
 }
 
 // ParseSupportBundle parses a support bundle from a byte array into a SupportBundle object
-// Deprecated: use loader.LoadSpecs instead
+// We will deprecate this in favour of use loader.LoadSpecs once the new API is stable
 func ParseSupportBundle(doc []byte, followURI bool) (*troubleshootv1beta2.SupportBundle, error) {
 	doc, err := docrewrite.ConvertToV1Beta2(doc)
 	if err != nil {
@@ -102,13 +102,13 @@ func ParseSupportBundle(doc []byte, followURI bool) (*troubleshootv1beta2.Suppor
 }
 
 // ParseSupportBundle parses a support bundle from a byte array into a SupportBundle object
-// Deprecated: use loader.LoadSpecs instead
+// We will deprecate this in favour of use loader.LoadSpecs once the new API is stable
 func ParseSupportBundleFromDoc(doc []byte) (*troubleshootv1beta2.SupportBundle, error) {
 	return ParseSupportBundle(doc, true)
 }
 
 // GetRedactorFromURI parses a redactor from a URI into a Redactor object
-// Deprecated: use loader.LoadSpecs instead
+// We will deprecate this in favour of use loader.LoadSpecs once the new API is stable
 func GetRedactorFromURI(redactorURI string) (*troubleshootv1beta2.Redactor, error) {
 	redactorContent, err := LoadRedactorSpec(redactorURI)
 	if err != nil {
@@ -127,7 +127,7 @@ func GetRedactorFromURI(redactorURI string) (*troubleshootv1beta2.Redactor, erro
 }
 
 // GetRedactorsFromURIs parses redactors from a URIs Redactor objects
-// Deprecated: use loader.LoadSpecs instead
+// We will deprecate this in favour of use loader.LoadSpecs once the new API is stable
 func GetRedactorsFromURIs(redactorURIs []string) ([]*troubleshootv1beta2.Redact, error) {
 	redactors := []*troubleshootv1beta2.Redact{}
 	for _, redactor := range redactorURIs {
@@ -263,7 +263,7 @@ func loadSpecFromURL(arg string) ([]byte, error) {
 }
 
 // ParseRedactorsFromDocs parses a slice of YAML docs and returns a slice of Redactors
-// Deprecated: use loader.LoadSpecs instead
+// We will deprecate this in favour of use loader.LoadSpecs once the new API is stable
 func ParseRedactorsFromDocs(docs []string) ([]*troubleshootv1beta2.Redact, error) {
 	var redactors []*troubleshootv1beta2.Redact
 


### PR DESCRIPTION
## Description, Motivation and Context

Remove deprecation warnings directing people to us `loader.LoadSpecs`. The APIs we mark deprecated do not have a `loader.LoadSpecs` replacement

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
