### PR TITLE
Allow `collect` to chroot itself

### DIFF
--- a/cmd/collect/cli/chroot_darwin.go
+++ b/cmd/collect/cli/chroot_darwin.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"syscall"
+)
+
+func checkAndSetChroot(newroot string) error {
+	if newroot == "" {
+		return nil
+	}
+	if err := syscall.Chroot(newroot); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/collect/cli/chroot_darwin.go
+++ b/cmd/collect/cli/chroot_darwin.go
@@ -1,12 +1,18 @@
 package cli
 
 import (
+	"errors"
 	"syscall"
+
+	"github.com/replicatedhq/troubleshoot/internal/util"
 )
 
 func checkAndSetChroot(newroot string) error {
 	if newroot == "" {
 		return nil
+	}
+	if !util.IsRunningAsRoot() {
+		return errors.New("Can only chroot when run as root")
 	}
 	if err := syscall.Chroot(newroot); err != nil {
 		return err

--- a/cmd/collect/cli/chroot_linux.go
+++ b/cmd/collect/cli/chroot_linux.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"syscall"
+)
+
+func checkAndSetChroot(newroot string) error {
+	if newroot == "" {
+		return nil
+	}
+	if err := syscall.Chroot(newroot); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/collect/cli/chroot_linux.go
+++ b/cmd/collect/cli/chroot_linux.go
@@ -1,12 +1,18 @@
 package cli
 
 import (
+	"errors"
 	"syscall"
+
+	"github.com/replicatedhq/troubleshoot/internal/util"
 )
 
 func checkAndSetChroot(newroot string) error {
 	if newroot == "" {
 		return nil
+	}
+	if !util.IsRunningAsRoot() {
+		return errors.New("Can only chroot when run as root")
 	}
 	if err := syscall.Chroot(newroot); err != nil {
 		return err

--- a/cmd/collect/cli/chroot_windows.go
+++ b/cmd/collect/cli/chroot_windows.go
@@ -1,0 +1,9 @@
+package cli
+
+import (
+	"errors"
+)
+
+func checkAndSetChroot(newroot string) error {
+	return errors.New("chroot is only implimented in linux/darwin")
+}

--- a/cmd/collect/cli/root.go
+++ b/cmd/collect/cli/root.go
@@ -58,7 +58,7 @@ func RootCmd() *cobra.Command {
 	cmd.Flags().String("selector", "", "selector (label query) to filter remote collection nodes on.")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
 	cmd.Flags().Bool("debug", false, "enable debug logging")
-	cmf.Flags().String("chroot", "", "Chroot to path")
+	cmd.Flags().String("chroot", "", "Chroot to path")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")

--- a/cmd/collect/cli/root.go
+++ b/cmd/collect/cli/root.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/replicatedhq/troubleshoot/cmd/internal/util"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
@@ -77,16 +76,6 @@ func RootCmd() *cobra.Command {
 	util.AddProfilingFlags(cmd)
 
 	return cmd
-}
-
-func checkAndSetChroot(newroot string) error {
-	if newroot == "" {
-		return nil
-	}
-	if err := syscall.Chroot(newroot); err != nil {
-		return err
-	}
-	return nil
 }
 
 func InitAndExecute() {

--- a/cmd/collect/cli/root.go
+++ b/cmd/collect/cli/root.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/replicatedhq/troubleshoot/cmd/internal/util"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
@@ -32,6 +33,10 @@ func RootCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
+			if err := checkAndSetChroot(v.GetString("chroot")); err != nil {
+				return err
+			}
+
 			return runCollect(v, args[0])
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
@@ -53,6 +58,7 @@ func RootCmd() *cobra.Command {
 	cmd.Flags().String("selector", "", "selector (label query) to filter remote collection nodes on.")
 	cmd.Flags().Bool("collect-without-permissions", false, "always generate a support bundle, even if it some require additional permissions")
 	cmd.Flags().Bool("debug", false, "enable debug logging")
+	cmf.Flags().String("chroot", "", "Chroot to path")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")
@@ -71,6 +77,16 @@ func RootCmd() *cobra.Command {
 	util.AddProfilingFlags(cmd)
 
 	return cmd
+}
+
+func checkAndSetChroot(newroot string) error {
+	if newroot == "" {
+		return nil
+	}
+	if err := syscall.Chroot(newroot); err != nil {
+		return err
+	}
+	return nil
 }
 
 func InitAndExecute() {


### PR DESCRIPTION
## Description, Motivation and Context

This PR allows the `collect` binary to `chroot` based on a flag, this simplifies running it inside a container where the desired root is at a path other than the containers root without the need to copy the `collect` binary itself onto the host. 


<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
