### PR TITLE
feat: Handle failure to load cluster specs gracefully in support-bundle command

### DIFF
--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -221,10 +221,13 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 	if vp.GetBool("load-cluster-specs") {
 		clusterKinds, err := LoadFromCluster(ctx, client, vp.GetStringSlice("selector"), vp.GetString("namespace"))
 		if err != nil {
-			return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
+			if kinds.IsEmpty() {
+				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
+			}
+			klog.Warningf("failed to load specs from the cluster: %v", err)
+		} else {
+			kinds.Add(clusterKinds)
 		}
-
-		kinds.Add(clusterKinds)
 	}
 
 	return kinds, nil

--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -224,6 +224,7 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 			if kinds.IsEmpty() {
 				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
 			}
+			// TODO: Consider colour coding and graceful failures when loading specs
 			fmt.Printf("failed to load specs from the cluster: %v\n", err)
 		} else {
 			kinds.Add(clusterKinds)

--- a/internal/specs/specs.go
+++ b/internal/specs/specs.go
@@ -224,7 +224,7 @@ func LoadFromCLIArgs(ctx context.Context, client kubernetes.Interface, args []st
 			if kinds.IsEmpty() {
 				return nil, types.NewExitCodeError(constants.EXIT_CODE_SPEC_ISSUES, err)
 			}
-			klog.Warningf("failed to load specs from the cluster: %v", err)
+			fmt.Printf("failed to load specs from the cluster: %v\n", err)
 		} else {
 			kinds.Add(clusterKinds)
 		}


### PR DESCRIPTION
## Description, Motivation and Context

In some scenarios, we don't want to fail when unable to load specs from the cluster. This is particularly useful when:

- A host support bundle is available on disk.
- There are specs defined in the cluster.
- The cluster is malfunctioning or inaccessible.
- We still need to generate a support bundle using only the host specs.
- This change allows users to generate a support bundle even if the embedded cluster is not functioning properly, making the process more resilient.

The primary motivation is to introduce a new command:

```
./embedded-cluster support-bundle
```

When executed, this command attempts to collect both host and cluster specs. However, if the embedded cluster is broken or unavailable, the command will skip loading the cluster specs and focus on the host, ensuring that users can still gather critical information without interruption.

This is how the output looks like:

```
root@wild-field:/home/developer# /var/lib/embedded-cluster/bin/kubectl-support_bundle --load-cluster-specs /var/lib/embedded-cluster/support/host-support-bundle.yaml
failed to load specs from the cluster: failed to check if I can read secrets and configmaps: Post "http://localhost:8080/apis/authorization.k8s.io/v1/selfsubjectaccessreviews": dial tcp 127.0.0.1:8080: connect: connection refused


A support bundle was generated and saved at support-bundle-2024-10-23T09_27_10.tar.gz. Please send this file to your software vendor for support.
root@wild-field:/home/developer#
```