### PR TITLE
feat: Do not prompt users to save support bundle analysis results

### DIFF
--- a/pkg/preflight/interactive_results.go
+++ b/pkg/preflight/interactive_results.go
@@ -130,7 +130,7 @@ func drawFooter() {
 func drawPreflightTable(analyzeResults []*analyzerunner.AnalyzeResult) {
 	termWidth, termHeight := ui.TerminalDimensions()
 
-	table.SetRect(0, 3, termWidth/2, termHeight-6)
+	table.SetRect(0, 3, termWidth/2, termHeight-4)
 	table.FillRow = true
 	table.Border = true
 	table.Rows = [][]string{}


### PR DESCRIPTION
## Description, Motivation and Context

In interactive mode, do not prompt users to save support bundle analysis results. Users end up providing this file instead of the support bundle archive. The analysis results are contained in the support bundle archive already

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1627

Demo: https://asciinema.org/a/hw0j44bwo5jRFllxOJMCmlI67

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
