### PR TITLE
fix(collector): limit run pod collector to delete only one related secret

### DIFF
--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -63,9 +63,9 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (result Collect
 
 	if c.Collector.ImagePullSecret != nil && c.Collector.ImagePullSecret.Data != nil {
 		defer func() {
-			for _, k := range pod.Spec.ImagePullSecrets {
-				if err := client.CoreV1().Secrets(pod.Namespace).Delete(context.Background(), k.Name, metav1.DeleteOptions{}); err != nil {
-					klog.Errorf("Failed to delete secret %s: %v", k.Name, err)
+			if c.Collector.ImagePullSecret.Name != "" {
+				if err := client.CoreV1().Secrets(pod.Namespace).Delete(context.Background(), c.Collector.ImagePullSecret.Name, metav1.DeleteOptions{}); err != nil {
+					klog.Errorf("Failed to delete secret %s: %v", c.Collector.ImagePullSecret.Name, err)
 				}
 			}
 		}()

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -64,7 +64,7 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (result Collect
 	if c.Collector.ImagePullSecret != nil && c.Collector.ImagePullSecret.Data != nil {
 		defer func() {
 			if c.Collector.ImagePullSecret.Name != "" {
-				if err := client.CoreV1().Secrets(pod.Namespace).Delete(context.Background(), c.Collector.ImagePullSecret.Name, metav1.DeleteOptions{}); err != nil {
+				if err := client.CoreV1().Secrets(pod.Namespace).Delete(ctx, c.Collector.ImagePullSecret.Name, metav1.DeleteOptions{}); err != nil {
 					klog.Errorf("Failed to delete secret %s: %v", c.Collector.ImagePullSecret.Name, err)
 				}
 			}


### PR DESCRIPTION
## Description, Motivation and Context
-  stop using range which will delete other image pull secret
- 
<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
