### PR TITLE
[sc-114813] copy HostCollector fails to copy binary files when run in cluster

### DIFF
--- a/pkg/collect/runner.go
+++ b/pkg/collect/runner.go
@@ -351,7 +351,7 @@ func getContainerLogsInternal(ctx context.Context, client kubernetes.Interface, 
 	if err != nil {
 		return nil, err
 	}
-	if strings.Contains(string(logs), "Internal Error") {
+	if bytes.Contains(logs, []byte("Internal Error")) {
 		return nil, fmt.Errorf("Fetched log contains \"Internal Error\": %q", string(logs))
 	}
 

--- a/pkg/collect/runner.go
+++ b/pkg/collect/runner.go
@@ -1,11 +1,11 @@
 package collect
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"


### PR DESCRIPTION
This prevents binary files getting mangled when the collector output is being passed around between functions

## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
