### PR TITLE
fix(analyzer): add missing warning in outcome

### DIFF
--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -121,9 +121,11 @@ func analyzeRegexPattern(pattern string, collected []byte, outcomes []*troublesh
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 	}
 
+	isMatch := re.MatchString(string(collected))
+
 	for _, outcome := range outcomes {
 		if outcome.Fail != nil {
-			isMatch := re.MatchString(string(collected))
+
 			// if the outcome.Fail.When is not set, default to false
 			if outcome.Fail.When == "" {
 				outcome.Fail.When = "false"
@@ -141,7 +143,6 @@ func analyzeRegexPattern(pattern string, collected []byte, outcomes []*troublesh
 				result.URI = outcome.Fail.URI
 			}
 		} else if outcome.Warn != nil {
-			isMatch := re.MatchString(string(collected))
 			// if the outcome.Warn.When is not set, default to false
 			if outcome.Warn.When == "" {
 				outcome.Warn.When = "false"
@@ -158,7 +159,6 @@ func analyzeRegexPattern(pattern string, collected []byte, outcomes []*troublesh
 				result.URI = outcome.Warn.URI
 			}
 		} else if outcome.Pass != nil {
-			isMatch := re.MatchString(string(collected))
 			// if the outcome.Pass.When is not set, default to true
 			if outcome.Pass.When == "" {
 				outcome.Pass.When = "true"

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -115,54 +115,66 @@ func analyzeRegexPattern(pattern string, collected []byte, outcomes []*troublesh
 		return nil, errors.Wrapf(err, "failed to compile regex: %s", pattern)
 	}
 
-	var failOutcome *troubleshootv1beta2.SingleOutcome
-	var passOutcome *troubleshootv1beta2.SingleOutcome
-	for _, outcome := range outcomes {
-		if outcome.Fail != nil {
-			failOutcome = outcome.Fail
-		} else if outcome.Pass != nil {
-			passOutcome = outcome.Pass
-		}
-	}
 	result := AnalyzeResult{
 		Title:   checkName,
 		IconKey: "kubernetes_text_analyze",
 		IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 	}
 
-	reMatch := re.MatchString(string(collected))
-	failWhen := false
-	if failOutcome != nil && failOutcome.When != "" {
-		failWhen, err = strconv.ParseBool(failOutcome.When)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to process when statement: %s", failOutcome.When)
-		}
-	}
-	passWhen := true
-	if passOutcome != nil && passOutcome.When != "" {
-		passWhen, err = strconv.ParseBool(passOutcome.When)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to process when statement: %s", passOutcome.When)
-		}
-	}
+	for _, outcome := range outcomes {
+		if outcome.Fail != nil {
+			isMatch := re.MatchString(string(collected))
+			// if the outcome.Fail.When is not set, default to false
+			if outcome.Fail.When == "" {
+				outcome.Fail.When = "false"
+			}
 
-	if passWhen == failWhen {
-		return nil, errors.Wrap(err, "outcome when conditions for fail and pass are equal")
-	}
+			failWhen, err := strconv.ParseBool(outcome.Fail.When)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to process when statement: %s", outcome.Fail.When)
+			}
 
-	if reMatch == passWhen {
-		result.IsPass = true
-		if passOutcome != nil {
-			result.Message = passOutcome.Message
-			result.URI = passOutcome.URI
+			if isMatch == failWhen {
+				result.IsFail = true
+				result.IsWarn = false
+				result.Message = outcome.Fail.Message
+				result.URI = outcome.Fail.URI
+			}
+		} else if outcome.Warn != nil {
+			isMatch := re.MatchString(string(collected))
+			// if the outcome.Warn.When is not set, default to false
+			if outcome.Warn.When == "" {
+				outcome.Warn.When = "false"
+			}
+
+			warnWhen, err := strconv.ParseBool(outcome.Warn.When)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to process when statement: %s", outcome.Warn.When)
+			}
+
+			if isMatch == warnWhen {
+				result.IsWarn = true
+				result.Message = outcome.Warn.Message
+				result.URI = outcome.Warn.URI
+			}
+		} else if outcome.Pass != nil {
+			isMatch := re.MatchString(string(collected))
+			// if the outcome.Pass.When is not set, default to true
+			if outcome.Pass.When == "" {
+				outcome.Pass.When = "true"
+			}
+
+			passWhen, err := strconv.ParseBool(outcome.Pass.When)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to process when statement: %s", outcome.Pass.When)
+			}
+
+			if isMatch == passWhen {
+				result.IsPass = true
+				result.Message = outcome.Pass.Message
+				result.URI = outcome.Pass.URI
+			}
 		}
-		return &result, nil
-	}
-
-	result.IsFail = true
-	if failOutcome != nil {
-		result.Message = failOutcome.Message
-		result.URI = failOutcome.URI
 	}
 	return &result, nil
 }

--- a/pkg/analyze/text_analyze_test.go
+++ b/pkg/analyze/text_analyze_test.go
@@ -223,6 +223,40 @@ func Test_textAnalyze(t *testing.T) {
 			},
 		},
 		{
+			name: "warn case 1",
+			analyzer: troubleshootv1beta2.TextAnalyze{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "success",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "warning",
+						},
+					},
+				},
+				CollectorName: "text-collector-6",
+				FileName:      "cfile-6.txt",
+				RegexPattern:  "([a-zA-Z0-9\\-_:*\\s])*succe([a-zA-Z0-9\\-_:*\\s!])*",
+			},
+			expectResult: []AnalyzeResult{
+				{
+					IsPass:  false,
+					IsWarn:  true,
+					IsFail:  false,
+					Title:   "text-collector-6",
+					Message: "warning",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+				},
+			},
+			files: map[string][]byte{
+				"text-collector-6/cfile-6.txt": []byte("A different message"),
+			},
+		},
+		{
 			name: "multiple results case 1",
 			analyzer: troubleshootv1beta2.TextAnalyze{
 				Outcomes: []*troubleshootv1beta2.Outcome{
@@ -300,6 +334,56 @@ func Test_textAnalyze(t *testing.T) {
 			files: map[string][]byte{
 				"text-collector-1/cfile-1.txt": []byte("Yes it all succeeded"),
 				"text-collector-1/cfile-2.log": []byte("no success here"),
+				"text-collector-2/cfile-3.txt": []byte("Yes it all succeeded"),
+			},
+		},
+		{
+			name: "multiple results with both warn and fail case 1, only fail",
+			analyzer: troubleshootv1beta2.TextAnalyze{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "pass",
+						},
+					},
+					{
+						Warn: &troubleshootv1beta2.SingleOutcome{
+							Message: "warning",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+						},
+					},
+				},
+				CollectorName: "text-collector-1",
+				FileName:      "cfile",
+				RegexPattern:  "succeeded",
+			},
+			expectResult: []AnalyzeResult{
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "text-collector-1",
+					Message: "pass",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+				},
+				{
+					IsPass:  false,
+					IsWarn:  false,
+					IsFail:  true,
+					Title:   "text-collector-1",
+					Message: "fail",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+				},
+			},
+			files: map[string][]byte{
+				"text-collector-1/cfile-1.txt": []byte("Yes it all succeeded"),
+				"text-collector-1/cfile-2.txt": []byte("no success here"),
 				"text-collector-2/cfile-3.txt": []byte("Yes it all succeeded"),
 			},
 		},


### PR DESCRIPTION
## Description, Motivation and Context

- added missing outcome condition for warning
- added tests for both warning and fail

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->
[sc-115535](https://app.shortcut.com/replicated/story/115535/regex-analyzer-warn-doesn-t-work)

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
