### PR TITLE
[bug] Quick fix for handling non 200 status codes when loading specs from URI

### DIFF
--- a/pkg/supportbundle/load.go
+++ b/pkg/supportbundle/load.go
@@ -252,6 +252,13 @@ func loadSpecFromURL(arg string) ([]byte, error) {
 			}
 			return nil, errors.Wrap(err, "execute request")
 		}
+
+		// handle non 2xx http statuses
+		// redirects appear to already be handled by the go http client
+		if resp.StatusCode != 200 {
+			return nil, errors.New("request returned non 200 response")
+		}
+
 		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)

--- a/pkg/supportbundle/load.go
+++ b/pkg/supportbundle/load.go
@@ -255,6 +255,7 @@ func loadSpecFromURL(arg string) ([]byte, error) {
 
 		// handle non 2xx http statuses
 		// redirects appear to already be handled by the go http client
+		// TODO: handle potential for redirect loops breaking this?
 		if resp.StatusCode != 200 {
 			return nil, errors.New("request returned non 200 response")
 		}


### PR DESCRIPTION
Go http client already handles 3xx responses for us

## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: #1694

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
