### PR TITLE
feat: add support for matchExpressions when filtering for nodes

### DIFF
--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -1186,6 +1186,36 @@ spec:
                               type: string
                             selector:
                               properties:
+                                matchExpressions:
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
                                 matchLabel:
                                   additionalProperties:
                                     type: string

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -1186,6 +1186,36 @@ spec:
                               type: string
                             selector:
                               properties:
+                                matchExpressions:
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
                                 matchLabel:
                                   additionalProperties:
                                     type: string

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -1217,6 +1217,36 @@ spec:
                               type: string
                             selector:
                               properties:
+                                matchExpressions:
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
                                 matchLabel:
                                   additionalProperties:
                                     type: string

--- a/pkg/analyze/node_resources_test.go
+++ b/pkg/analyze/node_resources_test.go
@@ -3,12 +3,13 @@ package analyzer
 import (
 	"testing"
 
-	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
 func Test_compareNodeResourceConditionalToActual(t *testing.T) {
@@ -500,6 +501,130 @@ func Test_nodeMatchesFilters(t *testing.T) {
 				},
 			},
 			expectResult: true,
+		},
+		{
+			name: "true when the label expression matches with operator In",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"value"},
+						},
+					},
+				},
+			},
+			expectResult: true,
+		},
+		{
+			name: "false when the label expression does not match with operator In",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"value2"},
+						},
+					},
+				},
+			},
+			expectResult: false,
+		},
+		{
+			name: "true when the label expression matches with operator NotIn",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"value2"},
+						},
+					},
+				},
+			},
+			expectResult: true,
+		},
+		{
+			name: "false when the label expression does not match with operator NotIn",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"value"},
+						},
+					},
+				},
+			},
+			expectResult: false,
+		},
+		{
+			name: "true when the label expression matches with operator Exists",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+			expectResult: true,
+		},
+		{
+			name: "false when the label expression matches with operator Exists",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label2",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
+			},
+			expectResult: false,
+		},
+		{
+			name: "true when the label expression matches with operator DoesNotExist",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label2",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+					},
+				},
+			},
+			expectResult: true,
+		},
+		{
+			name: "false when the label expression does not match with operator DoesNotExist",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				Selector: &troubleshootv1beta2.NodeResourceSelectors{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "label",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+					},
+				},
+			},
+			expectResult: false,
 		},
 	}
 

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -1,6 +1,8 @@
 package v1beta2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 )
 
@@ -133,7 +135,8 @@ type NodeResourceFilters struct {
 }
 
 type NodeResourceSelectors struct {
-	MatchLabel map[string]string `json:"matchLabel,omitempty" yaml:"matchLabel,omitempty"`
+	MatchLabel       map[string]string                 `json:"matchLabel,omitempty" yaml:"matchLabel,omitempty"`
+	MatchExpressions []metav1.LabelSelectorRequirement `json:"matchExpressions,omitempty" yaml:"matchExpressions,omitempty"`
 }
 
 type TextAnalyze struct {

--- a/pkg/apis/troubleshoot/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/troubleshoot/v1beta2/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta2
 
 import (
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -3406,6 +3407,13 @@ func (in *NodeResourceSelectors) DeepCopyInto(out *NodeResourceSelectors) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.MatchExpressions != nil {
+		in, out := &in.MatchExpressions, &out.MatchExpressions
+		*out = make([]v1.LabelSelectorRequirement, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/schemas/analyzer-troubleshoot-v1beta2.json
+++ b/schemas/analyzer-troubleshoot-v1beta2.json
@@ -1785,6 +1785,35 @@
                       "selector": {
                         "type": "object",
                         "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            }
+                          },
                           "matchLabel": {
                             "type": "object",
                             "additionalProperties": {

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -1785,6 +1785,35 @@
                       "selector": {
                         "type": "object",
                         "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            }
+                          },
                           "matchLabel": {
                             "type": "object",
                             "additionalProperties": {

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -1831,6 +1831,35 @@
                       "selector": {
                         "type": "object",
                         "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            }
+                          },
                           "matchLabel": {
                             "type": "object",
                             "additionalProperties": {


### PR DESCRIPTION
## Description, Motivation and Context

Includes the ability to use a Kubernetes `matchExpressions` label selector for the `nodeResources` analyzer.

I wanted to write pre-flight checks to analyze nodes that contained a specific label and another that negated it. Currently, this is not possible with the `MatchLabel` selector. It would be possible with a `MatchExpressions` label selector by using the negation operators (e.g., `NotIn` / `DoesNotExist`)

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls) - https://github.com/replicatedhq/troubleshoot.sh/pull/595

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
