### PR TITLE
fix(make): improve generate cmd for go mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,15 @@ generate: controller-gen client-gen
 	$(CONTROLLER_GEN) \
 		object:headerFile=./hack/boilerplate.go.txt paths=./pkg/apis/...
 	$(CLIENT_GEN) \
-		--output-base=$$(pwd)/../../../ \
+		--output-base=. \
 		--output-package=github.com/replicatedhq/troubleshoot/pkg/client \
 		--clientset-name troubleshootclientset \
 		--input-base github.com/replicatedhq/troubleshoot/pkg/apis \
 		--input troubleshoot/v1beta1 \
 		--input troubleshoot/v1beta2 \
 		-h ./hack/boilerplate.go.txt
+	cp -r github.com/replicatedhq/troubleshoot/pkg/client/troubleshootclientset pkg/client
+	rm -rf github.com
 
 .PHONY: openapischema
 openapischema: controller-gen


### PR DESCRIPTION
## Description, Motivation and Context
- solve `make generate` only works with GOPATH

Demo PR: https://github.com/replicatedhq/troubleshoot/pull/1700
This demo show if you change a scheme like add `GenerateTest` field in `pkg/apis/troubleshoot/v1beta2/hostcollector_shared.go`

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
