### PR TITLE
feat: add support for GPU resources

### DIFF
--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -1176,6 +1176,10 @@ spec:
                               type: string
                             ephemeralStorageCapacity:
                               type: string
+                            gpuAllocatable:
+                              type: string
+                            gpuCapacity:
+                              type: string
                             memoryAllocatable:
                               type: string
                             memoryCapacity:

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -1176,6 +1176,10 @@ spec:
                               type: string
                             ephemeralStorageCapacity:
                               type: string
+                            gpuAllocatable:
+                              type: string
+                            gpuCapacity:
+                              type: string
                             memoryAllocatable:
                               type: string
                             memoryCapacity:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -1207,6 +1207,10 @@ spec:
                               type: string
                             ephemeralStorageCapacity:
                               type: string
+                            gpuAllocatable:
+                              type: string
+                            gpuCapacity:
+                              type: string
                             memoryAllocatable:
                               type: string
                             memoryCapacity:

--- a/pkg/analyze/node_resources_test.go
+++ b/pkg/analyze/node_resources_test.go
@@ -404,6 +404,7 @@ func Test_nodeMatchesFilters(t *testing.T) {
 				"hugepages-2Mi":              resource.MustParse("0"),
 				"memory":                     resource.MustParse("7951376Ki"),
 				"pods":                       resource.MustParse("29"),
+				gpuResourceName:              resource.MustParse("1"),
 			},
 			Allocatable: corev1.ResourceList{
 				"attachable-volumes-aws-ebs": resource.MustParse("25"),
@@ -413,6 +414,7 @@ func Test_nodeMatchesFilters(t *testing.T) {
 				"hugepages-2Mi":              resource.MustParse("0"),
 				"memory":                     resource.MustParse("7848976Ki"),
 				"pods":                       resource.MustParse("29"),
+				gpuResourceName:              resource.MustParse("1"),
 			},
 		},
 	}
@@ -623,6 +625,38 @@ func Test_nodeMatchesFilters(t *testing.T) {
 						},
 					},
 				},
+			},
+			expectResult: false,
+		},
+		{
+			name: "true when gpu capacity is available",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				GPUCapacity: "1",
+			},
+			expectResult: true,
+		},
+		{
+			name: "true when allocatable gpu is available",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				GPUAllocatable: "1",
+			},
+			expectResult: true,
+		},
+		{
+			name: "false when gpu capacity is not available",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				GPUCapacity: "2",
+			},
+			expectResult: false,
+		},
+		{
+			name: "false when allocatable gpu is not available",
+			node: node,
+			filters: &troubleshootv1beta2.NodeResourceFilters{
+				GPUAllocatable: "2",
 			},
 			expectResult: false,
 		},

--- a/pkg/analyze/node_resources_test.go
+++ b/pkg/analyze/node_resources_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_compareNodeResourceConditionalToActual(t *testing.T) {
 	nodeData := []corev1.Node{
-		corev1.Node{
+		{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Node",
@@ -28,16 +28,18 @@ func Test_compareNodeResourceConditionalToActual(t *testing.T) {
 					"ephemeral-storage": resource.MustParse("20959212Ki"),
 					"memory":            resource.MustParse("3999Ki"),
 					"pods":              resource.MustParse("15"),
+					gpuResourceName:     resource.MustParse("4"),
 				},
 				Allocatable: corev1.ResourceList{
 					"cpu":               resource.MustParse("1.5"),
 					"ephemeral-storage": resource.MustParse("19316009748"),
 					"memory":            resource.MustParse("16Ki"),
 					"pods":              resource.MustParse("14"),
+					gpuResourceName:     resource.MustParse("4"),
 				},
 			},
 		},
-		corev1.Node{
+		{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Node",
@@ -365,6 +367,70 @@ func Test_compareNodeResourceConditionalToActual(t *testing.T) {
 			totalNodeCount: len(nodeData),
 			expected:       false,
 			isError:        true,
+		},
+		{
+			name:           "sum(gpuCapacity) > 1 (true)",
+			conditional:    "sum(gpuCapacity) > 1",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       true,
+			isError:        false,
+		},
+		{
+			name:           "sum(gpuCapacity) >= 8 (false)",
+			conditional:    "sum(gpuCapacity) >= 8",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       false,
+			isError:        false,
+		},
+		{
+			name:           "min(gpuCapacity) > 1 (false)",
+			conditional:    "min(gpuCapacity) > 1",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       false,
+			isError:        false,
+		},
+		{
+			name:           "min(gpuAllocatable) > 1 (false)",
+			conditional:    "min(gpuAllocatable) > 1",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       false,
+			isError:        false,
+		},
+		{
+			name:           "max(gpuCapacity) == 4 (true)",
+			conditional:    "max(gpuCapacity) == 4",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       true,
+			isError:        false,
+		},
+		{
+			name:           "max(gpuAllocatable) == 4 (true)",
+			conditional:    "max(gpuAllocatable) == 4",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       true,
+			isError:        false,
+		},
+		{
+			name:           "sum(gpuAllocatable) > 1 (true)",
+			conditional:    "sum(gpuAllocatable) > 1",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       true,
+			isError:        false,
+		},
+		{
+			name:           "sum(gpuAllocatable) >= 8 (false)",
+			conditional:    "sum(gpuAllocatable) >= 8",
+			matchingNodes:  nodeData,
+			totalNodeCount: len(nodeData),
+			expected:       false,
+			isError:        false,
 		},
 	}
 

--- a/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/analyzer_shared.go
@@ -131,6 +131,8 @@ type NodeResourceFilters struct {
 	PodAllocatable              string                 `json:"podAllocatable,omitempty" yaml:"podAllocatable,omitempty"`
 	EphemeralStorageCapacity    string                 `json:"ephemeralStorageCapacity,omitempty" yaml:"ephemeralStorageCapacity,omitempty"`
 	EphemeralStorageAllocatable string                 `json:"ephemeralStorageAllocatable,omitempty" yaml:"ephemeralStorageAllocatable,omitempty"`
+	GPUCapacity                 string                 `json:"gpuCapacity,omitempty" yaml:"gpuCapacity,omitempty"`
+	GPUAllocatable              string                 `json:"gpuAllocatable,omitempty" yaml:"gpuAllocatable,omitempty"`
 	Selector                    *NodeResourceSelectors `json:"selector,omitempty" yaml:"selector,omitempty"`
 }
 

--- a/schemas/analyzer-troubleshoot-v1beta2.json
+++ b/schemas/analyzer-troubleshoot-v1beta2.json
@@ -1770,6 +1770,12 @@
                       "ephemeralStorageCapacity": {
                         "type": "string"
                       },
+                      "gpuAllocatable": {
+                        "type": "string"
+                      },
+                      "gpuCapacity": {
+                        "type": "string"
+                      },
                       "memoryAllocatable": {
                         "type": "string"
                       },

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -1770,6 +1770,12 @@
                       "ephemeralStorageCapacity": {
                         "type": "string"
                       },
+                      "gpuAllocatable": {
+                        "type": "string"
+                      },
+                      "gpuCapacity": {
+                        "type": "string"
+                      },
                       "memoryAllocatable": {
                         "type": "string"
                       },

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -1816,6 +1816,12 @@
                       "ephemeralStorageCapacity": {
                         "type": "string"
                       },
+                      "gpuAllocatable": {
+                        "type": "string"
+                      },
+                      "gpuCapacity": {
+                        "type": "string"
+                      },
                       "memoryAllocatable": {
                         "type": "string"
                       },


### PR DESCRIPTION
## Description, Motivation and Context

`nvidia.com/gpu` is a common resource for many AI applications, but currently, Troubleshoot does not allow users to check the availability of GPUs in their cluster. 

I've considered taking a more generic approach with a function `resourceName(<resource>)`, but decided against it because it would either require taking in the units as a parameter `resourceName(<resource>, <units>)` or default to something like `DecimalSI`, which could lead to errors for certain resources.

For simplicity, I decided to go with the more explicit approach. 

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
