### PR TITLE
feat: save YAML spec used to generate support bundle/preflight

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,8 @@ const (
 	DEFAULT_CLIENT_USER_AGENT = "ReplicatedTroubleshoot"
 	// VERSION_FILENAME is the name of the file that contains the support bundle version.
 	VERSION_FILENAME = "version.yaml"
+	// SPEC_FILENAME is the name of the file that contains the support bundle/preflight spec.
+	SPEC_FILENAME = "spec.yaml"
 	// DEFAULT_LOGS_COLLECTOR_TIMEOUT is the default timeout for logs collector.
 	DEFAULT_LOGS_COLLECTOR_TIMEOUT = 60 * time.Second
 	// MAX_TIME_TO_WAIT_FOR_POD_DELETION is the maximum time to wait for pod deletion.

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -470,6 +470,15 @@ func getRedactors(path string) ([]Redactor, error) {
 		}
 	}
 
+	// redact final YAML spec used to generate the support bundle/preflight
+	// redact TLS private key if any
+	// todo: any other TLS keys to redact?
+	tlsKeys := []string{"clientKey"}
+	for _, key := range tlsKeys {
+		yamlPath := fmt.Sprintf("spec.collectors.*.*.tls.%s", key)
+		redactors = append(redactors, NewYamlRedactor(yamlPath, constants.SPEC_FILENAME, "Redact TLS private key"))
+	}
+
 	return redactors, nil
 }
 

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -475,8 +475,13 @@ func getRedactors(path string) ([]Redactor, error) {
 	// todo: any other TLS keys to redact?
 	tlsKeys := []string{"clientKey"}
 	for _, key := range tlsKeys {
-		yamlPath := fmt.Sprintf("spec.collectors.*.*.tls.%s", key)
-		redactors = append(redactors, NewYamlRedactor(yamlPath, constants.SPEC_FILENAME, "Redact TLS private key"))
+		yamlPaths := []string{
+			fmt.Sprintf("spec.collectors.*.*.tls.%s", key),   // Database collector
+			fmt.Sprintf("spec.collectors.*.*.*.tls.%s", key), // HTTP collector
+		}
+		for _, yamlPath := range yamlPaths {
+			redactors = append(redactors, NewYamlRedactor(yamlPath, constants.SPEC_FILENAME, "Redact TLS private key"))
+		}
 	}
 
 	return redactors, nil

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -349,7 +349,11 @@ func saveAndRedactFinalSpec(spec *troubleshootv1beta2.SupportBundleSpec, result 
 		constants.SPEC_FILENAME: []byte(yamlContent),
 	}
 
-	err = collect.RedactResult(bundlePath, singleResult, additionalRedactors.Spec.Redactors)
+	var redactors []*troubleshootv1beta2.Redact
+	if additionalRedactors != nil {
+		redactors = additionalRedactors.Spec.Redactors
+	}
+	err = collect.RedactResult(bundlePath, singleResult, redactors)
 	if err != nil {
 		return errors.Wrap(err, "failed to redact final support bundle yaml spec")
 	}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -344,7 +344,7 @@ func saveAndRedactFinalSpec(spec *troubleshootv1beta2.SupportBundleSpec, result 
 		return errors.Wrap(err, "failed to write final support bundle yaml spec")
 	}
 
-	// react the final YAML spec
+	// redact the final YAML spec
 	singleResult := map[string][]byte{
 		constants.SPEC_FILENAME: []byte(yamlContent),
 	}

--- a/pkg/supportbundle/supportbundle_test.go
+++ b/pkg/supportbundle/supportbundle_test.go
@@ -130,6 +130,11 @@ func Test_saveAndRedactFinalSpec(t *testing.T) {
 				ClusterResources: &troubleshootv1beta2.ClusterResources{},
 				Postgres: &troubleshootv1beta2.Database{
 					URI: "postgresql://user:password@hostname:5432/defaultdb?sslmode=require",
+					TLS: &troubleshootv1beta2.TLSParams{
+						CACert:     `CA CERT`,
+						ClientCert: `CLIENT CERT`,
+						ClientKey:  `PRIVATE KEY`,
+					},
 				},
 			},
 		},
@@ -147,8 +152,13 @@ spec:
   - clusterInfo: {}
     clusterResources: {}
     postgres:
-     uri: postgresql://***HIDDEN***:***HIDDEN***@***HIDDEN***:5432/***HIDDEN***
-status: {}`
+      uri: postgresql://***HIDDEN***:***HIDDEN***@***HIDDEN***:5432/***HIDDEN***
+      tls:
+        cacert: CA CERT
+        clientCert: CLIENT CERT
+        clientKey: "***HIDDEN***"
+status: {}
+`
 
 	err := saveAndRedactFinalSpec(spec, &result, bundlePath, nil)
 	if err != nil {

--- a/pkg/supportbundle/supportbundle_test.go
+++ b/pkg/supportbundle/supportbundle_test.go
@@ -136,6 +136,14 @@ func Test_saveAndRedactFinalSpec(t *testing.T) {
 						ClientKey:  `PRIVATE KEY`,
 					},
 				},
+				HTTP: &troubleshootv1beta2.HTTP{
+					Get: &troubleshootv1beta2.Get{
+						URL: "http:api:3000/healthz",
+						TLS: &troubleshootv1beta2.TLSParams{
+							ClientKey: `PRIVATE KEY`,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -157,6 +165,11 @@ spec:
         cacert: CA CERT
         clientCert: CLIENT CERT
         clientKey: "***HIDDEN***"
+    http:
+      get:
+        url: http:api:3000/healthz
+        tls:
+          clientKey: "***HIDDEN***"
 status: {}
 `
 

--- a/pkg/supportbundle/supportbundle_test.go
+++ b/pkg/supportbundle/supportbundle_test.go
@@ -1,10 +1,17 @@
 package supportbundle
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -113,4 +120,48 @@ func Test_getNodeList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_saveAndRedactFinalSpec(t *testing.T) {
+	spec := &troubleshootv1beta2.SupportBundleSpec{
+		Collectors: []*troubleshootv1beta2.Collect{
+			{
+				ClusterInfo:      &troubleshootv1beta2.ClusterInfo{},
+				ClusterResources: &troubleshootv1beta2.ClusterResources{},
+				Postgres: &troubleshootv1beta2.Database{
+					URI: "postgresql://user:password@hostname:5432/defaultdb?sslmode=require",
+				},
+			},
+		},
+	}
+
+	result := make(collect.CollectorResult)
+	bundlePath := t.TempDir()
+	expectedYAML := `
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  creationTimestamp: null
+spec:
+  collectors:
+  - clusterInfo: {}
+    clusterResources: {}
+    postgres:
+     uri: postgresql://***HIDDEN***:***HIDDEN***@***HIDDEN***:5432/***HIDDEN***
+status: {}`
+
+	err := saveAndRedactFinalSpec(spec, &result, bundlePath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualYAML, err := os.ReadFile(filepath.Join(bundlePath, constants.SPEC_FILENAME))
+	require.NoError(t, err)
+
+	var expectedData, actualData interface{}
+	err = yaml.Unmarshal([]byte(expectedYAML), &expectedData)
+	require.NoError(t, err)
+	err = yaml.Unmarshal(actualYAML, &actualData)
+	require.NoError(t, err)
+	assert.Equal(t, expectedData, actualData)
 }


### PR DESCRIPTION
## Description, Motivation and Context

As of now, it is not possible to know which final YAML spec is used to generate a support bundle.
Knowing the spec used to generate a support bundle will aid with further troubleshooting, to understand the content of a support bundle, e.g. which collectors, analyzers are used, any render, conditional error?

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Demo: https://asciinema.org/a/rTzxKjMRQezLAfNpTLEqJGESZ

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
