### PR TITLE
fix: [sc-116508] [Troubleshoot] support-bundle load-spec from URI field logic is fragile

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -273,6 +273,13 @@ func loadSupportBundleSpecsFromURIs(ctx context.Context, kinds *loader.Troublesh
 			continue
 		}
 
+		if len(k.SupportBundlesV1Beta2) == 0 {
+			// add back original spec
+			moreKinds.SupportBundlesV1Beta2 = append(moreKinds.SupportBundlesV1Beta2, s)
+			klog.Warningf("no support bundle spec found in URI: %s", s.Spec.Uri)
+			continue
+		}
+
 		// finally append the uri spec
 		moreKinds.SupportBundlesV1Beta2 = append(moreKinds.SupportBundlesV1Beta2, k.SupportBundlesV1Beta2...)
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/116508
Demo: https://asciinema.org/a/jHxsEzwu3wnQ3xccJtkSp5JOb

This PR ensure that we fallback to original spec if the provided URI is malformed.
