### PR TITLE
fix: [sc-118962] Unable to Retrieve TLS Parameters from Kubernetes Secrets with the Postgres Collector

### DIFF
--- a/pkg/collect/util.go
+++ b/pkg/collect/util.go
@@ -208,20 +208,20 @@ func getTLSParamsFromSecret(ctx context.Context, client kubernetes.Interface, se
 		return "", "", "", errors.Wrap(err, "failed to get secret")
 	}
 
-	if val, ok := secret.StringData["cacert"]; ok {
-		caCert = val
+	if val, ok := secret.Data["cacert"]; ok {
+		caCert = string(val)
 	} else {
 		return "", "", "", fmt.Errorf("failed to find 'cacert' key for CA cert data in secret")
 	}
 
 	var foundClientCert, foundClientKey bool
-	if val, ok := secret.StringData["clientCert"]; ok {
-		clientCert = val
+	if val, ok := secret.Data["clientCert"]; ok {
+		clientCert = string(val)
 		foundClientCert = true
 	}
 
-	if val, ok := secret.StringData["clientKey"]; ok {
-		clientKey = val
+	if val, ok := secret.Data["clientKey"]; ok {
+		clientKey = string(val)
 		foundClientKey = true
 	}
 

--- a/pkg/collect/util_test.go
+++ b/pkg/collect/util_test.go
@@ -270,13 +270,18 @@ func createTLSSecret(t *testing.T, client kubernetes.Interface, secretData map[s
 	secretName := "secret-name-" + randStringRunes(20)
 	namespace := "namespace-" + randStringRunes(20)
 
+	data := make(map[string][]byte)
+	for k, v := range secretData {
+		data[k] = []byte(v)
+	}
+
 	_, err := client.CoreV1().Secrets(namespace).Create(
 		context.Background(),
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretName,
 			},
-			StringData: secretData,
+			Data: data,
 		},
 		metav1.CreateOptions{},
 	)


### PR DESCRIPTION
Story details: https://app.shortcut.com/replicated/story/118962

Changing from reading secret from `StringData` to `Data` field.

From K8S API doc

```
        // stringData allows specifying non-binary secret data in string form.
	// It is provided as a write-only input field for convenience.
	// All keys and values are merged into the data field on write, overwriting any existing values.
	// The stringData field is never output when reading from the API.
	// +k8s:conversion-gen=false
	// +optional
	StringData map[[string](https://pkg.go.dev/builtin#string)][string](https://pkg.go.dev/builtin#string) `json:"stringData,omitempty" protobuf:"bytes,4,rep,name=stringData"`
```