### PR TITLE
chore: updates to make targets for building binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,16 +257,16 @@ npm-install:
 ######## Lagacy make targets ###########
 # Deprecated: These can be removed
 .PHONY: support-bundle
-support-bundle: clean bin/support-bundle
+support-bundle: bin/support-bundle
 
 .PHONY: preflight
-preflight: clean bin/preflight
+preflight: bin/preflight
 
 .PHONY: analyze
-analyze: clean bin/analyze
+analyze: bin/analyze
 
 .PHONY: collect
-collect: clean bin/collect
+collect: bin/collect
 
 .PHONY: run-troubleshoot
 run-troubleshoot: run-support-bundle


### PR DESCRIPTION
## Description, Motivation and Context

- When someone runs for example `make support-bundle`, any previous binaries such as `analyze` or `preflight` are deleted. This is unnecessary and leads to needing to rebuild them when needed. This PR removes automatically deleting them
- Add ability to detect if source code files would have changed before attempting to build binaries

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
