### PR TITLE
fix(preflights): support for builtin kernel modules

### DIFF
--- a/pkg/collect/host_kernel_modules_test.go
+++ b/pkg/collect/host_kernel_modules_test.go
@@ -2,6 +2,7 @@ package collect
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -160,6 +161,54 @@ func TestCollectHostKernelModules_Collect(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CollectHostKernelModules.Collect() = \n%v, want \n%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseBuiltin(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    map[string]KernelModuleInfo
+	}{
+		{
+			name:    "empty",
+			content: "",
+			want:    map[string]KernelModuleInfo{},
+		},
+		{
+			name: "basic",
+			content: `kernel/arch/x86/events/rapl.ko
+kernel/arch/x86/events/amd/amd-uncore.ko
+kernel/arch/x86/events/intel/intel-uncore.ko
+kernel/arch/x86/events/intel/intel-cstate.ko`,
+			want: map[string]KernelModuleInfo{
+				"rapl": {
+					Status: KernelModuleLoaded,
+				},
+				"amd-uncore": {
+					Status: KernelModuleLoaded,
+				},
+				"intel-uncore": {
+					Status: KernelModuleLoaded,
+				},
+				"intel-cstate": {
+					Status: KernelModuleLoaded,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := kernelModulesLoaded{}
+			got, err := l.parseBuiltin(strings.NewReader(tt.content))
+			if err != nil {
+				t.Errorf("parseBuiltin() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseBuiltin() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description, Motivation and Context

kernelModule host collector does not take into account the `modules.builtin` file.

Collector and analyzer fail on some hosts with modules built in.

```
[   33.194758] cloud-init[974]: ✗  4 host preflights failed
[   33.195554] cloud-init[974]:  •  The 'overlay' kernel module is not loaded or loadable
[   33.196514] cloud-init[974]:  •  The 'ip_tables' kernel module is not loaded or loadable
[   33.196950] cloud-init[974]:  •  The 'br_netfilter' kernel module is not loaded or loadable
[   33.197368] cloud-init[974]:  •  The 'nf_conntrack' kernel module is not loaded or loadable
[   33.197597] cloud-init[974]: Please address these issues and try again.
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
