### PR TITLE
fix(preflights): builtin kernel modules file may be not found

### DIFF
--- a/pkg/collect/host_kernel_modules.go
+++ b/pkg/collect/host_kernel_modules.go
@@ -230,6 +230,9 @@ func (l kernelModulesLoaded) collectBuiltin() (map[string]KernelModuleInfo, erro
 
 	file, err := os.Open(fmt.Sprintf("/usr/lib/modules/%s/modules.builtin", kernel))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	defer file.Close()


### PR DESCRIPTION
## Description, Motivation and Context

If the file does not exist the collector will fail.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
