### PR TITLE
fix(host-preflights): builtin kernel modules file from wrong path

### DIFF
--- a/pkg/collect/host_collector.go
+++ b/pkg/collect/host_collector.go
@@ -69,7 +69,9 @@ func GetHostCollector(collector *troubleshootv1beta2.HostCollect, bundlePath str
 			hostCollector: collector.KernelModules,
 			BundlePath:    bundlePath,
 			loadable:      kernelModulesLoadable{},
-			loaded:        kernelModulesLoaded{},
+			loaded: kernelModulesLoaded{
+				fs: os.DirFS("/"),
+			},
 		}, true
 	case collector.TCPConnect != nil:
 		return &CollectHostTCPConnect{collector.TCPConnect, bundlePath}, true

--- a/pkg/collect/host_kernel_modules.go
+++ b/pkg/collect/host_kernel_modules.go
@@ -128,6 +128,7 @@ func (l kernelModulesLoadable) collect(kernelRelease string) (map[string]KernelM
 	if _, err := os.Stat(kernelPath); os.IsNotExist(err) {
 		kernelPath = filepath.Join("/usr/lib/modules", kernelRelease)
 		if _, err := os.Stat(kernelPath); os.IsNotExist(err) {
+			kernelPath = filepath.Join("/lib/modules", kernelRelease)
 			klog.V(2).Infof("kernel modules are not loadable because path %q does not exist, assuming we are in a container", kernelPath)
 			return modules, nil
 		}
@@ -231,6 +232,7 @@ func (l kernelModulesLoaded) collectBuiltin(kernelRelease string) (map[string]Ke
 	if _, err := fs.Stat(l.fs, builtinPath); os.IsNotExist(err) {
 		builtinPath = filepath.Join("usr/lib/modules", kernelRelease, "modules.builtin")
 		if _, err := fs.Stat(l.fs, builtinPath); os.IsNotExist(err) {
+			builtinPath = filepath.Join("lib/modules", kernelRelease, "modules.builtin")
 			klog.V(2).Infof("kernel builtin modules path %q does not exist, assuming we are in a container", builtinPath)
 			return nil, nil
 		}

--- a/pkg/collect/host_kernel_modules.go
+++ b/pkg/collect/host_kernel_modules.go
@@ -124,9 +124,9 @@ type kernelModulesLoadable struct{}
 func (l kernelModulesLoadable) collect(kernelRelease string) (map[string]KernelModuleInfo, error) {
 	modules := make(map[string]KernelModuleInfo)
 
-	kernelPath := filepath.Join("/lib/modules/", kernelRelease)
+	kernelPath := filepath.Join("/lib/modules", kernelRelease)
 	if _, err := os.Stat(kernelPath); os.IsNotExist(err) {
-		kernelPath = filepath.Join("/usr/lib/modules/", kernelRelease)
+		kernelPath = filepath.Join("/usr/lib/modules", kernelRelease)
 		if _, err := os.Stat(kernelPath); os.IsNotExist(err) {
 			klog.V(2).Infof("kernel modules are not loadable because path %q does not exist, assuming we are in a container", kernelPath)
 			return modules, nil
@@ -227,9 +227,9 @@ func (l kernelModulesLoaded) collectProc() (map[string]KernelModuleInfo, error) 
 }
 
 func (l kernelModulesLoaded) collectBuiltin(kernelRelease string) (map[string]KernelModuleInfo, error) {
-	builtinPath := filepath.Join("lib/modules/", kernelRelease, "modules.builtin")
+	builtinPath := filepath.Join("lib/modules", kernelRelease, "modules.builtin")
 	if _, err := fs.Stat(l.fs, builtinPath); os.IsNotExist(err) {
-		builtinPath = filepath.Join("usr/lib/modules/", kernelRelease, "modules.builtin")
+		builtinPath = filepath.Join("usr/lib/modules", kernelRelease, "modules.builtin")
 		if _, err := fs.Stat(l.fs, builtinPath); os.IsNotExist(err) {
 			klog.V(2).Infof("kernel builtin modules path %q does not exist, assuming we are in a container", builtinPath)
 			return nil, nil

--- a/pkg/collect/host_kernel_modules.go
+++ b/pkg/collect/host_kernel_modules.go
@@ -228,7 +228,7 @@ func (l kernelModulesLoaded) collectBuiltin() (map[string]KernelModuleInfo, erro
 	}
 	kernel := strings.TrimSpace(string(out))
 
-	file, err := os.Open(fmt.Sprintf("/usr/lib/modules/%s/modules.builtin", kernel))
+	file, err := os.Open(fmt.Sprintf("/lib/modules/%s/modules.builtin", kernel))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil


### PR DESCRIPTION
## Description, Motivation and Context

Path is wrong for some systems.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
