### PR TITLE
fix(redact): multi-line redactors strip empty lines

### DIFF
--- a/pkg/redact/multi_line.go
+++ b/pkg/redact/multi_line.go
@@ -76,7 +76,7 @@ func (r *MultiLineRedactor) Redact(input io.Reader, path string) io.Reader {
 					if err != nil {
 						return
 					}
-					line1, line2, err = getNextTwoLines(reader, line2)
+					line1, line2, err = getNextTwoLines(reader, &line2)
 					flushLastLine = true
 					continue
 				}
@@ -89,7 +89,7 @@ func (r *MultiLineRedactor) Redact(input io.Reader, path string) io.Reader {
 				if err != nil {
 					return
 				}
-				line1, line2, err = getNextTwoLines(reader, line2)
+				line1, line2, err = getNextTwoLines(reader, &line2)
 				flushLastLine = true
 				continue
 			}
@@ -127,7 +127,7 @@ func (r *MultiLineRedactor) Redact(input io.Reader, path string) io.Reader {
 	return out
 }
 
-func getNextTwoLines(reader *bufio.Reader, curLine2 []byte) (line1 []byte, line2 []byte, err error) {
+func getNextTwoLines(reader *bufio.Reader, curLine2 *[]byte) (line1 []byte, line2 []byte, err error) {
 	line2 = []byte{}
 
 	if curLine2 == nil {
@@ -140,7 +140,7 @@ func getNextTwoLines(reader *bufio.Reader, curLine2 []byte) (line1 []byte, line2
 		return
 	}
 
-	line1 = curLine2
+	line1 = *curLine2
 	line2, err = readLine(reader)
 	if err != nil {
 		return

--- a/pkg/redact/multi_line_test.go
+++ b/pkg/redact/multi_line_test.go
@@ -94,6 +94,16 @@ func Test_NewMultiLineRedactor(t *testing.T) {
 "key": "***HIDDEN***"
 `,
 		},
+		{
+			name: "Multiple newlines with no match",
+			selector: LineRedactor{
+				regex: `(?i)"name": *"[^\"]*SECRET_?ACCESS_?KEY[^\"]*"`,
+				scan:  `secret_?access_?key`,
+			},
+			redactor:    `(?i)("value": *")(?P<mask>.*[^\"]*)(")`,
+			inputString: "no match\n\n no match \n\n",
+			wantString:  "no match\n\n no match \n\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/redact/single_line_test.go
+++ b/pkg/redact/single_line_test.go
@@ -308,6 +308,16 @@ func TestNewSingleLineRedactor(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "Multiple newlines with no match",
+			re:          `abcd`,
+			inputString: "no match\n\n no match \n\n",
+			wantString:  "no match\n\n no match \n\n",
+			wantRedactions: RedactionList{
+				ByRedactor: map[string][]Redaction{},
+				ByFile:     map[string][]Redaction{},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description, Motivation and Context

Multi-line redactors strip empty lines since an empty byte slice == nil

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
