### PR TITLE
Ability to use sprig functions in analyzer templates

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -94,7 +95,7 @@ func IsInCluster() bool {
 // RenderTemplate renders a template and returns the result as a string
 func RenderTemplate(tpl string, data interface{}) (string, error) {
 	// Create a new template and parse the letter into it
-	t, err := template.New("data").Parse(tpl)
+	t, err := template.New("data").Funcs(sprig.FuncMap()).Parse(tpl)
 	if err != nil {
 		return "", err
 	}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -284,6 +284,20 @@ func TestRenderTemplate(t *testing.T) {
 			want:    "Hello, <no value>!",
 			wantErr: false,
 		},
+		{
+			name:    "template with sprig function works",
+			tpl:     "{{ \"hello \" | upper }}{{ .Name }}",
+			data:    map[string]string{"Name": "World"},
+			want:    "HELLO World",
+			wantErr: false,
+		},
+		{
+			name:    "template with undefined sprig function errors",
+			tpl:     "{{ \"hello \" | upp }}{{ .Name }}",
+			data:    map[string]string{"Name": "World"},
+			want:    "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/analyze/cluster_container_statuses.go
+++ b/pkg/analyze/cluster_container_statuses.go
@@ -1,15 +1,14 @@
 package analyzer
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
-	"text/template"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/troubleshoot/internal/util"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -240,21 +239,14 @@ func renderContainerMessage(message string, info *matchedContainerInfo) string {
 	if info == nil {
 		return message
 	}
+
 	out := fmt.Sprintf("Container matched. Container: %s, Namespace: %s, Pod: %s", info.ContainerName, info.Namespace, info.PodName)
 
-	tmpl := template.New("container")
-	msgTmpl, err := tmpl.Parse(message)
-	if err != nil {
-		klog.V(2).Infof("failed to parse message template: %v", err)
-		return out
-	}
-
-	var m bytes.Buffer
-	err = msgTmpl.Execute(&m, info)
+	renderedMsg, err := util.RenderTemplate(message, info)
 	if err != nil {
 		klog.V(2).Infof("failed to render message template: %v", err)
 		return out
 	}
 
-	return strings.TrimSpace(m.String())
+	return strings.TrimSpace(renderedMsg)
 }

--- a/pkg/analyze/host_filesystem_performance.go
+++ b/pkg/analyze/host_filesystem_performance.go
@@ -1,15 +1,14 @@
 package analyzer
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/troubleshoot/internal/util"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/collect"
 )
@@ -171,18 +170,12 @@ func doCompareHostFilesystemPerformance(operator string, actual time.Duration, d
 }
 
 func renderFSPerfOutcome(outcome string, fsPerf collect.FSPerfResults) string {
-	t, err := template.New("").Parse(outcome)
-	if err != nil {
-		log.Printf("Failed to parse filesystem performance outcome: %v", err)
-		return outcome
-	}
-	var buf bytes.Buffer
-	err = t.Execute(&buf, fsPerf)
+	rendered, err := util.RenderTemplate(outcome, fsPerf)
 	if err != nil {
 		log.Printf("Failed to render filesystem performance outcome: %v", err)
 		return outcome
 	}
-	return buf.String()
+	return rendered
 }
 
 func (a *AnalyzeHostFilesystemPerformance) analyzeSingleNode(content collectedContent, currentTitle string) ([]*AnalyzeResult, error) {

--- a/pkg/analyze/k8s_node_metrics.go
+++ b/pkg/analyze/k8s_node_metrics.go
@@ -1,16 +1,15 @@
 package analyzer
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/troubleshoot/internal/util"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"k8s.io/klog/v2"
 	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
@@ -299,18 +298,11 @@ func renderTemplate(tmpMsg string, data any) string {
 		return tmpMsg
 	}
 
-	t, err := template.New("msg").Parse(tmpMsg)
+	rendered, err := util.RenderTemplate(tmpMsg, data)
 	if err != nil {
-		klog.V(2).Infof("Failed to parse template: %s", err)
+		klog.V(2).Infof("Failed to render template: %s", err)
 		return tmpMsg
 	}
 
-	var m bytes.Buffer
-	err = t.Execute(&m, data)
-	if err != nil {
-		klog.V(2).Infof("Failed to execute template: %s", err)
-		return tmpMsg
-	}
-
-	return m.String()
+	return rendered
 }

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -1,15 +1,14 @@
 package analyzer
 
 import (
-	"bytes"
 	"fmt"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/troubleshoot/internal/util"
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 )
 
@@ -210,7 +209,7 @@ func analyzeRegexGroups(pattern string, collected []byte, outcomes []*troublesho
 
 			if isMatch {
 				result.IsFail = true
-				tplMessage, err := templateRegExGroup(outcome.Fail.Message, foundMatches)
+				tplMessage, err := util.RenderTemplate(outcome.Fail.Message, foundMatches)
 				if err != nil {
 					return result, errors.Wrap(err, "failed to template message in outcome.Fail block")
 				}
@@ -227,7 +226,7 @@ func analyzeRegexGroups(pattern string, collected []byte, outcomes []*troublesho
 
 			if isMatch {
 				result.IsWarn = true
-				tplMessage, err := templateRegExGroup(outcome.Warn.Message, foundMatches)
+				tplMessage, err := util.RenderTemplate(outcome.Warn.Message, foundMatches)
 				if err != nil {
 					return result, errors.Wrap(err, "failed to template message in outcome.Warn block")
 				}
@@ -244,7 +243,7 @@ func analyzeRegexGroups(pattern string, collected []byte, outcomes []*troublesho
 
 			if isMatch {
 				result.IsPass = true
-				tplMessage, err := templateRegExGroup(outcome.Pass.Message, foundMatches)
+				tplMessage, err := util.RenderTemplate(outcome.Pass.Message, foundMatches)
 				if err != nil {
 					return result, errors.Wrap(err, "failed to template message in outcome.Pass block")
 				}
@@ -257,20 +256,6 @@ func analyzeRegexGroups(pattern string, collected []byte, outcomes []*troublesho
 	}
 
 	return result, nil
-}
-
-// templateRegExGroup takes a tpl and replaces the variables using matches.
-func templateRegExGroup(tpl string, matches map[string]string) (string, error) {
-	t, err := template.New("").Parse(tpl)
-	if err != nil {
-		return "", err
-	}
-	var msg bytes.Buffer
-	err = t.Execute(&msg, matches)
-	if err != nil {
-		return "", err
-	}
-	return msg.String(), nil
 }
 
 func compareRegex(conditional string, foundMatches map[string]string) (bool, error) {

--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -272,6 +272,11 @@ func compareRegex(conditional string, foundMatches map[string]string) (bool, err
 	operator := parts[1]
 	lookForValue := parts[2]
 
+	// handle empty strings
+	if lookForValue == "''" || lookForValue == `""` {
+		lookForValue = ""
+	}
+
 	foundValue, ok := foundMatches[lookForMatchName]
 	if !ok {
 		// not an error, just wasn't matched


### PR DESCRIPTION
## Description, Motivation and Context

This change adds support for using Sprig template functions in analyzer templates. The Sprig library provides a comprehensive set of template functions that are commonly used in Go templating, which will give users more flexibility and power when writing analyzer templates.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No