### PR TITLE
feat: add CPU architecture check and template support

### DIFF
--- a/test-cpu-arch.yaml
+++ b/test-cpu-arch.yaml
@@ -1,0 +1,17 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: cpu-arch-test
+spec:
+  hostCollectors:
+    - cpu: {}
+  hostAnalyzers:
+    - cpu:
+        checkName: "Check machine architecture"
+        outcomes:
+          - fail:
+              when: "machineArch != x86_64"
+              message: "Current architecture {{ Info.MachineArch }} is not supported"
+          - pass:
+              message: "Architecture {{ Info.MachineArch }} is supported"
+


### PR DESCRIPTION
## Description, Motivation and Context

Adds template support for CPU architecture in analyzer messages, allowing dynamic insertion of the machine architecture value using {{ Info.MachineArch }}. This enhances the existing CPU analyzer by making messages more informative and customizable.

Fixes: #1584

## Checklist
- [x] New and existing tests pass locally with introduced changes
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow conventional commits format: "feat: add CPU architecture check and template support"
- [x] Documentation updates not required as this extends existing functionality

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
