### PR TITLE
Remove the hard coding of the cosign release [sc-77445]

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -234,8 +234,6 @@ jobs:
           go-version: "1.23"
 
       - uses: sigstore/cosign-installer@v3.8.1
-        with:
-          cosign-release: "v2.4.3"  # Binary version to install
 
       - name: Get Cosign Key
         run: |


### PR DESCRIPTION
## Description, Motivation and Context

Removing the hardcoded version of the cosign-library in the cosign GHA. The version defaults to the version we need: https://github.com/sigstore/cosign-installer/blob/main/action.yml#L13