### PR TITLE
Log namespace when analyzing deployment status

### DIFF
--- a/pkg/analyze/deployment_status.go
+++ b/pkg/analyze/deployment_status.go
@@ -21,7 +21,7 @@ func (a *AnalyzeDeploymentStatus) Title() string {
 	}
 
 	if a.analyzer.Name != "" && a.analyzer.Namespace != "" {
-		return fmt.Sprintf("%s/%s Deployment Status", a.analyzer.Name, a.analyzer.Name)
+		return fmt.Sprintf("%s/%s Deployment Status", a.analyzer.Namespace, a.analyzer.Name)
 	}
 
 	if a.analyzer.Name != "" {


### PR DESCRIPTION
Simply fixes an issue with the support bundle log message for deployment status