### PR TITLE
Handling the case when the Cluster Analyzer doesn't find a resource

### DIFF
--- a/pkg/analyze/files/support-bundle/cluster-resources/namespaces.json
+++ b/pkg/analyze/files/support-bundle/cluster-resources/namespaces.json
@@ -1,0 +1,206 @@
+{
+  "kind": "NamespaceList",
+  "apiVersion": "v1",
+  "metadata": {
+    "resourceVersion": "10270"
+  },
+  "items": [
+    {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "default",
+        "uid": "a70276f2-a14e-494a-ba66-31548e09da6e",
+        "resourceVersion": "67",
+        "creationTimestamp": "2025-03-13T20:09:31Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "default"
+        },
+        "managedFields": [
+          {
+            "manager": "kube-apiserver",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2025-03-13T20:09:31Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:labels": {
+                  ".": {},
+                  "f:kubernetes.io/metadata.name": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "kube-node-lease",
+        "uid": "77f4b65c-0cf1-4c5f-8d0d-cce5bcd4b7a4",
+        "resourceVersion": "103",
+        "creationTimestamp": "2025-03-13T20:09:31Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "kube-node-lease"
+        },
+        "managedFields": [
+          {
+            "manager": "kube-apiserver",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2025-03-13T20:09:31Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:labels": {
+                  ".": {},
+                  "f:kubernetes.io/metadata.name": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "kube-public",
+        "uid": "b6b29c1d-e278-4916-a644-a4fcd9330654",
+        "resourceVersion": "65",
+        "creationTimestamp": "2025-03-13T20:09:31Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "kube-public"
+        },
+        "managedFields": [
+          {
+            "manager": "kube-apiserver",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2025-03-13T20:09:31Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:labels": {
+                  ".": {},
+                  "f:kubernetes.io/metadata.name": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "kube-system",
+        "uid": "00470492-1276-40ff-9642-ba40327ffed6",
+        "resourceVersion": "11",
+        "creationTimestamp": "2025-03-13T20:09:31Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "kube-system"
+        },
+        "managedFields": [
+          {
+            "manager": "kube-apiserver",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2025-03-13T20:09:31Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:labels": {
+                  ".": {},
+                  "f:kubernetes.io/metadata.name": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "kind": "Namespace",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "local-path-storage",
+        "uid": "7a0660de-14e9-4aad-bc4d-3d78f0cc6619",
+        "resourceVersion": "305",
+        "creationTimestamp": "2025-03-13T20:09:35Z",
+        "labels": {
+          "kubernetes.io/metadata.name": "local-path-storage"
+        },
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-storage\"}}\n"
+        },
+        "managedFields": [
+          {
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "apiVersion": "v1",
+            "time": "2025-03-13T20:09:35Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                },
+                "f:labels": {
+                  ".": {},
+                  "f:kubernetes.io/metadata.name": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Failed"
+      }
+    }
+  ]
+}

--- a/pkg/analyze/kube_resource.go
+++ b/pkg/analyze/kube_resource.go
@@ -246,12 +246,14 @@ func (a *AnalyzeClusterResource) analyzeResource(analyzer *troubleshootv1beta2.C
 	selected, err := FindResource(analyzer.Kind, analyzer.ClusterScoped, analyzer.Namespace, analyzer.Name, getFileContents)
 	if err != nil {
 		klog.Errorf("failed to find resource: %v", err)
+	}
+	if err != nil || selected == nil {
 		return &AnalyzeResult{
 			Title:   a.Title(),
 			IconKey: "kubernetes_text_analyze",
 			IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 			IsFail:  true,
-			Message: "resource does not exist",
+			Message: fmt.Sprintf("%s %s does not exist", analyzer.Kind, analyzer.Name),
 		}, nil
 	}
 

--- a/pkg/analyze/kube_resource.go
+++ b/pkg/analyze/kube_resource.go
@@ -248,12 +248,18 @@ func (a *AnalyzeClusterResource) analyzeResource(analyzer *troubleshootv1beta2.C
 		klog.Errorf("failed to find resource: %v", err)
 	}
 	if err != nil || selected == nil {
+		var message string
+		if analyzer.ClusterScoped {
+			message = fmt.Sprintf("%s %s does not exist", analyzer.Kind, analyzer.Name)
+		} else {
+			message = fmt.Sprintf("%s %s in namespace %s does not exist", analyzer.Kind, analyzer.Name, analyzer.Namespace)
+		}
 		return &AnalyzeResult{
 			Title:   a.Title(),
 			IconKey: "kubernetes_text_analyze",
 			IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 			IsFail:  true,
-			Message: fmt.Sprintf("%s %s does not exist", analyzer.Kind, analyzer.Name),
+			Message: message,
 		}, nil
 	}
 

--- a/pkg/analyze/kube_resource_test.go
+++ b/pkg/analyze/kube_resource_test.go
@@ -191,7 +191,7 @@ func Test_analyzeResource(t *testing.T) {
 				IsWarn:  false,
 				IsFail:  true,
 				Title:   "check-pvc-exists",
-				Message: "YAML path provided is invalid",
+				Message: "PersistentVolumeClaim data-postgresql-00 does not exist",
 				IconKey: "kubernetes_text_analyze",
 				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 			},
@@ -333,6 +333,111 @@ func Test_analyzeResource(t *testing.T) {
 				Message: "fail",
 				IconKey: "kubernetes_text_analyze",
 				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg?w=13&h=16",
+			},
+		},
+		{
+			name: "pass when namespace exists",
+			analyzer: troubleshootv1beta2.ClusterResource{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "namespace-check",
+				},
+				Kind:          "namespace",
+				Name:          "kube-node-lease",
+				ClusterScoped: true,
+				YamlPath:      "status.phase",
+				RegexPattern:  "Active",
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "true",
+							Message: "pass",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+						},
+					},
+				},
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  true,
+				IsWarn:  false,
+				IsFail:  false,
+				Title:   "namespace-check",
+				Message: "pass",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+			},
+		},
+		{
+			name: "fail when the namespace does not match the regex",
+			analyzer: troubleshootv1beta2.ClusterResource{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "namespace-check",
+				},
+				Kind:          "namespace",
+				Name:          "local-path-storage",
+				ClusterScoped: true,
+				YamlPath:      "status.phase",
+				RegexPattern:  "Active",
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "true",
+							Message: "pass",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "my custom fail message",
+						},
+					},
+				},
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  false,
+				IsWarn:  false,
+				IsFail:  true,
+				Title:   "namespace-check",
+				Message: "my custom fail message",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+			},
+		},
+		{
+			name: "fail when the namespace does not exist",
+			analyzer: troubleshootv1beta2.ClusterResource{
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "namespace-check",
+				},
+				Kind:          "namespace",
+				Name:          "foobar",
+				ClusterScoped: true,
+				YamlPath:      "status.phase",
+				RegexPattern:  "Active",
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "true",
+							Message: "pass",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							Message: "fail",
+						},
+					},
+				},
+			},
+			expectResult: AnalyzeResult{
+				IsPass:  false,
+				IsWarn:  false,
+				IsFail:  true,
+				Title:   "namespace-check",
+				Message: "namespace foobar does not exist",
+				IconKey: "kubernetes_text_analyze",
+				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 			},
 		},
 	}

--- a/pkg/analyze/kube_resource_test.go
+++ b/pkg/analyze/kube_resource_test.go
@@ -191,7 +191,7 @@ func Test_analyzeResource(t *testing.T) {
 				IsWarn:  false,
 				IsFail:  true,
 				Title:   "check-pvc-exists",
-				Message: "PersistentVolumeClaim data-postgresql-00 does not exist",
+				Message: "PersistentVolumeClaim data-postgresql-00 in namespace default does not exist",
 				IconKey: "kubernetes_text_analyze",
 				IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
 			},


### PR DESCRIPTION
## Description, Motivation and Context

When using the clusterResourceAnalyzer to check if a resource exists, we show a misleading message about the YAML path being incorrect. This PR fixes this by providing a meaningful Fail message if a resource by the specified name cannot be found. E.g.:

`namespace foobar does not exist`

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
