### PR TITLE
fix(collect.runPod): does not delete image pull secrets without name in spec

### DIFF
--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -111,7 +111,7 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (result Collect
 	}
 }
 
-func (c *CollectRunPod) deleteImagePullSecret(ctx context.Context, client *kubernetes.Clientset, pod *corev1.Pod) {
+func (c *CollectRunPod) deleteImagePullSecret(ctx context.Context, client kubernetes.Interface, pod *corev1.Pod) {
 	for _, k := range pod.Spec.ImagePullSecrets {
 		secret, err := client.CoreV1().Secrets(pod.Namespace).Get(ctx, k.Name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -62,13 +62,7 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (result Collect
 	}()
 
 	if c.Collector.ImagePullSecret != nil && c.Collector.ImagePullSecret.Data != nil {
-		defer func() {
-			if c.Collector.ImagePullSecret.Name != "" {
-				if err := client.CoreV1().Secrets(pod.Namespace).Delete(ctx, c.Collector.ImagePullSecret.Name, metav1.DeleteOptions{}); err != nil {
-					klog.Errorf("Failed to delete secret %s: %v", c.Collector.ImagePullSecret.Name, err)
-				}
-			}
-		}()
+		defer c.deleteImagePullSecret(context.Background(), client, pod)
 	}
 
 	defer func() {
@@ -114,6 +108,30 @@ func (c *CollectRunPod) Collect(progressChan chan<- interface{}) (result Collect
 		return result, nil
 	case err := <-errCh:
 		return result, err
+	}
+}
+
+func (c *CollectRunPod) deleteImagePullSecret(ctx context.Context, client *kubernetes.Clientset, pod *corev1.Pod) {
+	for _, k := range pod.Spec.ImagePullSecrets {
+		secret, err := client.CoreV1().Secrets(pod.Namespace).Get(ctx, k.Name, metav1.GetOptions{})
+		if err != nil {
+			if kuberneteserrors.IsNotFound(err) {
+				klog.V(2).Infof("Secret %s in namespace %s not found", k.Name, pod.Namespace)
+			} else {
+				klog.Errorf("Failed to get secret %s in namespace %s: %v", k.Name, pod.Namespace, err)
+			}
+			continue
+		}
+		for _, label := range secret.Labels {
+			if label == "app.kubernetes.io/managed-by=troubleshoot.sh" {
+				if err := client.CoreV1().Secrets(pod.Namespace).Delete(context.Background(), k.Name, metav1.DeleteOptions{}); err != nil {
+					klog.Errorf("Failed to delete secret %s in namespace %s: %v", k.Name, pod.Namespace, err)
+				} else {
+					klog.V(2).Infof("Deleted secret %s in namespace %s", k.Name, pod.Namespace)
+				}
+				break
+			}
+		}
 	}
 }
 

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -122,14 +122,11 @@ func (c *CollectRunPod) deleteImagePullSecret(ctx context.Context, client *kuber
 			}
 			continue
 		}
-		for _, label := range secret.Labels {
-			if label == "app.kubernetes.io/managed-by=troubleshoot.sh" {
-				if err := client.CoreV1().Secrets(pod.Namespace).Delete(context.Background(), k.Name, metav1.DeleteOptions{}); err != nil {
-					klog.Errorf("Failed to delete secret %s in namespace %s: %v", k.Name, pod.Namespace, err)
-				} else {
-					klog.V(2).Infof("Deleted secret %s in namespace %s", k.Name, pod.Namespace)
-				}
-				break
+		if secret.Labels["app.kubernetes.io/managed-by"] == "troubleshoot.sh" {
+			if err := client.CoreV1().Secrets(pod.Namespace).Delete(context.Background(), k.Name, metav1.DeleteOptions{}); err != nil {
+				klog.Errorf("Failed to delete secret %s in namespace %s: %v", k.Name, pod.Namespace, err)
+			} else {
+				klog.V(2).Infof("Deleted secret %s in namespace %s", k.Name, pod.Namespace)
 			}
 		}
 	}


### PR DESCRIPTION
## Description, Motivation and Context

If the image pull secret in the spec does not have a name and instead uses generate name it will not get deleted. This pertains to all secrets injected by kots.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
