### PR TITLE
feat: add timestamps flag to logs collector

### DIFF
--- a/config/crds/troubleshoot.replicated.com_collectors.yaml
+++ b/config/crds/troubleshoot.replicated.com_collectors.yaml
@@ -252,6 +252,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        timestamps:
+                          type: boolean
                       required:
                       - selector
                       type: object

--- a/config/crds/troubleshoot.replicated.com_collectors.yaml
+++ b/config/crds/troubleshoot.replicated.com_collectors.yaml
@@ -252,8 +252,6 @@ spec:
                           items:
                             type: string
                           type: array
-                        timestamps:
-                          type: boolean
                       required:
                       - selector
                       type: object

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -562,6 +562,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        timestamps:
+                          type: boolean
                       required:
                       - selector
                       type: object

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -2382,6 +2382,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        timestamps:
+                          type: boolean
                       required:
                       - selector
                       type: object

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -2413,6 +2413,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        timestamps:
+                          type: boolean
                       required:
                       - selector
                       type: object

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -83,6 +83,7 @@ type Logs struct {
 	Namespace      string     `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	ContainerNames []string   `json:"containerNames,omitempty" yaml:"containerNames,omitempty"`
 	Limits         *LogLimits `json:"limits,omitempty" yaml:"limits,omitempty"`
+	Timestamps     bool       `json:"timestamps,omitempty" yaml:"timestamps,omitempty"`
 }
 
 type Data struct {

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -183,7 +183,7 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 				// that is too old/not relevant.
 				MaxBytes: 5000000,
 			}
-			podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, "", container.Name, limits, false, false)
+			podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, "", container.Name, limits, false, false, false)
 			if err != nil {
 				errPath := filepath.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_PODS_LOGS, pod.Namespace, pod.Name, fmt.Sprintf("%s-logs-errors.log", container.Name))
 				output.SaveResult(c.BundlePath, errPath, bytes.NewBuffer([]byte(err.Error())))

--- a/pkg/collect/logs.go
+++ b/pkg/collect/logs.go
@@ -81,7 +81,7 @@ func (c *CollectLogs) CollectWithClient(progressChan chan<- interface{}, client 
 			}
 
 			for _, containerName := range containerNames {
-				podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
+				podLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true, c.Collector.Timestamps)
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) {
 						klog.Errorf("Pod logs timed out for pod %s and container %s: %v", pod.Name, containerName, err)
@@ -100,7 +100,7 @@ func (c *CollectLogs) CollectWithClient(progressChan chan<- interface{}, client 
 			}
 		} else {
 			for _, containerName := range c.Collector.ContainerNames {
-				containerLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true)
+				containerLogs, err := savePodLogs(ctx, c.BundlePath, client, &pod, c.Collector.Name, containerName, c.Collector.Limits, false, true, c.Collector.Timestamps)
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) {
 						klog.Errorf("Pod logs timed out for pod %s and container %s: %v", pod.Name, containerName, err)
@@ -144,10 +144,12 @@ func savePodLogs(
 	limits *troubleshootv1beta2.LogLimits,
 	follow bool,
 	createSymLinks bool,
+	timestamps bool,
 ) (CollectorResult, error) {
 	podLogOpts := corev1.PodLogOptions{
-		Follow:    follow,
-		Container: container,
+		Follow:     follow,
+		Container:  container,
+		Timestamps: timestamps,
 	}
 
 	result := NewResult()

--- a/pkg/collect/logs_test.go
+++ b/pkg/collect/logs_test.go
@@ -103,6 +103,7 @@ func Test_savePodLogs(t *testing.T) {
 		withContainerName bool
 		collectorName     string
 		createSymLinks    bool
+		timestamps        bool
 		want              CollectorResult
 	}{
 		{
@@ -150,6 +151,16 @@ func Test_savePodLogs(t *testing.T) {
 				"cluster-resources/pods/logs/my-namespace/test-pod/nginx-previous.log": []byte("fake logs"),
 			},
 		},
+		{
+			name:              "with timestamps",
+			withContainerName: true,
+			collectorName:     "all-logs",
+			timestamps:        true,
+			want: CollectorResult{
+				"cluster-resources/pods/logs/my-namespace/test-pod/nginx.log":          []byte("fake logs"),
+				"cluster-resources/pods/logs/my-namespace/test-pod/nginx-previous.log": []byte("fake logs"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -165,7 +176,7 @@ func Test_savePodLogs(t *testing.T) {
 			if !tt.withContainerName {
 				containerName = ""
 			}
-			got, err := savePodLogs(ctx, "", client, pod, tt.collectorName, containerName, limits, false, tt.createSymLinks)
+			got, err := savePodLogs(ctx, "", client, pod, tt.collectorName, containerName, limits, false, tt.createSymLinks, tt.timestamps)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -202,7 +202,7 @@ func runWithoutTimeout(ctx context.Context, bundlePath string, clientConfig *res
 		MaxLines: 10000,
 		MaxBytes: 5000000,
 	}
-	podLogs, err := savePodLogs(ctx, bundlePath, client, pod, collectorName, "", &limits, true, true)
+	podLogs, err := savePodLogs(ctx, bundlePath, client, pod, collectorName, "", &limits, true, true, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pod logs")
 	}

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -792,6 +792,9 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "timestamps": {
+                    "type": "boolean"
                   }
                 }
               },

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -3578,6 +3578,9 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "timestamps": {
+                    "type": "boolean"
                   }
                 }
               },

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -3624,6 +3624,9 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "timestamps": {
+                    "type": "boolean"
                   }
                 }
               },


### PR DESCRIPTION
## Description, Motivation and Context

Kubernetes logs can be transmitted with the captured timestamps. This is useful for containers that do not log with timestamps. So I'm exposing that as a flag.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
