### PR TITLE
Follow logs when using runDaemonSet and runPod collectors

### DIFF
--- a/pkg/collect/run_pod.go
+++ b/pkg/collect/run_pod.go
@@ -390,6 +390,7 @@ func RunPodLogs(ctx context.Context, client v1.CoreV1Interface, podSpec *corev1.
 	// 3. Logs
 	podLogOpts := corev1.PodLogOptions{
 		Container: pod.Spec.Containers[0].Name,
+		Follow:    true,
 	}
 	req := client.Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
 	logs, err := req.Stream(ctx)


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

`runDaemonSet` collector does not include entire pod log due to a race condition.  To reproduce, run  support bundle with this spec:

```
apiVersion: troubleshoot.sh/v1beta2
kind: SupportBundle
metadata:
  name: connectivity
spec:
  collectors:
    - clusterResources:
        exclude: true
    - clusterInfo:
        exclude: true
    - runDaemonSet:
        name: connectivity
        namespace: default
        podSpec:
          containers:
            - name: wget
              image: busybox:1
              command: ["wget"]
              args: ["-O", "-", "https://docs.replicated.com"]
  analyzers:
    - textAnalyze:
        checkName: "connectivity"
        fileName: connectivity/*.log
        regex: 'title=\"Replicated Docs\"'
        outcomes:
          - pass:
              when: "true"
              message: Successful download from from https://docs.replicated.com
          - fail:
              message: Was unable to download from https://docs.replicated.com
```

This will result in this analyzer error even though the site was reached successfully:

```
                "detail": "Was unable to download from https://docs.replicated.com",
                "severity": "error"
```

In the support bundle, the file will contain only the beginning of the log.

This was reproduces with `kind` distiribution

```
$ kubectl version
Client Version: v1.32.3
Kustomize Version: v5.5.0
Server Version: v1.33.0
```


## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Potentially this can change time it takes to collect logs and introduce potential timeouts. However, this only affects `runPod` and `runDaemonSet` collectors, which intended to spin up ephemeral containers. Other log collector has its own "follow" flag control.