### PR TITLE
Making the HTTP Collector tests more robust.

### DIFF
--- a/pkg/collect/http.go
+++ b/pkg/collect/http.go
@@ -213,7 +213,7 @@ func responseToOutput(response *http.Response, err error) ([]byte, error) {
 		var rawJSON json.RawMessage
 		if len(body) > 0 {
 			if err := json.Unmarshal(body, &rawJSON); err != nil {
-				klog.Infof("failed to unmarshal response body as JSON: %+v", err)
+				klog.Infof("response body is not in JSON format: %+v", err)
 				rawJSON = json.RawMessage{}
 			}
 		} else {


### PR DESCRIPTION
Previously, the certificate-mismatch test result was masked by the timeout test result

## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
