### PR TITLE
chore: use go.mod file in actions setup-go

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -30,12 +30,6 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     steps:
-      - name: setup env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
-
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -50,11 +44,6 @@ jobs:
   ensure-schemas-are-generated:
     runs-on: ubuntu-latest
     steps:
-      - name: setup env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -67,11 +56,6 @@ jobs:
   compile-preflight:
     runs-on: ubuntu-latest
     steps:
-      - name: setup env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -108,11 +92,6 @@ jobs:
   compile-supportbundle:
     runs-on: ubuntu-latest
     steps:
-      - name: setup env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -163,11 +142,6 @@ jobs:
   compile-collect:
     runs-on: ubuntu-latest
     steps:
-      - name: setup env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -30,10 +30,6 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
       - name: setup env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -41,6 +37,9 @@ jobs:
         shell: bash
 
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - uses: replicatedhq/action-k3s@main
         id: k3s
         with:
@@ -51,9 +50,6 @@ jobs:
   ensure-schemas-are-generated:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
       - name: setup env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -62,23 +58,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          path: github.com/replicatedhq/troubleshoot
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - run: |
-          cd github.com/replicatedhq/troubleshoot
           make check-schemas
 
   compile-preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
       - name: setup env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - run: make generate preflight
       - uses: actions/upload-artifact@v4
         with:
@@ -111,15 +108,15 @@ jobs:
   compile-supportbundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
       - name: setup env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - run: make generate support-bundle
       - uses: actions/upload-artifact@v4
         with:
@@ -142,7 +139,7 @@ jobs:
           path: bin/
       - run: chmod +x bin/support-bundle
       - run: make support-bundle-e2e-test
-  
+
   # Additional e2e tests for support bundle that run in Go, these create a Kind cluster
   validate-supportbundle-e2e-go:
      runs-on: ubuntu-latest
@@ -166,15 +163,15 @@ jobs:
   compile-collect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
       - name: setup env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - run: make generate collect
       - uses: actions/upload-artifact@v4
         with:
@@ -201,7 +198,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -231,7 +228,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: 'go.mod'
 
       - uses: sigstore/cosign-installer@v3.9.1
 


### PR DESCRIPTION
## Description, Motivation and Context

In GH action to setup go environment, pick go version from `go.mod` file instead of hardcoding it. This will reduce chances of forgetting to update version in all places.

Github actions will also use the exact version specified in `go.mod` to build and test the project

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
