### PR TITLE
fix(host-analyze): certificate analyzer wrong file path

### DIFF
--- a/pkg/analyze/host_certificate.go
+++ b/pkg/analyze/host_certificate.go
@@ -30,7 +30,7 @@ func (a *AnalyzeHostCertificate) Analyze(
 	}
 
 	const nodeBaseDir = "host-collectors/certificate"
-	localPath := fmt.Sprintf("%s/%s", nodeBaseDir, collectorName)
+	localPath := fmt.Sprintf("%s/%s.json", nodeBaseDir, collectorName)
 	fileName := fmt.Sprintf("%s.json", collectorName)
 
 	collectedContents, err := retrieveCollectedContents(


### PR DESCRIPTION
## Description, Motivation and Context

Collector file path is wrong leading to preflight failures

```
[FAIL] Certificate Key Pair: Analyzer Failed: analyze: failed to get node list: file host-collectors/system/node_list.json was not collected
[FAIL] Certificate Key Pair: Analyzer Failed: analyze: failed to get node list: file host-collectors/system/node_list.json was not collected
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
