### PR TITLE
chore: fix noisy info logs

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -140,7 +140,7 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 		go func() {
 			defer wg.Done()
 			for msg := range progressChan {
-				klog.Infof("Collecting support bundle: %v", msg)
+				klog.V(2).Infof("Collecting support bundle: %v", msg)
 			}
 		}()
 	} else {

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -140,7 +140,7 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 		go func() {
 			defer wg.Done()
 			for msg := range progressChan {
-				klog.V(2).Infof("Collecting support bundle: %v", msg)
+				klog.Infof("Collecting support bundle: %v", msg)
 			}
 		}()
 	} else {

--- a/pkg/analyze/analyzer.go
+++ b/pkg/analyze/analyzer.go
@@ -80,7 +80,7 @@ func HostAnalyze(
 
 	isExcluded, _ := analyzer.IsExcluded()
 	if isExcluded {
-		klog.Infof("excluding %q analyzer", analyzer.Title())
+		klog.V(1).Infof("excluding %q analyzer", analyzer.Title())
 		span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 		return nil
 	}
@@ -124,7 +124,7 @@ func Analyze(
 
 	analyzerInst := GetAnalyzer(analyzer)
 	if analyzerInst == nil {
-		klog.Info("Non-existent analyzer found in the spec. Please double-check the spelling and indentation of the analyzers in the spec.")
+		klog.V(1).Info("Non-existent analyzer found in the spec. Please double-check the spelling and indentation of the analyzers in the spec.")
 		return nil, nil
 	}
 
@@ -138,7 +138,7 @@ func Analyze(
 		return nil, err
 	}
 	if isExcluded {
-		klog.Infof("excluding %q analyzer", analyzerInst.Title())
+		klog.V(1).Infof("excluding %q analyzer", analyzerInst.Title())
 		span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 		return nil, nil
 	}

--- a/pkg/collect/ceph.go
+++ b/pkg/collect/ceph.go
@@ -246,7 +246,7 @@ func findRookCephToolsPod(ctx context.Context, c *CollectCeph, namespace string)
 		return &pods[0], nil
 	}
 
-	klog.Info("rook ceph tools pod not found")
+	klog.V(1).Info("rook ceph tools pod not found")
 
 	return nil, nil
 }

--- a/pkg/collect/etcd.go
+++ b/pkg/collect/etcd.go
@@ -105,7 +105,7 @@ func (c *CollectEtcd) Collect(progressChan chan<- interface{}) (CollectorResult,
 		fileName := generateFilenameFromCommand(command)
 		stdout, stderr, err := debugInstance.executeCommand(command)
 		if err != nil {
-			klog.Infof("failed to exec command %s: %v", command, err)
+			klog.V(2).Infof("failed to exec command %s: %v", command, err)
 			continue
 		}
 		if len(stdout) > 0 {

--- a/pkg/collect/http.go
+++ b/pkg/collect/http.go
@@ -213,7 +213,7 @@ func responseToOutput(response *http.Response, err error) ([]byte, error) {
 		var rawJSON json.RawMessage
 		if len(body) > 0 {
 			if err := json.Unmarshal(body, &rawJSON); err != nil {
-				klog.Infof("failed to unmarshal response body as JSON: %+v", err)
+				klog.V(2).Infof("failed to unmarshal response body as JSON: %+v", err)
 				rawJSON = json.RawMessage{}
 			}
 		} else {

--- a/pkg/collect/registry.go
+++ b/pkg/collect/registry.go
@@ -117,7 +117,7 @@ func imageExists(namespace string, clientConfig *rest.Config, registryCollector 
 
 		remoteImage, err := imageRef.NewImage(context.Background(), &sysCtx)
 		if err == nil {
-			klog.Infof("image %s exists", image)
+			klog.V(2).Infof("image %s exists", image)
 			remoteImage.Close()
 			return true, nil
 		}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -67,8 +67,17 @@ func InitKlog(verbosity int) {
 
 // SetupLogger sets up klog logger based on viper configuration.
 func SetupLogger(v *viper.Viper) {
-	quiet := v.GetBool("debug") || v.IsSet("v")
-	SetQuiet(!quiet)
+	shouldShowLogs := v.GetBool("debug") || v.IsSet("v")
+	SetQuiet(!shouldShowLogs)
+
+	// If verbosity is set, configure klog verbosity level
+	if v.IsSet("v") {
+		verbosity := v.GetInt("v")
+		if verbosity > 0 {
+			// Use the existing InitKlog function to set verbosity
+			InitKlog(verbosity)
+		}
+	}
 }
 
 // SetQuiet enables or disables klog logger.

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -243,7 +243,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 
 		isExcluded, _ := collector.IsExcluded()
 		if isExcluded {
-			klog.Infof("excluding %q collector", collector.Title())
+			klog.V(1).Infof("excluding %q collector", collector.Title())
 			span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 			span.End()
 			continue

--- a/pkg/supportbundle/load.go
+++ b/pkg/supportbundle/load.go
@@ -80,7 +80,7 @@ func ParseSupportBundle(doc []byte, followURI bool) (*troubleshootv1beta2.Suppor
 		// use the upstream spec, otherwise fall back to
 		// what's defined in the current spec
 		if supportBundle.Spec.Uri != "" && followURI {
-			klog.Infof("using upstream reference: %+v\n", supportBundle.Spec.Uri)
+			klog.V(1).Infof("using upstream reference: %+v\n", supportBundle.Spec.Uri)
 			upstreamSupportBundleContent, err := LoadSupportBundleSpec(supportBundle.Spec.Uri)
 			if err != nil {
 				klog.Errorf("failed to load upstream supportbundle, falling back")


### PR DESCRIPTION
## Description, Motivation and Context

Suppress noisy info level logs that shouldn't be shown by default

```
I0709 12:47:08.463600   22133 analyzer.go:83] excluding "Ephemeral Disk Usage /var/lib/docker" analyzer
I0709 12:47:08.463630   22133 analyzer.go:83] excluding "Ephemeral Disk Usage /var/lib/rook" analyzer
I0709 12:47:08.463636   22133 analyzer.go:83] excluding "Ephemeral Disk Usage /var/openebs" analyzer
I0709 12:47:08.463641   22133 analyzer.go:83] excluding "Kubernetes API Server Load Balancer" analyzer
I0709 12:47:08.463645   22133 analyzer.go:83] excluding "Kubernetes API Server Load Balancer Upgrade" analyzer
I0709 12:47:08.463649   22133 analyzer.go:83] excluding "Kubernetes API TCP Port Status" analyzer
I0709 12:47:08.463653   22133 analyzer.go:83] excluding "ETCD Client API TCP Port Status" analyzer
I0709 12:47:08.463657   22133 analyzer.go:83] excluding "ETCD Server API TCP Port Status" analyzer
I0709 12:47:08.463660   22133 analyzer.go:83] excluding "ETCD Health Server TCP Port Status" analyzer
I0709 12:47:08.463664   22133 analyzer.go:83] excluding "Kubelet Health Server TCP Port Status" analyzer
I0709 12:47:08.463668   22133 analyzer.go:83] excluding "Kubelet API TCP Port Status" analyzer
I0709 12:47:08.463672   22133 analyzer.go:83] excluding "Kube Controller Manager Health Server TCP Port Status" analyzer
I0709 12:47:08.463676   22133 analyzer.go:83] excluding "Kube Scheduler Health Server TCP Port Status" analyzer
I0709 12:47:08.463680   22133 analyzer.go:83] excluding "Kubernetes API TCP Connection Status" analyzer
I0709 12:47:08.463684   22133 analyzer.go:83] excluding "Filesystem Performance" analyzer
I0709 12:47:08.463710   22133 analyzer.go:83] excluding "Docker Support" analyzer
I0709 12:47:08.463715   22133 analyzer.go:83] excluding "Containerd and Weave Compatibility" analyzer
I0709 12:47:08.463718   22133 analyzer.go:83] excluding "Kots and Kubernetes Compatibility" analyzer
I0709 12:47:08.463723   22133 analyzer.go:83] excluding "Docker Support" analyzer
I0709 12:47:08.463728   22133 analyzer.go:83] excluding "Kubernetes Support" analyzer
I0709 12:47:08.463931   22133 analyzer.go:83] excluding "Flannel UDP port 8472 status" analyzer
```

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
