### PR TITLE
feat(run-pod): allow image pull retries in run pod collector

### DIFF
--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -8947,6 +8947,8 @@ spec:
                       type: object
                     runPod:
                       properties:
+                        allowImagePullRetries:
+                          type: boolean
                         annotations:
                           additionalProperties:
                             type: string

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -10767,6 +10767,8 @@ spec:
                       type: object
                     runPod:
                       properties:
+                        allowImagePullRetries:
+                          type: boolean
                         annotations:
                           additionalProperties:
                             type: string

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -10798,6 +10798,8 @@ spec:
                       type: object
                     runPod:
                       properties:
+                        allowImagePullRetries:
+                          type: boolean
                         annotations:
                           additionalProperties:
                             type: string

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -107,13 +107,14 @@ type Run struct {
 }
 
 type RunPod struct {
-	CollectorMeta   `json:",inline" yaml:",inline"`
-	Name            string            `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace       string            `json:"namespace" yaml:"namespace"`
-	Timeout         string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	ImagePullSecret *ImagePullSecrets `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
-	PodSpec         corev1.PodSpec    `json:"podSpec,omitempty" yaml:"podSpec,omitempty"`
-	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	CollectorMeta        `json:",inline" yaml:",inline"`
+	Name                 string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace            string            `json:"namespace" yaml:"namespace"`
+	Timeout              string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	ImagePullSecret      *ImagePullSecrets `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
+	PodSpec              corev1.PodSpec    `json:"podSpec,omitempty" yaml:"podSpec,omitempty"`
+	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AllowImagePullRetries bool             `json:"allowImagePullRetries,omitempty" yaml:"allowImagePullRetries,omitempty"`
 }
 
 type RunDaemonSet struct {

--- a/pkg/apis/troubleshoot/v1beta2/collector_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/collector_shared.go
@@ -107,14 +107,14 @@ type Run struct {
 }
 
 type RunPod struct {
-	CollectorMeta        `json:",inline" yaml:",inline"`
-	Name                 string            `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace            string            `json:"namespace" yaml:"namespace"`
-	Timeout              string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	ImagePullSecret      *ImagePullSecrets `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
-	PodSpec              corev1.PodSpec    `json:"podSpec,omitempty" yaml:"podSpec,omitempty"`
-	Annotations          map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	AllowImagePullRetries bool             `json:"allowImagePullRetries,omitempty" yaml:"allowImagePullRetries,omitempty"`
+	CollectorMeta         `json:",inline" yaml:",inline"`
+	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace             string            `json:"namespace" yaml:"namespace"`
+	Timeout               string            `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	ImagePullSecret       *ImagePullSecrets `json:"imagePullSecret,omitempty" yaml:"imagePullSecret,omitempty"`
+	PodSpec               corev1.PodSpec    `json:"podSpec,omitempty" yaml:"podSpec,omitempty"`
+	Annotations           map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	AllowImagePullRetries bool              `json:"allowImagePullRetries,omitempty" yaml:"allowImagePullRetries,omitempty"`
 }
 
 type RunDaemonSet struct {

--- a/schemas/collector-troubleshoot-v1beta2.json
+++ b/schemas/collector-troubleshoot-v1beta2.json
@@ -7856,6 +7856,9 @@
                   "namespace"
                 ],
                 "properties": {
+                  "allowImagePullRetries": {
+                    "type": "boolean"
+                  },
                   "annotations": {
                     "type": "object",
                     "additionalProperties": {

--- a/schemas/preflight-troubleshoot-v1beta2.json
+++ b/schemas/preflight-troubleshoot-v1beta2.json
@@ -10642,6 +10642,9 @@
                   "namespace"
                 ],
                 "properties": {
+                  "allowImagePullRetries": {
+                    "type": "boolean"
+                  },
                   "annotations": {
                     "type": "object",
                     "additionalProperties": {

--- a/schemas/supportbundle-troubleshoot-v1beta2.json
+++ b/schemas/supportbundle-troubleshoot-v1beta2.json
@@ -10688,6 +10688,9 @@
                   "namespace"
                 ],
                 "properties": {
+                  "allowImagePullRetries": {
+                    "type": "boolean"
+                  },
                   "annotations": {
                     "type": "object",
                     "additionalProperties": {


### PR DESCRIPTION
## Description, Motivation and Context

This PR adds a new `allowImagePullRetries` field to the RunPod collector configuration to control how ImagePullBackOff errors are handled.

**Problem**: Currently, when a RunPod collector encounters a pod in ImagePullBackOff state, it immediately fails regardless of any configured timeout. This prevents users from handling scenarios where image pulls might eventually succeed (e.g., temporary registry issues, authentication delays, or slow networks).

**Solution**: Added an optional `allowImagePullRetries` boolean field that allows ImagePullBackOff conditions to respect the configured timeout instead of failing immediately.

**Behavior**:
- When `allowImagePullRetries: false` (default): Maintains existing behavior - fails immediately on ImagePullBackOff
- When `allowImagePullRetries: true`: Waits for the configured timeout, allowing image pull retries to potentially succeed

**Usage Example**:
```yaml
- runPod:
    timeout: "5m"
    allowImagePullRetries: true
    podSpec:
      containers:
      - name: my-container
        image: my-private-image
```

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No