### PR TITLE
chore(ci): make sure our CI builds the prod binaries

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
         run: exit 1
 
-  tidy-diff:
+  tidy-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -250,7 +250,7 @@ jobs:
   validate-pr-tests:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - tidy-check
       - test-integration
       - run-examples
       - compile-collect

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -27,14 +27,14 @@ jobs:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
         run: exit 1
 
-  build:
+  tidy-diff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - run: make build
+      - run: make tidy-diff
 
   test-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -27,6 +27,15 @@ jobs:
       - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
         run: exit 1
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - run: make build
+
   test-integration:
     runs-on: ubuntu-latest
     steps:
@@ -241,6 +250,7 @@ jobs:
   validate-pr-tests:
     runs-on: ubuntu-latest
     needs:
+      - build
       - test-integration
       - run-examples
       - compile-collect

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ clean:
 tidy:
 	go mod tidy
 
+# Prints  the diff of the changes that would be made by `go mod tidy`. Used in CI
+.PHONY: tidy-diff
+tidy-diff:
+	go mod tidy -diff
+
 # Only build when any of the files in SOURCES changes, or if bin/<file> is absent
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 SOURCES := $(shell find $(MAKEFILE_DIR) -type f \( -name "*.go" -o -name "go.mod" -o -name "go.sum" \))


### PR DESCRIPTION
## Description, Motivation and Context
See: https://app.shortcut.com/replicated/story/127308/troubleshoot-ci-pipeline-broken

This PR broke our builds - https://github.com/replicatedhq/troubleshoot/pull/1809 - however it wasn't caught because we never go through the process of running `go mod tidy`. This PR adds a `make tidy-diff` job to our CI pipeline.

Related to - https://github.com/replicatedhq/troubleshoot/pull/1812

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
