### PR TITLE
chore(ci): fix go-release

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -232,7 +232,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "v1.x"  # Binary version to install
-          args: release --rm-dist --config deploy/.goreleaser.yaml
+          args: release --clean --config deploy/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/deploy/Dockerfile.troubleshoot
+++ b/deploy/Dockerfile.troubleshoot
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 WORKDIR /
 
 RUN apt-get -qq update \


### PR DESCRIPTION
## Description, Motivation and Context
- https://app.shortcut.com/replicated/story/127308/troubleshoot-ci-pipeline-broken

This should fix the go-release pipeline which is currently broken see:
- https://github.com/replicatedhq/troubleshoot/actions/runs/16527148578/job/46743527978

Tested out locally:
```
goreleaser release --snapshot --clean  --config deploy/.goreleaser.yaml
  • only version: 2 configuration files are supported, yours is version: 0, please update your configuration
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=835a5c5b9c9448279f8414e3fb2d028a703e2d8b branch=chore/ci-build current_tag=v0.121.1 previous_tag=v0.121.0 dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
    • DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
  • snapshotting
    • building snapshot...                           version=0.121.1-SNAPSHOT-835a5c5b
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/collect_linux_riscv64_rva20u64/collect
    • building                                       binary=dist/preflight_linux_arm64_v8.0/preflight
    • building                                       binary=dist/preflight_linux_riscv64_rva20u64/preflight
    • building                                       binary=dist/preflight_darwin_amd64_v1/preflight
    • building                                       binary=dist/preflight_linux_amd64_v1/preflight
    • building                                       binary=dist/support-bundle_linux_amd64_v1/support-bundle
    • building                                       binary=dist/support-bundle_darwin_arm64_v8.0/support-bundle
    • building                                       binary=dist/collect_linux_amd64_v1/collect
    • building                                       binary=dist/support-bundle_linux_arm64_v8.0/support-bundle
    • building                                       binary=dist/collect_linux_arm_6/collect
    • building                                       binary=dist/support-bundle_darwin_amd64_v1/support-bundle
    • building                                       binary=dist/support-bundle_linux_riscv64_rva20u64/support-bundle
    • building                                       binary=dist/preflight_linux_arm_6/preflight
    • building                                       binary=dist/preflight_darwin_arm64_v8.0/preflight
    • building                                       binary=dist/collect_linux_arm64_v8.0/collect
    • building                                       binary=dist/support-bundle_linux_arm_6/support-bundle
    • building                                       binary=dist/collect_darwin_amd64_v1/collect
    • building                                       binary=dist/collect_darwin_arm64_v8.0/collect
  • archives
    • archiving                                      name=dist/preflight_darwin_amd64.tar.gz
    • archiving                                      name=dist/preflight_linux_arm64.tar.gz
    • archiving                                      name=dist/collect_darwin_arm64.tar.gz
    • archiving                                      name=dist/collect_linux_arm.tar.gz
    • archiving                                      name=dist/collect_linux_riscv64.tar.gz
    • archiving                                      name=dist/preflight_linux_amd64.tar.gz
    • archiving                                      name=dist/preflight_linux_arm.tar.gz
    • archiving                                      name=dist/collect_darwin_amd64.tar.gz
    • archiving                                      name=dist/support-bundle_linux_arm64.tar.gz
    • archiving                                      name=dist/support-bundle_darwin_arm64.tar.gz
    • archiving                                      name=dist/support-bundle_linux_amd64.tar.gz
    • archiving                                      name=dist/preflight_darwin_arm64.tar.gz
    • archiving                                      name=dist/support-bundle_darwin_amd64.tar.gz
    • archiving                                      name=dist/support-bundle_linux_riscv64.tar.gz
    • archiving                                      name=dist/support-bundle_linux_arm.tar.gz
    • archiving                                      name=dist/preflight_linux_riscv64.tar.gz
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=licence*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=license*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=readme*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=changelog*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=sbom/assets/*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • archiving                                      name=dist/collect_linux_amd64.tar.gz
    • no files matched                               glob=licence*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=license*
    • no files matched                               glob=readme*
    • no files matched                               glob=changelog*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
    • archiving                                      name=dist/collect_linux_arm64.tar.gz
    • no files matched                               glob=licence*
    • no files matched                               glob=LICENCE*
    • no files matched                               glob=license*
    • no files matched                               glob=readme*
    • no files matched                               glob=changelog*
    • no files matched                               glob=CHANGELOG*
    • no files matched                               glob=sbom/assets/*
      • took: 12s
  • calculating checksums
  • docker images
    • building docker image                          image=replicated/troubleshoot:latest
    • building docker image                          image=replicated/preflight:latest
      • took: 11s
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • release succeeded after 31s
  • thanks for using GoReleaser!
  ```

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
