### PR TITLE
fix(cluster_resources): pod disruption budgets for policy v1 not being collected

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -512,8 +512,8 @@ func pods(ctx context.Context, client *kubernetes.Clientset, namespaces []string
 	return podsByNamespace, errorsByNamespace, unhealthyPods
 }
 
-func getPodDisruptionBudgets(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
-	ok, err := discovery.HasResource(client, "policy/v1", "PodDisruptionBudgets")
+func getPodDisruptionBudgets(ctx context.Context, client kubernetes.Interface, namespaces []string) (map[string][]byte, map[string]string) {
+	ok, err := discovery.HasResource(client.Discovery(), "policy/v1", "PodDisruptionBudget")
 	if err != nil {
 		return nil, map[string]string{"": err.Error()}
 	}
@@ -525,7 +525,7 @@ func getPodDisruptionBudgets(ctx context.Context, client *kubernetes.Clientset, 
 }
 
 // TODO: The below function (`pdbV1`) needs to be DRY'd and moved into the main `getPodDisruptionBudgets` function.
-func pdbV1(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
+func pdbV1(ctx context.Context, client kubernetes.Interface, namespaces []string) (map[string][]byte, map[string]string) {
 	pdbByNamespace := make(map[string][]byte)
 	errorsByNamespace := make(map[string]string)
 
@@ -561,7 +561,7 @@ func pdbV1(ctx context.Context, client *kubernetes.Clientset, namespaces []strin
 }
 
 // This block/function can remain as is
-func pdbV1beta(ctx context.Context, client *kubernetes.Clientset, namespaces []string) (map[string][]byte, map[string]string) {
+func pdbV1beta(ctx context.Context, client kubernetes.Interface, namespaces []string) (map[string][]byte, map[string]string) {
 	pdbByNamespace := make(map[string][]byte)
 	errorsByNamespace := make(map[string]string)
 

--- a/test/e2e/support-bundle/cluster_resources_e2e_test.go
+++ b/test/e2e/support-bundle/cluster_resources_e2e_test.go
@@ -58,13 +58,14 @@ func TestClusterResources(t *testing.T) {
 				"resource-quota",
 				"ingress",
 				"pods",
+				"pod-disruption-budgets",
 			},
 			expectType: "folder",
 		},
 	}
 
-	feature := features.New("Cluster Resouces Test").
-		Assess("check support bundle catch cluster resouces", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	feature := features.New("Cluster Resources Test").
+		Assess("check support bundle catch cluster resources", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			var out bytes.Buffer
 			supportBundleName := "cluster-resources"
 			tarPath := fmt.Sprintf("%s.tar.gz", supportBundleName)

--- a/test/e2e/support-bundle/cluster_resources_e2e_test.go
+++ b/test/e2e/support-bundle/cluster_resources_e2e_test.go
@@ -24,7 +24,6 @@ func TestClusterResources(t *testing.T) {
 				"volumeattachments.json",
 				"nodes.json",
 				"pvs.json",
-				"pod-disruption-budgets-errors.json",
 				"resources.json",
 				"custom-resource-definitions.json",
 				"groups.json",


### PR DESCRIPTION
## Description, Motivation and Context

We're not collecting `PodDisruptionBudget` for the `policy/v1`

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

Fixes: https://app.shortcut.com/replicated/story/128920/troubleshoot-s-pod-disruption-budget-collection-for-policy-v1-isn-t-working

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
