### PR TITLE
Auto updater

### DIFF
--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
 	"github.com/replicatedhq/troubleshoot/pkg/preflight"
 	"github.com/replicatedhq/troubleshoot/pkg/types"
+	"github.com/replicatedhq/troubleshoot/pkg/updater"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
@@ -36,6 +37,25 @@ that a cluster meets the requirements to run an application.`,
 
 			if err := util.StartProfiling(); err != nil {
 				klog.Errorf("Failed to start profiling: %v", err)
+			}
+
+			// Auto-update preflight unless disabled by flag or env
+			envAuto := os.Getenv("PREFLIGHT_AUTO_UPDATE")
+			autoFromEnv := true
+			if envAuto != "" {
+				if strings.EqualFold(envAuto, "0") || strings.EqualFold(envAuto, "false") {
+					autoFromEnv = false
+				}
+			}
+			if v.GetBool("auto-update") && autoFromEnv {
+				exe, err := os.Executable()
+				if err == nil {
+					_ = updater.CheckAndUpdate(cmd.Context(), updater.Options{
+						BinaryName:  "preflight",
+						CurrentPath: exe,
+						Printf:      func(f string, a ...interface{}) { klog.V(1).Infof(f, a...) },
+					})
+				}
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,6 +92,7 @@ that a cluster meets the requirements to run an application.`,
 	// Adding here to avoid that
 	cmd.Flags().Bool("dry-run", false, "print the preflight spec without running preflight checks")
 	cmd.Flags().Bool("no-uri", false, "When this flag is used, Preflight does not attempt to retrieve the spec referenced by the uri: field`")
+	cmd.Flags().Bool("auto-update", true, "enable automatic binary self-update check and install")
 
 	k8sutil.AddFlags(cmd.Flags())
 

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/internal/traces"
 	"github.com/replicatedhq/troubleshoot/pkg/k8sutil"
 	"github.com/replicatedhq/troubleshoot/pkg/logger"
+	"github.com/replicatedhq/troubleshoot/pkg/updater"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/klog/v2"
@@ -39,6 +40,25 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 
 			if err := util.StartProfiling(); err != nil {
 				klog.Errorf("Failed to start profiling: %v", err)
+			}
+
+			// Auto-update support-bundle unless disabled by flag or env
+			envAuto := os.Getenv("TROUBLESHOOT_AUTO_UPDATE")
+			autoFromEnv := true
+			if envAuto != "" {
+				if strings.EqualFold(envAuto, "0") || strings.EqualFold(envAuto, "false") {
+					autoFromEnv = false
+				}
+			}
+			if v.GetBool("auto-update") && autoFromEnv {
+				exe, err := os.Executable()
+				if err == nil {
+					_ = updater.CheckAndUpdate(cmd.Context(), updater.Options{
+						BinaryName:  "support-bundle",
+						CurrentPath: exe,
+						Printf:      func(f string, a ...interface{}) { klog.V(1).Infof(f, a...) },
+					})
+				}
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,6 +115,7 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 	cmd.Flags().StringP("output", "o", "", "specify the output file path for the support bundle")
 	cmd.Flags().Bool("debug", false, "enable debug logging. This is equivalent to --v=0")
 	cmd.Flags().Bool("dry-run", false, "print support bundle spec without collecting anything")
+	cmd.Flags().Bool("auto-update", true, "enable automatic binary self-update check and install")
 
 	// hidden in favor of the `insecure-skip-tls-verify` flag
 	cmd.Flags().Bool("allow-insecure-connections", false, "when set, do not verify TLS certs when retrieving spec and reporting results")

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -10,7 +10,7 @@ that a cluster meets the requirements to run an application.
 ```
 preflight [url] [flags]
 ```
-
+ 
 ### Auto-update
 
 Preflight includes a built-in self-updater.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -11,6 +11,16 @@ that a cluster meets the requirements to run an application.
 preflight [url] [flags]
 ```
 
+### Auto-update
+
+Preflight includes a built-in self-updater.
+
+- Default behavior: On startup, it checks the latest release on `replicatedhq/troubleshoot`. If a newer version exists, it downloads and atomically replaces the running binary. Dev builds without a version skip auto-update.
+- Control via flag: `--auto-update` (default true). Disable with `--auto-update=false`.
+- Control via env: `PREFLIGHT_AUTO_UPDATE=true|false` (empty = default true).
+- Logging: use `--v=1` to see updater messages (e.g., "Updating …", "Update complete.").
+- Airgap/network errors: if the release API or download is unreachable, Preflight continues without updating.
+
 ### Options
 
 ```

--- a/docs/support-bundle.md
+++ b/docs/support-bundle.md
@@ -19,6 +19,16 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 support-bundle [urls...] [flags]
 ```
 
+### Auto-update
+
+Support-bundle includes a built-in self-updater.
+
+- Default behavior: On startup, it checks the latest release on `replicatedhq/troubleshoot`. If a newer version exists, it downloads and atomically replaces the running binary. Dev builds without a version skip auto-update.
+- Control via flag: `--auto-update` (default true). Disable with `--auto-update=false`.
+- Control via env: `TROUBLESHOOT_AUTO_UPDATE=true|false` (empty = default true).
+- Logging: use `--v=1` to see updater messages (e.g., "Updating …", "Update complete.").
+- Airgap/network errors: if the release API or download is unreachable, it continues without updating.
+
 ### Options
 
 ```

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1,0 +1,261 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	hv "github.com/hashicorp/go-version"
+	"github.com/replicatedhq/troubleshoot/pkg/version"
+)
+
+const defaultRepo = "replicatedhq/troubleshoot"
+
+// Options control updater behavior.
+type Options struct {
+	// Repo in owner/name form. Defaults to replicatedhq/troubleshoot
+	Repo string
+	// BinaryName expected executable name inside the archive (preflight or support-bundle)
+	BinaryName string
+	// CurrentPath path to the currently executing binary to be replaced
+	CurrentPath string
+	// Skip whether to skip update (effective no-op)
+	Skip bool
+	// HTTPClient optional custom client
+	HTTPClient *http.Client
+	// Printf allows caller to receive status messages (optional)
+	Printf func(string, ...interface{})
+}
+
+func (o *Options) client() *http.Client {
+	if o.HTTPClient != nil {
+		return o.HTTPClient
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+// CheckAndUpdate checks GitHub releases for a newer version and, if newer, downloads
+// the corresponding tar.gz asset, extracts the binary, and atomically replaces CurrentPath.
+func CheckAndUpdate(ctx context.Context, o Options) error {
+	if o.Skip {
+		return nil
+	}
+	if o.BinaryName == "" || o.CurrentPath == "" {
+		return fmt.Errorf("updater: BinaryName and CurrentPath are required")
+	}
+	repo := o.Repo
+	if repo == "" {
+		repo = defaultRepo
+	}
+
+	current := strings.TrimPrefix(version.Version(), "v")
+	if current == "" {
+		// If version is unknown (dev builds), do not auto-update
+		return nil
+	}
+
+	latestTag, err := getLatestTag(ctx, o, repo)
+	if err != nil {
+		// Non-fatal: don't block command on update check failure
+		if o.Printf != nil {
+			o.Printf("Skipping auto-update (failed to check latest): %v\n", err)
+		}
+		return nil
+	}
+
+	latest := strings.TrimPrefix(latestTag, "v")
+	newer, err := isNewer(latest, current)
+	if err != nil || !newer {
+		return nil
+	}
+
+	if o.Printf != nil {
+		o.Printf("Updating %s from %s to %s...\n", o.BinaryName, current, latest)
+	}
+
+	assetURL := assetDownloadURL(repo, o.BinaryName, runtime.GOOS, runtime.GOARCH, latest)
+	tgz, err := download(ctx, o, assetURL)
+	if err != nil {
+		return fmt.Errorf("download asset: %w", err)
+	}
+	defer tgz.Close()
+
+	tempDir := filepath.Dir(o.CurrentPath)
+	extractedPath, err := extractSingleBinary(tgz, o.BinaryName, tempDir)
+	if err != nil {
+		return fmt.Errorf("extract: %w", err)
+	}
+	// Make sure mode is executable
+	_ = os.Chmod(extractedPath, 0o755)
+
+	// Optional integrity check: size non-zero and simple sha256 not empty
+	if err := sanityCheckBinary(extractedPath); err != nil {
+		return fmt.Errorf("sanity check: %w", err)
+	}
+
+	// Atomic replace with backup
+	backup := o.CurrentPath + ".bak"
+	_ = os.Remove(backup)
+	if err := os.Rename(o.CurrentPath, backup); err != nil {
+		// If rename fails (e.g., permissions), abort and keep original
+		_ = os.Remove(extractedPath)
+		return nil
+	}
+	if err := os.Rename(extractedPath, o.CurrentPath); err != nil {
+		// Attempt rollback
+		_ = os.Rename(backup, o.CurrentPath)
+		_ = os.Remove(extractedPath)
+		return nil
+	}
+	// Best-effort remove backup
+	_ = os.Remove(backup)
+
+	if o.Printf != nil {
+		o.Printf("Update complete.\n")
+	}
+	return nil
+}
+
+func getLatestTag(ctx context.Context, o Options, repo string) (string, error) {
+	// Use GitHub REST to retrieve latest release. No auth; subject to rate limits.
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+	resp, err := o.client().Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	// Minimal JSON extraction to avoid bringing in a JSON dep footprint here.
+	// The payload includes "tag_name":"vX.Y.Z". We'll parse it via a simple scan.
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	s := string(b)
+	idx := strings.Index(s, "\"tag_name\"")
+	if idx < 0 {
+		return "", errors.New("tag_name not found")
+	}
+	// Find the next quoted value
+	start := strings.Index(s[idx:], ":")
+	if start < 0 {
+		return "", errors.New("invalid JSON")
+	}
+	start += idx + 1
+	// find first quote
+	q1 := strings.Index(s[start:], "\"")
+	if q1 < 0 {
+		return "", errors.New("invalid JSON")
+	}
+	q1 += start + 1
+	q2 := strings.Index(s[q1:], "\"")
+	if q2 < 0 {
+		return "", errors.New("invalid JSON")
+	}
+	q2 += q1
+	return s[q1:q2], nil
+}
+
+func isNewer(latest, current string) (bool, error) {
+	lv, err := hv.NewVersion(latest)
+	if err != nil {
+		return false, err
+	}
+	cv, err := hv.NewVersion(current)
+	if err != nil {
+		return false, err
+	}
+	return lv.GreaterThan(cv), nil
+}
+
+func assetDownloadURL(repo, bin, goos, arch, version string) string {
+	// Matches deploy/.goreleaser.yaml naming: <binary>_<os>_<arch>.tar.gz
+	name := fmt.Sprintf("%s_%s_%s.tar.gz", bin, goos, arch)
+	return fmt.Sprintf("https://github.com/%s/releases/download/v%s/%s", repo, version, name)
+}
+
+func download(ctx context.Context, o Options, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := o.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		return nil, fmt.Errorf("bad status: %s", resp.Status)
+	}
+	return resp.Body, nil
+}
+
+func extractSingleBinary(r io.Reader, expectedName, outDir string) (string, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return "", err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		base := filepath.Base(hdr.Name)
+		if base != expectedName {
+			continue
+		}
+		tmp := filepath.Join(outDir, "."+expectedName+".tmp")
+		f, err := os.CreateTemp(outDir, expectedName+"-dl-")
+		if err != nil {
+			return "", err
+		}
+		tmp = f.Name()
+		if _, err := io.Copy(f, tr); err != nil {
+			f.Close()
+			_ = os.Remove(f.Name())
+			return "", err
+		}
+		f.Close()
+		return tmp, nil
+	}
+	return "", fmt.Errorf("binary %q not found in archive", expectedName)
+}
+
+func sanityCheckBinary(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.Size() == 0 {
+		return fmt.Errorf("empty file")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.CopyN(h, f, 1<<20); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	_ = hex.EncodeToString(h.Sum(nil))
+	return nil
+}


### PR DESCRIPTION
## Description, Motivation and Context

Added an automatic updater for preflight and support-bundle, where it checks to see if the current version running is the latest or not, and will automatically update to the latest version if it is not. Can be disabled by the --auto-update flag, or setting PREFLIGHT_AUTO_UPDATE to false.

## Checklist

- [X] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] The commit message(s) are informative and highlight any breaking changes
- [X] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No