### PR TITLE
does not auto update for package managers

### DIFF
--- a/cmd/preflight/cli/root.go
+++ b/cmd/preflight/cli/root.go
@@ -53,7 +53,7 @@ that a cluster meets the requirements to run an application.`,
 					_ = updater.CheckAndUpdate(cmd.Context(), updater.Options{
 						BinaryName:  "preflight",
 						CurrentPath: exe,
-						Printf:      func(f string, a ...interface{}) { klog.V(1).Infof(f, a...) },
+						Printf:      func(f string, a ...interface{}) { fmt.Fprintf(os.Stderr, f, a...) },
 					})
 				}
 			}

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -56,7 +56,7 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 					_ = updater.CheckAndUpdate(cmd.Context(), updater.Options{
 						BinaryName:  "support-bundle",
 						CurrentPath: exe,
-						Printf:      func(f string, a ...interface{}) { klog.V(1).Infof(f, a...) },
+						Printf:      func(f string, a ...interface{}) { fmt.Fprintf(os.Stderr, f, a...) },
 					})
 				}
 			}

--- a/pkg/updater/pkgmgr/homebrew.go
+++ b/pkg/updater/pkgmgr/homebrew.go
@@ -1,0 +1,74 @@
+package pkgmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// HomebrewPackageManager detects if a binary was installed via Homebrew
+type HomebrewPackageManager struct{
+	formula string
+}
+
+var _ PackageManager = (*HomebrewPackageManager)(nil)
+
+type homebrewInfoOutput struct {
+	Installed []struct {
+		Version      string `json:"version"`
+		InstalledOn  bool   `json:"installed_on_request"`
+		LinkedKeg    string `json:"linked_keg"`
+	} `json:"installed"`
+}
+
+// NewHomebrewPackageManager creates a new Homebrew package manager detector
+func NewHomebrewPackageManager(formula string) PackageManager {
+	return &HomebrewPackageManager{
+		formula: formula,
+	}
+}
+
+// Name returns the human-readable name of the package manager
+func (h *HomebrewPackageManager) Name() string {
+	return "Homebrew"
+}
+
+// IsInstalled checks if the formula is installed via Homebrew
+func (h *HomebrewPackageManager) IsInstalled() (bool, error) {
+	// First check if brew command exists
+	brewPath, err := exec.LookPath("brew")
+	if err != nil {
+		// No brew command found, definitely not installed via brew
+		return false, nil
+	}
+
+	// Check if the formula is installed
+	out, err := exec.Command(brewPath, "info", h.formula, "--json").Output()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 1 {
+				// brew info with an invalid (not installed) package name returns an error
+				return false, nil
+			}
+		}
+		return false, err
+	}
+
+	var info []homebrewInfoOutput
+	if err := json.Unmarshal(out, &info); err != nil {
+		return false, err
+	}
+
+	if len(info) == 0 {
+		return false, nil
+	}
+
+	// Check if the formula has any installed versions
+	return len(info[0].Installed) > 0, nil
+}
+
+// UpgradeCommand returns the command to upgrade the package
+func (h *HomebrewPackageManager) UpgradeCommand() string {
+	return fmt.Sprintf("brew upgrade %s", h.formula)
+}
+

--- a/pkg/updater/pkgmgr/krew.go
+++ b/pkg/updater/pkgmgr/krew.go
@@ -1,0 +1,69 @@
+package pkgmgr
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// KrewPackageManager detects if a binary was installed via kubectl krew
+type KrewPackageManager struct{
+	pluginName string
+}
+
+var _ PackageManager = (*KrewPackageManager)(nil)
+
+// NewKrewPackageManager creates a new Krew package manager detector
+func NewKrewPackageManager(pluginName string) PackageManager {
+	return &KrewPackageManager{
+		pluginName: pluginName,
+	}
+}
+
+// Name returns the human-readable name of the package manager
+func (k *KrewPackageManager) Name() string {
+	return "kubectl krew"
+}
+
+// IsInstalled checks if the plugin is installed via krew
+func (k *KrewPackageManager) IsInstalled() (bool, error) {
+	// First check if kubectl krew command exists
+	_, err := exec.LookPath("kubectl")
+	if err != nil {
+		return false, nil
+	}
+
+	// Check if krew plugin is available
+	out, err := exec.Command("kubectl", "krew", "version").Output()
+	if err != nil {
+		// krew not installed
+		return false, nil
+	}
+
+	if !strings.Contains(string(out), "krew") {
+		return false, nil
+	}
+
+	// Check if the plugin is installed by listing installed plugins
+	listOut, err := exec.Command("kubectl", "krew", "list").Output()
+	if err != nil {
+		return false, err
+	}
+
+	// Check if our plugin is in the installed list
+	installedPlugins := strings.Split(string(listOut), "\n")
+	for _, line := range installedPlugins {
+		// Lines are in format: "PLUGIN VERSION"
+		if strings.HasPrefix(strings.TrimSpace(line), k.pluginName+" ") || strings.TrimSpace(line) == k.pluginName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// UpgradeCommand returns the command to upgrade the plugin
+func (k *KrewPackageManager) UpgradeCommand() string {
+	return fmt.Sprintf("kubectl krew upgrade %s", k.pluginName)
+}
+

--- a/pkg/updater/pkgmgr/pkgmgr.go
+++ b/pkg/updater/pkgmgr/pkgmgr.go
@@ -1,0 +1,11 @@
+package pkgmgr
+
+// PackageManager represents an external package manager that can manage the binary
+type PackageManager interface {
+	// IsInstalled returns true if the package/formula is installed via this package manager
+	IsInstalled() (bool, error)
+	// UpgradeCommand returns the command the user should run to upgrade
+	UpgradeCommand() string
+	// Name returns the human-readable name of the package manager
+	Name() string
+}


### PR DESCRIPTION
## Description, Motivation and Context

If support-bundle or preflight is installed via package manager like krew or homebrew, the auto updater will only alert the user that an updated version is available instead of auto updating the binary

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] The commit message(s) are informative and highlight any breaking changes
- [X] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No