### PR TITLE
adding brew

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,10 @@ on:
   push:
     tags:
       - 'v*'
-      - '!v*-*'  # Exclude prerelease tags like v1.0.1-beta, v1.0.1-alpha, etc.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false  # Don't cancel releases
+  cancel-in-progress: false
 
 jobs:
   goreleaser:
@@ -34,14 +33,16 @@ jobs:
           version: "v1.x"  # Binary version to install
           args: release --clean --config deploy/.goreleaser.yaml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
 
       - name: Update new preflight version in krew-index
+        if: ${{ !contains(github.ref_name, '-') }}
         uses: rajatjindal/krew-release-bot@v0.0.47
         with:
           krew_template_file: deploy/krew/preflight.yaml
 
       - name: Update new support-bundle version in krew-index
+        if: ${{ !contains(github.ref_name, '-') }}
         uses: rajatjindal/krew-release-bot@v0.0.47
         with:
           krew_template_file: deploy/krew/support-bundle.yaml

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -48,29 +48,6 @@ builds:
     flags: -tags netgo -tags containers_image_ostree_stub -tags exclude_graphdriver_devicemapper -tags exclude_graphdriver_btrfs -tags containers_image_openpgp -installsuffix netgo
     binary: support-bundle
     hooks: {}
-  - id: collect
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm
-      - arm64
-      - riscv64
-    ignore:
-      - goos: windows
-        goarch: arm
-    env:
-      - CGO_ENABLED=0
-    main: cmd/collect/main.go
-    ldflags: -s -w
-      -X github.com/replicatedhq/troubleshoot/pkg/version.version={{.Version}}
-      -X github.com/replicatedhq/troubleshoot/pkg/version.gitSHA={{.Commit}}
-      -X github.com/replicatedhq/troubleshoot/pkg/version.buildTime={{.Date}}
-      -extldflags "-static"
-    flags: -tags netgo -tags containers_image_ostree_stub -tags exclude_graphdriver_devicemapper -tags exclude_graphdriver_btrfs -tags containers_image_openpgp -installsuffix netgo
-    binary: collect
-    hooks: {}
 archives:
   - id: preflight
     builds:
@@ -112,26 +89,6 @@ archives:
       - src: 'sbom/assets/*'
         dst: .
         strip_parent: true # this is needed to make up for the way unzips work in krew v0.4.1
-  - id: collect
-    builds:
-      - collect
-    format: tar.gz
-    format_overrides:
-      - goos: windows
-        format: zip
-    name_template: 'collect_{{ .Os }}_{{ .Arch }}'
-    files:
-      - licence*
-      - LICENCE*
-      - license*
-      - LICENSE*
-      - readme*
-      - README*
-      - changelog*
-      - CHANGELOG*
-      - src: 'sbom/assets/*'
-        dst: .
-        strip_parent: true # this is needed to make up for the way unzips work in krew v0.4.1
 dockers:
   - dockerfile: ./deploy/Dockerfile.troubleshoot
     image_templates:
@@ -142,7 +99,6 @@ dockers:
     ids:
       - support-bundle
       - preflight
-      - collect
   - dockerfile: ./deploy/Dockerfile.troubleshoot
     image_templates:
       - "replicated/preflight:latest"
@@ -152,4 +108,35 @@ dockers:
     ids:
       - support-bundle
       - preflight
-      - collect
+universal_binaries:
+  - ids:
+      - preflight
+    replace: true
+    name_template: preflight
+  - ids:
+      - support-bundle
+    replace: true
+    name_template: support-bundle
+brews:
+  - name: preflight
+    ids:
+      - preflight
+    homepage: https://docs.replicated.com/reference/preflight-overview/
+    description: "A preflight checker and conformance test for Kubernetes clusters."
+    repository:
+      name: homebrew-replicated
+      owner: replicatedhq
+      branch: main
+    install: bin.install "preflight"
+    directory: HomebrewFormula
+  - name: support-bundle
+    ids:
+      - support-bundle
+    homepage: https://docs.replicated.com/reference/support-bundle-overview/
+    description: "Collect and redact support bundles for Kubernetes clusters."
+    repository:
+      name: homebrew-replicated
+      owner: replicatedhq
+      branch: main
+    install: bin.install "support-bundle"
+    directory: HomebrewFormula


### PR DESCRIPTION
adding homebrew releases 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Homebrew publishing and universal binaries for `preflight`/`support-bundle`, removes `collect`, and updates release workflow tokens/conditions.
> 
> - **Release workflow (`.github/workflows/release.yaml`)**:
>   - Trigger on all `v*` tags (including prereleases); gate krew updates with `if: !contains(github.ref_name, '-')`.
>   - Use `secrets.HOMEBREW_GITHUB_TOKEN` for GoReleaser.
> - **GoReleaser config (`deploy/.goreleaser.yaml`)**:
>   - Add `universal_binaries` for `preflight` and `support-bundle` (replace=true, plain names).
>   - Add `brews` to publish `preflight` and `support-bundle` to `replicatedhq/homebrew-replicated` (`HomebrewFormula/`).
>   - Remove `collect` build, archive, and docker image IDs.
>   - Keep docker images for `troubleshoot` and `preflight` (without `collect`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc9e8a4cd0decbe6e10654ed15940e8eb37c5ecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->