### PR TITLE
Fix windows redaction clean

### DIFF
--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -8,7 +8,7 @@ builds:
   - id: preflight
     main: ./cmd/preflight/main.go
     env: [CGO_ENABLED=0]
-    goos: [linux, darwin]
+    goos: [linux, darwin, windows]
     goarch: [amd64, arm, arm64]
     ignore:
       - goos: windows
@@ -31,7 +31,7 @@ builds:
   - id: support-bundle
     main: ./cmd/troubleshoot/main.go
     env: [CGO_ENABLED=0]
-    goos: [linux, darwin]
+    goos: [linux, darwin, windows]
     goarch: [amd64, arm, arm64]
     ignore:
       - goos: windows

--- a/pkg/collect/redact.go
+++ b/pkg/collect/redact.go
@@ -135,7 +135,9 @@ func RedactResult(bundlePath string, input CollectorResult, additionalRedactors 
 				return
 			}
 
-			redacted, err := redact.Redact(reader, file, additionalRedactors)
+			// Normalize the path for redaction (convert Windows backslashes to forward slashes)
+			normalizedFile := filepath.ToSlash(file)
+			redacted, err := redact.Redact(reader, normalizedFile, additionalRedactors)
 			if err != nil {
 				errorCh <- errors.Wrap(err, "failed to redact io stream")
 				return

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -497,8 +497,9 @@ func copyFileWindows(src, dst string) error {
 		}
 	}
 
-	// All retries failed - clean up both temp files
+	// All retries failed - clean up dst temp file but keep src
+	// We intentionally leave src (the source temp file) to prevent data loss
+	// It will be cleaned up when the parent temp directory is removed
 	os.Remove(tmpDst)
-	os.Remove(src) // Always clean up source temp file to prevent leaks
 	return errors.Wrap(err, "failed to replace file after retries")
 }


### PR DESCRIPTION
## Description, Motivation and Context

Fixes Windows redaction file locking failures that completely prevented support bundle redaction from working on Windows systems.

**Problem**: Support bundle redaction consistently failed on Windows with "Access is denied" and "file is being used by another process" errors during file operations, making redaction unusable for Windows users.

**Solution**: Implemented Windows-specific file handling that uses destination directory temp files and copy+delete operations instead of system temp and rename operations, which are more compatible with Windows file system behavior and antivirus software.

**Impact**: Windows users can now successfully run support bundle redaction without file locking crashes.

Fixes: #1607

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

**Technical Changes**:
- Windows: Use destination directory for temp files and copy+delete file operations
- Linux/macOS: Preserve exact original behavior with no changes
- Platform detection using `runtime.GOOS` for Windows-specific handling only

## Test commands for redaction

**Multiline Redaction**

 Use unnamed capture group for the key, named capture for the value
@"
apiVersion: troubleshoot.sh/v1beta2
kind: Redactor
metadata:
  name: multiline-regex-test
spec:
  redactors:
  - name: Redact password value
    removals:
      regex:
      - selector: 'username:'
        redactor: '(password:\s*)(?P<mask>.*)'
  
  - name: Redact api_secret value
    removals:
      regex:
      - selector: 'api_key:'
        redactor: '(api_secret:\s*)(?P<mask>.*)'
"@ | Out-File -FilePath C:\Users\Public\Downloads\test-troubleshoot\multiline-redactor.yaml -Encoding UTF8 -Force


.\bin\troubleshoot.exe redact --bundle C:\Users\Public\Downloads\test-troubleshoot\multiline-test.tar.gz C:\Users\Public\Downloads\test-troubleshoot\multiline-redactor.yaml

 Check results
$latest = Get-Item redacted-support-bundle-*.tar.gz | Sort-Object LastWriteTime | Select-Object -Last 1
tar -xzf $latest.Name
Get-Content multiline-test\credentials.txt

**Single-line redaction**

 Create a redactor using VALUES (literal string replacement)
@"
apiVersion: troubleshoot.sh/v1beta2
kind: Redactor
metadata:
  name: test-redactor
spec:
  redactors:
  - name: Test literal replacement
    removals:
      values:
      - password
      - token
"@ | Out-File -FilePath C:\Users\Public\Downloads\test-troubleshoot\values-redactor.yaml -Encoding UTF8

 Test with values redactor
.\bin\troubleshoot.exe redact --bundle C:\Users\Public\Downloads\test-troubleshoot\test-bundle.tar.gz C:\Users\Public\Downloads\test-troubleshoot\values-redactor.yaml

 Extract and check - the word "password" and "token" should be replaced with "***HIDDEN***"
tar -xzf (Get-Item redacted-support-bundle-*.tar.gz | Sort-Object LastWriteTime | Select-Object -Last 1).Name
Get-Content test-bundle\cluster-resources\secret.json
