### PR TITLE
Fixing main checks.

### DIFF
--- a/examples/preflight/e2e.yaml
+++ b/examples/preflight/e2e.yaml
@@ -9,6 +9,7 @@ spec:
         data: "5"
     - runPod:
         collectorName: "static-hi-1"
+        allowImagePullRetries: true
         podSpec:
           containers:
           - name: static-hi
@@ -17,6 +18,7 @@ spec:
     ## This collector is intentionally duplicated to test same pod should be terminated after success
     - runPod:
         collectorName: "static-hi-2"
+        allowImagePullRetries: true
         podSpec:
           containers:
           - name: static-hi


### PR DESCRIPTION
## Description, Motivation and Context

Fixes failing preflight e2e tests in CI by adding `allowImagePullRetries: true` to the runPod collectors in the e2e test spec.

The CI was failing with `ImagePullBackOff` errors because the runPod collectors would immediately abort when encountering temporary image pull issues. Adding this flag allows the pods to retry pulling the `alpine:3` image, making the tests more resilient to transient network issues.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No