### PR TITLE
readded auto upload flag for support bundle

### DIFF
--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -132,6 +132,11 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 	cmd.Flags().Bool("dry-run", false, "print support bundle spec without collecting anything")
 	cmd.Flags().Bool("auto-update", true, "enable automatic binary self-update check and install")
 
+	// Upload flags
+	cmd.Flags().Bool("auto-upload", false, "automatically upload resulting bundle to replicated.app")
+	cmd.Flags().String("license-id", "", "license ID for authentication when uploading (auto-detected from bundle if not provided)")
+	cmd.Flags().String("app-slug", "", "application slug when uploading (auto-detected from bundle if not provided)")
+
 	// Auto-discovery flags
 	cmd.Flags().Bool("auto", false, "enable auto-discovery of foundational collectors. When used with YAML specs, adds foundational collectors to YAML collectors. When used alone, collects only foundational data")
 	cmd.Flags().Bool("include-images", false, "include container image metadata collection when using auto-discovery")

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -283,7 +283,7 @@ the %s Admin Console to begin analysis.`
 		fmt.Printf("\r%s\r", cursor.ClearEntireLine())
 	}
 	if response.FileUploaded {
-		fmt.Printf("A support bundle has been created and uploaded to your cluster for analysis. Please visit the Troubleshoot page to continue.\n")
+		fmt.Printf("A support bundle has been created and uploaded to replicated.app for analysis.\n")
 		fmt.Printf("A copy of this support bundle was written to the current directory, named %q\n", response.ArchivePath)
 	} else {
 		fmt.Printf("A support bundle has been created in the current directory named %q\n", response.ArchivePath)


### PR DESCRIPTION
## Description, Motivation and Context

Readds the --auto-upload flag for support bundle that will automatically upload a customer's support bundle to vendor portal after being generated by gathering the app slug and license ID from the generated bundle.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No