### PR TITLE
fixing cron job auto upload feature

### DIFF
--- a/pkg/schedule/cli.go
+++ b/pkg/schedule/cli.go
@@ -48,6 +48,8 @@ Examples:
 			namespace, _ := cmd.Flags().GetString("namespace")
 			auto, _ := cmd.Flags().GetBool("auto")
 			upload, _ := cmd.Flags().GetString("upload")
+			licenseID, _ := cmd.Flags().GetString("license-id")
+			appSlug, _ := cmd.Flags().GetString("app-slug")
 
 			if cronSchedule == "" {
 				return fmt.Errorf("--cron is required")
@@ -57,7 +59,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			job, err := manager.CreateJob(args[0], cronSchedule, namespace, auto, upload)
+			job, err := manager.CreateJobWithCredentials(args[0], cronSchedule, namespace, auto, upload, licenseID, appSlug)
 			if err != nil {
 				return err
 			}
@@ -71,6 +73,12 @@ Examples:
 			if upload != "" {
 				fmt.Printf("  Auto-upload: enabled (uploads to vendor portal)\n")
 			}
+			if licenseID != "" {
+				fmt.Printf("  License ID: %s\n", licenseID)
+			}
+			if appSlug != "" {
+				fmt.Printf("  App Slug: %s\n", appSlug)
+			}
 
 			fmt.Printf("\n💡 To activate, start the daemon:\n")
 			fmt.Printf("   support-bundle schedule daemon start\n")
@@ -83,6 +91,8 @@ Examples:
 	cmd.Flags().StringP("namespace", "n", "", "Kubernetes namespace (optional)")
 	cmd.Flags().Bool("auto", false, "Enable auto-discovery")
 	cmd.Flags().String("upload", "", "Enable auto-upload to vendor portal (any non-empty value enables auto-upload)")
+	cmd.Flags().String("license-id", "", "License ID for auto-upload")
+	cmd.Flags().String("app-slug", "", "Application slug for auto-upload")
 	cmd.MarkFlagRequired("cron")
 
 	return cmd

--- a/pkg/schedule/daemon.go
+++ b/pkg/schedule/daemon.go
@@ -253,13 +253,13 @@ func (d *Daemon) executeJob(job *Job) {
 	}
 	if job.Upload != "" {
 		args = append(args, "--auto-upload")
-		// Add license and app flags if available in the future
-		// if job.LicenseID != "" {
-		//     args = append(args, "--license-id", job.LicenseID)
-		// }
-		// if job.AppSlug != "" {
-		//     args = append(args, "--app-slug", job.AppSlug)
-		// }
+		// Add license and app flags if available
+		if job.LicenseID != "" {
+			args = append(args, "--license-id", job.LicenseID)
+		}
+		if job.AppSlug != "" {
+			args = append(args, "--app-slug", job.AppSlug)
+		}
 	}
 
 	// Disable auto-update for scheduled jobs

--- a/pkg/schedule/job.go
+++ b/pkg/schedule/job.go
@@ -18,6 +18,8 @@ type Job struct {
 	Namespace string    `json:"namespace"`
 	Auto      bool      `json:"auto"` // Auto-discovery
 	Upload    string    `json:"upload,omitempty"`
+	LicenseID string    `json:"licenseId,omitempty"`
+	AppSlug   string    `json:"appSlug,omitempty"`
 	Enabled   bool      `json:"enabled"`
 	RunCount  int       `json:"runCount"`
 	LastRun   time.Time `json:"lastRun,omitempty"`
@@ -77,10 +79,32 @@ func (m *Manager) CreateJob(name, schedule, namespace string, auto bool, upload 
 		Namespace: namespace,
 		Auto:      auto,
 		Upload:    upload,
+		LicenseID: "", // Will be set by CreateJobWithCredentials
+		AppSlug:   "", // Will be set by CreateJobWithCredentials
 		Enabled:   true,
 		Created:   time.Now(),
 	}
 
+	if err := m.saveJob(job); err != nil {
+		return nil, err
+	}
+
+	return job, nil
+}
+
+// CreateJobWithCredentials creates a new scheduled job with license credentials
+func (m *Manager) CreateJobWithCredentials(name, schedule, namespace string, auto bool, upload, licenseID, appSlug string) (*Job, error) {
+	// Use the existing CreateJob function for validation and basic setup
+	job, err := m.CreateJob(name, schedule, namespace, auto, upload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the license credentials
+	job.LicenseID = licenseID
+	job.AppSlug = appSlug
+
+	// Save the updated job
 	if err := m.saveJob(job); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description, Motivation and Context

**Enables license ID and app slug support for scheduled support bundle jobs**

This PR completes the auto-upload functionality for cron jobs by adding missing customer credential support. Previously, scheduled jobs could collect support bundles but failed to auto-upload due to missing license information, while the direct `support-bundle` command worked correctly.

**Changes:**
- Added `LicenseID` and `AppSlug` fields to the `Job` struct 
- Added `--license-id` and `--app-slug` CLI flags to `schedule create` command
- Updated job creation logic to store customer credentials
- Enabled credential passing in daemon execution (uncommented existing code)

**Before:** Scheduled jobs failed with "could not find license ID in bundle"  
**After:** Scheduled jobs successfully auto-upload to replicated.app with customer association

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

**Notes:** This is a non-breaking change that adds new optional CLI flags and extends existing functionality. Existing scheduled jobs without license credentials will continue to work as before (collecting bundles without auto-upload).