### PR TITLE
Support bundle upload functionality works for apps installed via Helm

### DIFF
--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -136,6 +136,7 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 	cmd.Flags().Bool("auto-upload", false, "automatically upload resulting bundle to replicated.app")
 	cmd.Flags().String("license-id", "", "license ID for authentication when uploading (auto-detected from bundle if not provided)")
 	cmd.Flags().String("app-slug", "", "application slug when uploading (auto-detected from bundle if not provided)")
+	cmd.Flags().String("upload-domain", "", "custom domain for upload (default: replicated.app)")
 
 	// Auto-discovery flags
 	cmd.Flags().Bool("auto", false, "enable auto-discovery of foundational collectors. When used with YAML specs, adds foundational collectors to YAML collectors. When used alone, collects only foundational data")

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -246,9 +246,15 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 	if v.GetBool("auto-upload") && !response.FileUploaded {
 		licenseID := v.GetString("license-id")
 		appSlug := v.GetString("app-slug")
+		uploadDomain := v.GetString("upload-domain")
 
-		fmt.Fprintf(os.Stderr, "Auto-uploading bundle to replicated.app...\n")
-		if err := supportbundle.UploadBundleAutoDetect(response.ArchivePath, licenseID, appSlug); err != nil {
+		targetDomain := uploadDomain
+		if targetDomain == "" {
+			targetDomain = "replicated.app"
+		}
+
+		fmt.Fprintf(os.Stderr, "Auto-uploading bundle to %s...\n", targetDomain)
+		if err := supportbundle.UploadBundleAutoDetect(response.ArchivePath, licenseID, appSlug, uploadDomain); err != nil {
 			fmt.Fprintf(os.Stderr, "Auto-upload failed: %v\n", err)
 			fmt.Fprintf(os.Stderr, "You can manually upload the bundle using: support-bundle upload %s\n", response.ArchivePath)
 		} else {

--- a/cmd/troubleshoot/cli/upload.go
+++ b/cmd/troubleshoot/cli/upload.go
@@ -26,7 +26,10 @@ Examples:
   support-bundle upload bundle.tar.gz --license-id YOUR_LICENSE_ID
 
   # Specify both license and app
-  support-bundle upload bundle.tar.gz --license-id YOUR_LICENSE_ID --app-slug my-app`,
+  support-bundle upload bundle.tar.gz --license-id YOUR_LICENSE_ID --app-slug my-app
+
+  # Upload to a custom domain (e.g., development environment)
+  support-bundle upload bundle.tar.gz --upload-domain replicated-app-dev.example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 			bundlePath := args[0]

--- a/cmd/troubleshoot/cli/upload.go
+++ b/cmd/troubleshoot/cli/upload.go
@@ -39,9 +39,10 @@ Examples:
 			// Get upload parameters
 			licenseID := v.GetString("license-id")
 			appSlug := v.GetString("app-slug")
+			uploadDomain := v.GetString("upload-domain")
 
 			// Use auto-detection for uploads
-			if err := supportbundle.UploadBundleAutoDetect(bundlePath, licenseID, appSlug); err != nil {
+			if err := supportbundle.UploadBundleAutoDetect(bundlePath, licenseID, appSlug, uploadDomain); err != nil {
 				return errors.Wrap(err, "upload failed")
 			}
 
@@ -51,6 +52,7 @@ Examples:
 
 	cmd.Flags().String("license-id", "", "license ID for authentication (auto-detected from bundle if not provided)")
 	cmd.Flags().String("app-slug", "", "application slug (auto-detected from bundle if not provided)")
+	cmd.Flags().String("upload-domain", "", "custom domain for upload (default: replicated.app)")
 
 	return cmd
 }

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -400,6 +400,13 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	}
 
 	output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_CONFIGMAPS)), marshalErrors(configMapsErrors))
+
+	// Replicated License
+	licenseData, licenseErr := replicatedLicense(ctx, client, namespaceNames)
+	if licenseErr == nil {
+		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_REPLICATED_LICENSE), bytes.NewBuffer(licenseData))
+	}
+
 	return output, nil
 }
 
@@ -2175,4 +2182,67 @@ func storeCustomResource(name string, objects any, m map[string][]byte) error {
 	m[fmt.Sprintf("%s.json", name)] = j
 	m[fmt.Sprintf("%s.yaml", name)] = y
 	return nil
+}
+
+// replicatedLicense searches for the replicated secret across namespaces,
+// extracts the config.yaml field, decodes it from base64, and extracts the licenseID and appSlug.
+func replicatedLicense(ctx context.Context, client *kubernetes.Clientset, namespaces []string) ([]byte, error) {
+	// Structure to parse the config.yaml content
+	type ConfigYAML struct {
+		License string `yaml:"license"` // This is a YAML string containing the License object
+	}
+
+	type LicenseSpec struct {
+		LicenseID string `yaml:"licenseID"`
+		AppSlug   string `yaml:"appSlug"`
+	}
+
+	type License struct {
+		Spec LicenseSpec `yaml:"spec"`
+	}
+
+	// Search through all namespaces for the replicated secret
+	for _, namespace := range namespaces {
+		secret, err := client.CoreV1().Secrets(namespace).Get(ctx, "replicated", metav1.GetOptions{})
+		if err != nil {
+			// Secret not found in this namespace, continue to next
+			continue
+		}
+
+		// Extract the config.yaml field from the secret data
+		configYAMLBase64, exists := secret.Data["config.yaml"]
+		if !exists {
+			continue
+		}
+
+		// Decode from base64
+		configYAMLBytes := configYAMLBase64 // In Kubernetes, secret.Data already contains decoded bytes
+
+		// Parse the YAML to extract the license field
+		var config ConfigYAML
+		if err := yaml.Unmarshal(configYAMLBytes, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse config.yaml from replicated secret in namespace %s: %w", namespace, err)
+		}
+
+		// Parse the license field (which is a YAML string) to extract licenseID and appSlug
+		var license License
+		if err := yaml.Unmarshal([]byte(config.License), &license); err != nil {
+			return nil, fmt.Errorf("failed to parse license from config.yaml in namespace %s: %w", namespace, err)
+		}
+
+		// Return both licenseID and appSlug as JSON
+		licenseData := map[string]string{
+			"licenseID": license.Spec.LicenseID,
+			"appSlug":   license.Spec.AppSlug,
+		}
+		licenseJSON, err := json.Marshal(licenseData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal license data: %w", err)
+		}
+
+		return licenseJSON, nil
+	}
+
+	// No replicated secret found in any namespace
+	return nil, fmt.Errorf("replicated secret not found in any namespace")
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -61,6 +61,7 @@ const (
 	CLUSTER_RESOURCES_LEASES                      = "leases"
 	CLUSTER_RESOURCES_VOLUME_ATTACHMENTS          = "volumeattachments"
 	CLUSTER_RESOURCES_CONFIGMAPS                  = "configmaps"
+	CLUSTER_RESOURCES_REPLICATED_LICENSE          = "license.json"
 
 	// SelfSubjectRulesReview evaluation responses
 	SELFSUBJECTRULESREVIEW_ERROR_AUTHORIZATION_WEBHOOK_UNSUPPORTED = "webhook authorizer does not support user rule resolution"

--- a/pkg/supportbundle/upload.go
+++ b/pkg/supportbundle/upload.go
@@ -10,7 +10,7 @@ import (
 
 // UploadToReplicatedApp uploads a support bundle directly to replicated.app
 // using the app slug as the upload path
-func UploadToReplicatedApp(bundlePath, licenseID, appSlug string) error {
+func UploadToReplicatedApp(bundlePath, licenseID, appSlug, uploadDomain string) error {
 	// Open the bundle file
 	file, err := os.Open(bundlePath)
 	if err != nil {
@@ -23,8 +23,14 @@ func UploadToReplicatedApp(bundlePath, licenseID, appSlug string) error {
 		return errors.Wrap(err, "failed to stat file")
 	}
 
+	// Use custom domain if provided, otherwise default to replicated.app
+	domain := uploadDomain
+	if domain == "" {
+		domain = "replicated.app"
+	}
+
 	// Build the upload URL using the app slug
-	uploadURL := fmt.Sprintf("https://replicated.app/supportbundle/upload/%s", appSlug)
+	uploadURL := fmt.Sprintf("https://%s/supportbundle/upload/%s", domain, appSlug)
 
 	// Create the request
 	req, err := http.NewRequest("POST", uploadURL, file)
@@ -53,7 +59,7 @@ func UploadToReplicatedApp(bundlePath, licenseID, appSlug string) error {
 }
 
 // UploadBundleAutoDetect uploads a support bundle with automatic license and app slug detection
-func UploadBundleAutoDetect(bundlePath string, providedLicenseID, providedAppSlug string) error {
+func UploadBundleAutoDetect(bundlePath string, providedLicenseID, providedAppSlug, uploadDomain string) error {
 	licenseID := providedLicenseID
 
 	// Always extract from bundle to get app slug (and license if not provided)
@@ -79,9 +85,15 @@ func UploadBundleAutoDetect(bundlePath string, providedLicenseID, providedAppSlu
 		appSlug = extractedAppSlug
 	}
 
+	// Determine target domain for upload message
+	targetDomain := uploadDomain
+	if targetDomain == "" {
+		targetDomain = "replicated.app"
+	}
+
 	// Upload the bundle
-	fmt.Printf("Uploading support bundle to replicated.app...\n")
-	if err := UploadToReplicatedApp(bundlePath, licenseID, appSlug); err != nil {
+	fmt.Printf("Uploading support bundle to %s...\n", targetDomain)
+	if err := UploadToReplicatedApp(bundlePath, licenseID, appSlug, uploadDomain); err != nil {
 		return errors.Wrap(err, "failed to upload bundle")
 	}
 


### PR DESCRIPTION
## Description, Motivation and Context

The new upload functionality is now extended to apps installed through Helm by accessing the licenseID and app slug through the replicated secret in a cluster after installation. Additionally for consistent support bundle generation, the license id and app slug are placed inside of a new license.json file created by the clusterResources collector and is used during the upload process.

There also is a upload-domain flag to override the upload domain for testing on non production, for example passing in
```
--upload-domain replicated-app-(okteto namespace).okteto.repldev.com
```
Will send the upload to your okteto environment

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No