### PR TITLE
added --values and --set flags to lint command

### DIFF
--- a/cmd/preflight/cli/docs.go
+++ b/cmd/preflight/cli/docs.go
@@ -88,7 +88,7 @@ func extractDocs(templateFiles []string, valuesFiles []string, setValues []strin
 		if err != nil {
 			return errors.Wrapf(err, "failed to load values file %s", valuesFile)
 		}
-		values = mergeMaps(values, fileValues)
+		values = preflight.MergeMaps(values, fileValues)
 	}
 
 	// Normalize maps for Helm set merging
@@ -329,25 +329,6 @@ func setNestedValue(m map[string]interface{}, keys []string, value interface{}) 
 		m[keys[0]] = make(map[string]interface{})
 		setNestedValue(m[keys[0]].(map[string]interface{}), keys[1:], value)
 	}
-}
-
-func mergeMaps(base, overlay map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-	for k, v := range base {
-		result[k] = v
-	}
-	for k, v := range overlay {
-		if baseVal, exists := result[k]; exists {
-			if baseMap, ok := baseVal.(map[string]interface{}); ok {
-				if overlayMap, ok := v.(map[string]interface{}); ok {
-					result[k] = mergeMaps(baseMap, overlayMap)
-					continue
-				}
-			}
-		}
-		result[k] = v
-	}
-	return result
 }
 
 func renderTemplate(templateContent string, values map[string]interface{}) (string, error) {

--- a/cmd/preflight/cli/lint.go
+++ b/cmd/preflight/cli/lint.go
@@ -54,9 +54,11 @@ Exit codes:
 			v := viper.GetViper()
 
 			opts := lint.LintOptions{
-				FilePaths: args,
-				Fix:       v.GetBool("fix"),
-				Format:    v.GetString("format"),
+				FilePaths:   args,
+				Fix:         v.GetBool("fix"),
+				Format:      v.GetString("format"),
+				ValuesFiles: v.GetStringSlice("values"),
+				SetValues:   v.GetStringSlice("set"),
 			}
 
 			return runLint(opts)
@@ -65,6 +67,8 @@ Exit codes:
 
 	cmd.Flags().Bool("fix", false, "Automatically fix issues where possible")
 	cmd.Flags().String("format", "text", "Output format: text or json")
+	cmd.Flags().StringSlice("values", []string{}, "Path to YAML files with template values (required for v1beta3 specs)")
+	cmd.Flags().StringSlice("set", []string{}, "Set template values via command line (e.g., --set key=value)")
 
 	return cmd
 }

--- a/cmd/troubleshoot/cli/lint.go
+++ b/cmd/troubleshoot/cli/lint.go
@@ -54,9 +54,11 @@ Exit codes:
 			v := viper.GetViper()
 
 			opts := lint.LintOptions{
-				FilePaths: args,
-				Fix:       v.GetBool("fix"),
-				Format:    v.GetString("format"),
+				FilePaths:   args,
+				Fix:         v.GetBool("fix"),
+				Format:      v.GetString("format"),
+				ValuesFiles: v.GetStringSlice("values"),
+				SetValues:   v.GetStringSlice("set"),
 			}
 
 			return runLint(opts)
@@ -65,6 +67,8 @@ Exit codes:
 
 	cmd.Flags().Bool("fix", false, "Automatically fix issues where possible")
 	cmd.Flags().String("format", "text", "Output format: text or json")
+	cmd.Flags().StringSlice("values", []string{}, "Path to YAML files with template values (required for v1beta3 specs)")
+	cmd.Flags().StringSlice("set", []string{}, "Set template values via command line (e.g., --set key=value)")
 
 	return cmd
 }

--- a/examples/test-error-messages/values-empty.yaml
+++ b/examples/test-error-messages/values-empty.yaml
@@ -1,0 +1,2 @@
+# Empty values file for v1beta3 specs without templates
+{}

--- a/examples/test-error-messages/values-helm-builtins.yaml
+++ b/examples/test-error-messages/values-helm-builtins.yaml
@@ -1,0 +1,1 @@
+minVersion: "1.19.0"

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -28,7 +28,7 @@ func TestLintMultipleFiles(t *testing.T) {
 			valuesFiles: []string{
 				"values-helm-builtins.yaml",
 			},
-			expectErrors: map[string][]string{},
+			expectErrors:   map[string][]string{},
 			expectWarnings: map[string][]string{},
 			expectPass: map[string]bool{
 				"helm-builtins-v1beta3.yaml": true,
@@ -277,7 +277,7 @@ spec:
           - pass:
               when: '>= 1.19.0'
               message: OK`,
-			expectFix:    false, // Template errors in v1beta3 are not auto-fixable, rendering will fail
+			expectFix:    false,                               // Template errors in v1beta3 are not auto-fixable, rendering will fail
 			fixedContent: "Failed to render v1beta3 template", // Expect an error message
 		},
 	}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -15,6 +15,7 @@ func TestLintMultipleFiles(t *testing.T) {
 	tests := []struct {
 		name           string
 		files          []string
+		valuesFiles    []string            // values files for v1beta3 specs
 		expectErrors   map[string][]string // filename -> expected error substrings
 		expectWarnings map[string][]string // filename -> expected warning substrings
 		expectPass     map[string]bool     // filename -> should pass without errors
@@ -24,20 +25,22 @@ func TestLintMultipleFiles(t *testing.T) {
 			files: []string{
 				"helm-builtins-v1beta3.yaml",
 			},
-			expectErrors: map[string][]string{},
-			expectWarnings: map[string][]string{
-				"helm-builtins-v1beta3.yaml": {
-					"Template values that must be provided at runtime: minVersion",
-				},
+			valuesFiles: []string{
+				"values-helm-builtins.yaml",
 			},
+			expectErrors: map[string][]string{},
+			expectWarnings: map[string][]string{},
 			expectPass: map[string]bool{
-				"helm-builtins-v1beta3.yaml": false, // has warnings
+				"helm-builtins-v1beta3.yaml": true,
 			},
 		},
 		{
 			name: "invalid collectors and analyzers",
 			files: []string{
 				"invalid-collectors-analyzers.yaml",
+			},
+			valuesFiles: []string{
+				"values-empty.yaml",
 			},
 			expectErrors: map[string][]string{
 				"invalid-collectors-analyzers.yaml": {
@@ -56,6 +59,9 @@ func TestLintMultipleFiles(t *testing.T) {
 				"missing-apiversion-v1beta3.yaml",
 				"missing-metadata-v1beta3.yaml",
 				"no-analyzers-v1beta3.yaml",
+			},
+			valuesFiles: []string{
+				"values-empty.yaml",
 			},
 			expectErrors: map[string][]string{
 				"missing-apiversion-v1beta3.yaml": {
@@ -95,6 +101,9 @@ func TestLintMultipleFiles(t *testing.T) {
 				"support-bundle-no-collectors-v1beta3.yaml",
 				"support-bundle-valid-v1beta3.yaml",
 			},
+			valuesFiles: []string{
+				"values-empty.yaml",
+			},
 			expectErrors: map[string][]string{
 				"support-bundle-no-collectors-v1beta3.yaml": {
 					"SupportBundle spec must contain 'collectors' or 'hostCollectors'",
@@ -111,6 +120,9 @@ func TestLintMultipleFiles(t *testing.T) {
 				"support-bundle-valid-v1beta3.yaml",
 				"missing-metadata-v1beta3.yaml",
 				"wrong-apiversion-v1beta3.yaml",
+			},
+			valuesFiles: []string{
+				"values-empty.yaml",
 			},
 			expectErrors: map[string][]string{
 				"missing-metadata-v1beta3.yaml": {
@@ -142,11 +154,18 @@ func TestLintMultipleFiles(t *testing.T) {
 				}
 			}
 
+			// Build values file paths
+			var valuesFilePaths []string
+			for _, vf := range tt.valuesFiles {
+				valuesFilePaths = append(valuesFilePaths, filepath.Join(testDir, vf))
+			}
+
 			// Run linter
 			opts := LintOptions{
-				FilePaths: filePaths,
-				Fix:       false,
-				Format:    "text",
+				FilePaths:   filePaths,
+				Fix:         false,
+				Format:      "text",
+				ValuesFiles: valuesFilePaths,
 			}
 
 			results, err := LintFiles(opts)
@@ -246,7 +265,7 @@ spec:
 			fixedContent: "apiVersion: troubleshoot.sh/v1beta3",
 		},
 		{
-			name: "fix missing leading dot in template",
+			name: "v1beta3 template syntax error is reported",
 			content: `apiVersion: troubleshoot.sh/v1beta3
 kind: Preflight
 metadata:
@@ -258,9 +277,15 @@ spec:
           - pass:
               when: '>= 1.19.0'
               message: OK`,
-			expectFix:    true,
-			fixedContent: "{{ .Values.name }}",
+			expectFix:    false, // Template errors in v1beta3 are not auto-fixable, rendering will fail
+			fixedContent: "Failed to render v1beta3 template", // Expect an error message
 		},
+	}
+
+	// Create empty values file for v1beta3 tests
+	emptyValuesFile := filepath.Join(tmpDir, "values-empty.yaml")
+	if err := os.WriteFile(emptyValuesFile, []byte("{}"), 0644); err != nil {
+		t.Fatalf("Failed to write empty values file: %v", err)
 	}
 
 	for _, tt := range tests {
@@ -273,9 +298,10 @@ spec:
 
 			// Run linter with fix enabled
 			opts := LintOptions{
-				FilePaths: []string{testFile},
-				Fix:       true,
-				Format:    "text",
+				FilePaths:   []string{testFile},
+				Fix:         true,
+				Format:      "text",
+				ValuesFiles: []string{emptyValuesFile},
 			}
 
 			results, err := LintFiles(opts)
@@ -294,11 +320,26 @@ spec:
 			}
 			fixedContent := string(fixedBytes)
 
-			// Check if fix was applied
+			// Check if fix was applied or error was reported
 			if tt.expectFix {
 				if !strings.Contains(fixedContent, tt.fixedContent) {
 					t.Errorf("Expected fixed content to contain '%s', but got:\n%s",
 						tt.fixedContent, fixedContent)
+				}
+			} else {
+				// For tests that don't expect fix, check for errors
+				if len(results[0].Errors) > 0 {
+					errorFound := false
+					for _, err := range results[0].Errors {
+						if strings.Contains(err.Message, tt.fixedContent) {
+							errorFound = true
+							break
+						}
+					}
+					if !errorFound {
+						t.Errorf("Expected error containing '%s', but got errors: %v",
+							tt.fixedContent, results[0].Errors)
+					}
 				}
 			}
 		})

--- a/pkg/lint/types.go
+++ b/pkg/lint/types.go
@@ -23,9 +23,11 @@ type LintWarning struct {
 }
 
 type LintOptions struct {
-	FilePaths []string
-	Fix       bool
-	Format    string // "text" or "json"
+	FilePaths   []string
+	Fix         bool
+	Format      string   // "text" or "json"
+	ValuesFiles []string // Path to YAML files with template values (for v1beta3)
+	SetValues   []string // Template values from command line (for v1beta3)
 }
 
 // HasErrors returns true if any of the results contain errors

--- a/pkg/preflight/template.go
+++ b/pkg/preflight/template.go
@@ -33,7 +33,7 @@ func RunTemplate(templateFile string, valuesFiles []string, setValues []string, 
 		if err != nil {
 			return errors.Wrapf(err, "failed to load values file %s", valuesFile)
 		}
-		values = mergeMaps(values, fileValues)
+		values = MergeMaps(values, fileValues)
 	}
 
 	// Apply --set values (Helm semantics)
@@ -165,8 +165,8 @@ func cleanRenderedYAML(content string) string {
 	return strings.Join(cleaned, "\n") + "\n"
 }
 
-// mergeMaps recursively merges two maps
-func mergeMaps(base, overlay map[string]interface{}) map[string]interface{} {
+// MergeMaps recursively merges two maps, with overlay taking precedence
+func MergeMaps(base, overlay map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	// Copy base map
@@ -180,7 +180,7 @@ func mergeMaps(base, overlay map[string]interface{}) map[string]interface{} {
 			// If both are maps, merge recursively
 			if baseMap, ok := baseVal.(map[string]interface{}); ok {
 				if overlayMap, ok := v.(map[string]interface{}); ok {
-					result[k] = mergeMaps(baseMap, overlayMap)
+					result[k] = MergeMaps(baseMap, overlayMap)
 					continue
 				}
 			}

--- a/pkg/preflight/template_test.go
+++ b/pkg/preflight/template_test.go
@@ -430,7 +430,7 @@ func TestRender_V1Beta3_MergeMultipleValuesFiles_And_SetPrecedence(t *testing.T)
 	for _, f := range []string{minimalFile, file1, file3} {
 		m, err := loadValuesFile(f)
 		require.NoError(t, err)
-		vals = mergeMaps(vals, m)
+		vals = MergeMaps(vals, m)
 	}
 
 	// First render without --set; expect NO kubernetes analyzer


### PR DESCRIPTION
## Description, Motivation and Context

This PR updates the lint command to make it so preflight specs that are v1beta3 require a --values or --set flag to be passed in, but remains the same for v1beta2 although if a v1beta2 spec is passed with a values file, it will give a warning that maybe they meant to use a v1beta3 file instead. 

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No