### PR TITLE
Use correct output path for replicasets in cluster resource collector

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -232,7 +232,7 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	// replicasets
 	replicasets, replicasetsErrors := replicasets(ctx, client, namespaceNames)
 	for k, v := range replicasets {
-		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_STATEFULSETS), k), bytes.NewBuffer(v))
+		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_REPLICASETS, k), bytes.NewBuffer(v))
 	}
 	output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_REPLICASETS)), marshalErrors(replicasetsErrors))
 

--- a/test/e2e/support-bundle/cluster_resources_e2e_test.go
+++ b/test/e2e/support-bundle/cluster_resources_e2e_test.go
@@ -47,7 +47,7 @@ func TestClusterResources(t *testing.T) {
 				"roles",
 				"events",
 				"rolebindings",
-				"statefulsets-errors.json",
+				"replicasets",
 				"jobs",
 				"serviceaccounts",
 				"configmaps",


### PR DESCRIPTION
## Description, Motivation and Context

This PR updates the cluster resources collector to use the proper output path for replicasets. It currently writes replicaset resources to a directory called `statefulsets-errors.json`

While collecting a support-bundle from a cluster with restricted permissions, I came across this error:

```
Error: failed to run collect and analyze process: create bundle file: failed to stat file: lstat /var/folders/j8/9dmckpr53fsgt2ttnjvc8x1h0000gn/T/supportbundle3684131245/support-bundle-2025-10-28T14_47_51/cluster-resources/statefulsets-errors.json/default.json: not a directory
Error: failed to run collect and analyze process: create bundle file: failed to stat file: lstat /var/folders/j8/9dmckpr53fsgt2ttnjvc8x1h0000gn/T/supportbundle3684131245/support-bundle-2025-10-28T14_47_51/cluster-resources/statefulsets-errors.json/default.json: not a directory
```

I only ran into it because of permissions issues with collecting statefulsets, so the `statefulsets-errors.json` file was created.

After building a binary from this branch, I was able to collect a bundle successfully.

Fixes: https://github.com/replicatedhq/troubleshoot/issues/1916

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
