### PR TITLE
chore(ci): skip regression-test workflow if dependabot

### DIFF
--- a/.github/workflows/regression-test.yaml
+++ b/.github/workflows/regression-test.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   regression-test:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
 


### PR DESCRIPTION
## Description, Motivation and Context

Adds a condition to the regression-test job in .github/workflows/regression-test.yaml:17 that will skip the entire regression test suite when the PR is from dependabot.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
