### PR TITLE
applied native sidecar fix

### DIFF
--- a/pkg/k8sutil/pod_test.go
+++ b/pkg/k8sutil/pod_test.go
@@ -1,9 +1,11 @@
 package k8sutil
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsPodUnhealthy(t *testing.T) {
@@ -97,5 +99,286 @@ func TestIsPodUnhealthy(t *testing.T) {
 			got := IsPodUnhealthy(tt.pod)
 			req.Equal(tt.want, got)
 		})
+	}
+}
+
+// TestGetPodStatusReason_HealthyNativeSidecar tests that a pod with a running native sidecar
+// is correctly reported as "Running" and not stuck initializing.
+func TestGetPodStatusReason_HealthyNativeSidecar(t *testing.T) {
+	startedTrue := true
+	restartPolicyAlways := corev1.ContainerRestartPolicyAlways
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:          "istio-proxy",
+					Image:         "istio/proxyv2:1.20",
+					RestartPolicy: &restartPolicyAlways, // Native sidecar!
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "myapp:latest",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "istio-proxy",
+					Ready:   true,
+					Started: &startedTrue,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Now(),
+						},
+					},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "app",
+					Ready:   true,
+					Started: &startedTrue,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	reason, message := GetPodStatusReason(pod)
+
+	// Should report as Running, not Init:0/1
+	if reason != "Running" {
+		t.Errorf("Expected reason 'Running', got '%s'", reason)
+	}
+
+	if message != "" {
+		t.Errorf("Expected empty message, got '%s'", message)
+	}
+}
+
+// TestIsPodUnhealthy_HealthyNativeSidecar tests that a pod with a healthy running native sidecar
+// is not marked as unhealthy.
+func TestIsPodUnhealthy_HealthyNativeSidecar(t *testing.T) {
+	startedTrue := true
+	restartPolicyAlways := corev1.ContainerRestartPolicyAlways
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:          "istio-proxy",
+					RestartPolicy: &restartPolicyAlways,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "istio-proxy",
+					Ready:   true,
+					Started: &startedTrue,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "app",
+					Ready:   true,
+					Started: &startedTrue,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+
+	unhealthy := IsPodUnhealthy(pod)
+
+	if unhealthy {
+		t.Error("Pod with healthy native sidecar should not be marked as unhealthy")
+	}
+}
+
+// TestGetPodStatusReason_TraditionalInitAndNativeSidecar tests that a pod with both
+// a completed traditional init container and a running native sidecar is reported as "Running".
+func TestGetPodStatusReason_TraditionalInitAndNativeSidecar(t *testing.T) {
+	startedTrue := true
+	restartPolicyAlways := corev1.ContainerRestartPolicyAlways
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "init-setup",
+					// No RestartPolicy = traditional init container
+				},
+				{
+					Name:          "istio-proxy",
+					RestartPolicy: &restartPolicyAlways, // Native sidecar
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "init-setup",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+							Reason:   "Completed",
+						},
+					},
+				},
+				{
+					Name:    "istio-proxy",
+					Ready:   true,
+					Started: &startedTrue,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:    "app",
+					Ready:   true,
+					Started: &startedTrue,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+
+	reason, _ := GetPodStatusReason(pod)
+
+	if reason != "Running" {
+		t.Errorf("Expected reason 'Running', got '%s'", reason)
+	}
+}
+
+// TestGetPodStatusReason_NativeSidecarCrashLoopBackOff tests that a native sidecar
+// in CrashLoopBackOff is still correctly detected as an error.
+func TestGetPodStatusReason_NativeSidecarCrashLoopBackOff(t *testing.T) {
+	restartPolicyAlways := corev1.ContainerRestartPolicyAlways
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:          "istio-proxy",
+					RestartPolicy: &restartPolicyAlways,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "istio-proxy",
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "CrashLoopBackOff",
+							Message: "Back-off 5m0s restarting failed container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	reason, _ := GetPodStatusReason(pod)
+
+	// Should still catch the error
+	if reason != "Init:CrashLoopBackOff" {
+		t.Errorf("Expected reason 'Init:CrashLoopBackOff', got '%s'", reason)
+	}
+}
+
+// TestGetPodStatusReason_TraditionalInitStuck tests that a traditional init container
+// that is stuck running is still correctly detected as stuck initializing.
+func TestGetPodStatusReason_TraditionalInitStuck(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "init-setup",
+					// No RestartPolicy = traditional init
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "init-setup",
+					Ready: false,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+
+	reason, _ := GetPodStatusReason(pod)
+
+	// Traditional init running = stuck
+	if reason != "Init:0/1" {
+		t.Errorf("Expected reason 'Init:0/1', got '%s'", reason)
 	}
 }


### PR DESCRIPTION
## Description

Fixes a bug where healthy pods with native sidecars were incorrectly reported as "stuck initializing".

**Problem:**  
Native sidecars (init containers with `restartPolicy: Always`) are a Kubernetes 1.28+ feature that run continuously alongside main containers. The pod health detection logic was treating running native sidecars as stuck init containers, causing false positives.

**Current behavior:**
- Pod with running native sidecar → Status: `Init:0/1` → Marked as unhealthy 

**Fixed behavior:**
- Pod with running native sidecar → Status: `Running` → Marked as healthy 

**Solution:**  
Added detection for native sidecars in `GetPodStatusReason()`:
- New helper function `isNativeSidecar()` checks if an init container has `restartPolicy: Always`
- Modified switch statement to skip running native sidecars (treat as healthy)
- Still catches actual errors like CrashLoopBackOff

**Testing:**
- Added 5 new tests for native sidecar scenarios
- All 7 tests pass (7/7)
- Zero regressions in dependent packages
- Backward compatible

Fixes https://app.shortcut.com/replicated/story/130858

## Checklist

- [x] New and existing tests pass locally with introduced changes
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No