### PR TITLE
Fix incorrect field names in nodeResources example files

### DIFF
--- a/examples/preflight/e2e.yaml
+++ b/examples/preflight/e2e.yaml
@@ -92,7 +92,7 @@ spec:
     - nodeResources:
         checkName: Must have 1 node with 2Gi (available) memory and at least 2 cores (on a single node)
         filters:
-          allocatableMemory: 2Gi
+          memoryAllocatable: 2Gi
           cpuCapacity: "2"
         outcomes:
           - pass:

--- a/examples/preflight/node-resources.yaml
+++ b/examples/preflight/node-resources.yaml
@@ -28,7 +28,7 @@ spec:
     - nodeResources:
         checkName: Must have 1 node with 16 GB (available) memory and 10 cores (on a single node)
         filters:
-          allocatableMemory: 16Gi
+          memoryAllocatable: 16Gi
           cpuCapacity: "10"
         outcomes:
           - fail:
@@ -39,7 +39,7 @@ spec:
     - nodeResources:
         checkName: Must have 1 node with 16 GB (available) memory and 4 cores of amd64 arch (on a single node)
         filters:
-          allocatableMemory: 16Gi
+          memoryAllocatable: 16Gi
           cpuArchitecture: amd64
           cpuCapacity: "4"
         outcomes:
@@ -54,7 +54,7 @@ spec:
           selector:
             matchLabel:
               node-role.kubernetes.io/master: ""
-          allocatableMemory: 16Gi
+          memoryAllocatable: 16Gi
           cpuArchitecture: amd64
           cpuCapacity: "6"
         outcomes:

--- a/examples/support-bundle/e2e.yaml
+++ b/examples/support-bundle/e2e.yaml
@@ -77,7 +77,7 @@ spec:
     - nodeResources:
         checkName: Must have 1 node with 2Gi (available) memory and at least 2 cores (on a single node)
         filters:
-          allocatableMemory: 2Gi
+          memoryAllocatable: 2Gi
           cpuCapacity: "2"
         outcomes:
           - pass:


### PR DESCRIPTION
## Summary

Fixes incorrect field names in nodeResources filter examples that caused silent YAML parsing failures.

## Changes

- Changed `allocatableMemory` → `memoryAllocatable` (5 instances across 3 files)

## Impact

The incorrect field names caused filters to be silently ignored during YAML parsing, leading to unexpected analyzer behavior and false failures in preflight checks. Users copying from these examples would experience issues where checks fail despite having sufficient resources.