### PR TITLE
chore(deps): enable Go toolchain updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - "type::security"
     schedule:
       interval: "weekly"
+    # Enable Go toolchain updates to catch stdlib CVEs
+    allow:
+      - dependency-type: "all"
     groups:
       security:
         update-types:
@@ -26,6 +29,9 @@ updates:
       - "type::security"
     schedule:
       interval: "weekly"
+    # Enable Go toolchain updates to catch stdlib CVEs
+    allow:
+      - dependency-type: "all"
     groups:
       security:
         update-types:


### PR DESCRIPTION
## Enable Go Toolchain Updates in Dependabot

### Problem

Dependabot currently tracks Go module dependencies but **not the Go toolchain version itself**. This means stdlib CVEs that are fixed in newer Go patch releases (e.g., go1.24.6 → go1.24.9) are not automatically detected.

Recent grype scans show 10 stdlib CVEs that are already fixed in Go 1.24.8+ but remain in our binaries because we're building with Go 1.24.6.

### Solution

Configure Dependabot to track Go toolchain updates by enabling `allow: dependency-type: all`. This allows Dependabot to track Go version changes in go.mod in addition to module dependencies.

Applied to both root and examples directories.

### Result

When Go releases a security patch (e.g., 1.24.9), Dependabot will automatically create a PR to update the `go` directive in go.mod, allowing stdlib CVEs to be fixed through the same process as module dependencies.

### Related

- https://github.com/replicated-collab/git-guardian-kots/issues/287