### PR TITLE
Fixing Goreleaser in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,17 +200,17 @@ CLIENT_GEN=$(shell which client-gen)
 .PHONY: release
 release: export GITHUB_TOKEN = $(shell echo ${GITHUB_TOKEN_TROUBLESHOOT})
 release:
-	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --config deploy/.goreleaser.yml
+	curl -sL https://git.io/goreleaser | bash -s -- --clean --config deploy/.goreleaser.yml
 
 .PHONY: snapshot-release
 snapshot-release:
-	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --snapshot --config deploy/.goreleaser.snapshot.yml
+	curl -sL https://git.io/goreleaser | bash -s -- --clean --snapshot --config deploy/.goreleaser.snapshot.yml
 	docker push replicated/troubleshoot:alpha
 	docker push replicated/preflight:alpha
 
 .PHONY: local-release
 local-release:
-	curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --snapshot --config deploy/.goreleaser.yaml
+	curl -sL https://git.io/goreleaser | bash -s -- --clean --snapshot --config deploy/.goreleaser.yaml
 	docker tag replicated/troubleshoot:alpha localhost:32000/troubleshoot:alpha
 	docker tag replicated/preflight:alpha localhost:32000/preflight:alpha
 	docker push localhost:32000/troubleshoot:alpha


### PR DESCRIPTION
## Fix goreleaser flag compatibility

### Summary
Replace deprecated `--rm-dist` flag with `--clean` in all goreleaser targets.

### Changes
- Updated `release` target: `--rm-dist` → `--clean`
- Updated `snapshot-release` target: `--rm-dist` → `--clean`
- Updated `local-release` target: `--rm-dist` → `--clean`

Both flags have identical functionality (clean the dist directory before building), `--clean` is just the modern replacement.

### Testing
- [ ] `make release` runs successfully
- [ ] `make snapshot-release` runs successfully
- [ ] `make local-release` runs successfully