### PR TITLE
Don't add extra newlines to files.

### DIFF
--- a/pkg/redact/multi_line.go
+++ b/pkg/redact/multi_line.go
@@ -126,8 +126,7 @@ func (r *MultiLineRedactor) Redact(input io.Reader, path string) io.Reader {
 		}
 
 		if flushLastLine {
-			// Append newline since scanner strip it
-			err = writeBytes(writer, line1, NEW_LINE)
+			err = writeBytes(writer, line1)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
## Description, Motivation and Context
When redacting files, the multi-line redactor always appends an extra newline at the end of parsed files, this is problematic when dealing with binary file formats. 

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
