### PR TITLE
Issue 1980: timeout for supportbundle collect too short

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ cmd/troubleshoot/troubleshoot
 cmd/*/troubleshoot
 /support-bundle
 /.worktrees/
+
+# IDEs
+## IntelliJ / GoLand
+/troubleshoot.iml

--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -132,6 +132,7 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 	cmd.Flags().Bool("load-cluster-specs", false, "enable/disable loading additional troubleshoot specs found within the cluster. Do not load by default unless no specs are provided in the cli args")
 	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
+	cmd.Flags().Int("remote-host-collect-timeout", 30, "timeout in seconds for remote host collect operations (e.g. waiting for pods/daemonsets)")
 	cmd.Flags().StringP("output", "o", "", "specify the output file path for the support bundle")
 	cmd.Flags().Bool("debug", false, "enable debug logging. This is equivalent to --v=0")
 	cmd.Flags().Bool("dry-run", false, "print support bundle spec without collecting anything")

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -201,16 +201,17 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 	}
 
 	createOpts := supportbundle.SupportBundleCreateOpts{
-		CollectorProgressCallback: collectorCB,
-		CollectWithoutPermissions: v.GetBool("collect-without-permissions"),
-		KubernetesRestConfig:      restConfig,
-		Namespace:                 v.GetString("namespace"),
-		ProgressChan:              progressChan,
-		SinceTime:                 sinceTime,
-		OutputPath:                v.GetString("output"),
-		Redact:                    v.GetBool("redact"),
-		FromCLI:                   true,
-		RunHostCollectorsInPod:    mainBundle.Spec.RunHostCollectorsInPod,
+		CollectorProgressCallback:       collectorCB,
+		CollectWithoutPermissions:       v.GetBool("collect-without-permissions"),
+		RemoteHostCollectTimeoutSeconds: v.GetInt("remote-host-collect-timeout"),
+		KubernetesRestConfig:            restConfig,
+		Namespace:                       v.GetString("namespace"),
+		ProgressChan:                    progressChan,
+		SinceTime:                       sinceTime,
+		OutputPath:                      v.GetString("output"),
+		Redact:                          v.GetBool("redact"),
+		FromCLI:                         true,
+		RunHostCollectorsInPod:          mainBundle.Spec.RunHostCollectorsInPod,
 
 		// Phase 4: Tokenization options
 		Tokenize:            v.GetBool("tokenize"),

--- a/cmd/troubleshoot/cli/run_test.go
+++ b/cmd/troubleshoot/cli/run_test.go
@@ -13,6 +13,7 @@ import (
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
 	"github.com/replicatedhq/troubleshoot/pkg/httputil"
 	"github.com/replicatedhq/troubleshoot/pkg/loader"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -435,4 +436,31 @@ func Test_loadInvalidURISpec(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, sb.Spec.Collectors, 3)              // default + clusterInfo + clusterResources
 	assert.NotNil(t, sb.Spec.Collectors[0].ConfigMap) // come from the original spec
+}
+
+func TestCollectTimeoutFlag(t *testing.T) {
+	const defaultCollectTimeout = 30
+
+	// Parse flags and bind to viper without running the full command (avoids k8s connection).
+	// This verifies the flag is defined and viper receives the correct value.
+	bindFlagsFromArgs := func(t *testing.T, args []string) {
+		t.Helper()
+		cmd := RootCmd()
+		require.NoError(t, cmd.Flags().Parse(args))
+		if cmd.PersistentPreRun != nil {
+			cmd.PersistentPreRun(cmd, nil)
+		}
+	}
+
+	t.Run("default value when flag not set", func(t *testing.T) {
+		bindFlagsFromArgs(t, []string{})
+		actualTimeout := viper.GetInt("remote-host-collect-timeout")
+		assert.Equal(t, defaultCollectTimeout, actualTimeout, "remote-host-collect-timeout should default to 30 seconds")
+	})
+
+	t.Run("custom value when flag set", func(t *testing.T) {
+		bindFlagsFromArgs(t, []string{"--remote-host-collect-timeout=90"})
+		actualTimeout := viper.GetInt("remote-host-collect-timeout")
+		assert.Equal(t, 90, actualTimeout, "remote-host-collect-timeout should be 90 when --remote-host-collect-timeout=90 is passed")
+	})
 }

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -366,6 +366,7 @@ func getExecOutputs(
 
 func runRemoteHostCollectors(ctx context.Context, hostCollectors []*troubleshootv1beta2.HostCollect, bundlePath string, opts SupportBundleCreateOpts) (map[string][]byte, error) {
 	output := collect.NewResult()
+	timeoutSec := getCollectTimeout(opts)
 
 	clientset, err := kubernetes.NewForConfig(opts.KubernetesRestConfig)
 	if err != nil {
@@ -388,7 +389,7 @@ func runRemoteHostCollectors(ctx context.Context, hostCollectors []*troubleshoot
 	}
 
 	// wait for at least one pod to be scheduled
-	err = waitForDS(ctx, clientset, ds)
+	err = waitForDS(ctx, clientset, ds, timeoutSec)
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +444,7 @@ func runRemoteHostCollectors(ctx context.Context, hostCollectors []*troubleshoot
 		klog.V(2).Infof("HostCollector spec: %s", specJSON)
 		for _, pod := range pods.Items {
 			eg.Go(func() error {
-				if err := waitForPodRunning(ctx, clientset, &pod); err != nil {
+				if err := waitForPodRunning(ctx, clientset, &pod, timeoutSec); err != nil {
 					return err
 				}
 
@@ -610,8 +611,8 @@ func createHostCollectorDS(ctx context.Context, clientset kubernetes.Interface, 
 	return createdDS, nil
 }
 
-func waitForPodRunning(ctx context.Context, clientset kubernetes.Interface, pod *corev1.Pod) error {
-	timeoutCh := time.After(defaultTimeout * time.Second)
+func waitForPodRunning(ctx context.Context, clientset kubernetes.Interface, pod *corev1.Pod, timeoutSec int) error {
+	timeoutCh := time.After(time.Duration(timeoutSec) * time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -639,8 +640,8 @@ func waitForPodRunning(ctx context.Context, clientset kubernetes.Interface, pod 
 	}
 }
 
-func waitForDS(ctx context.Context, clientset kubernetes.Interface, ds *appsv1.DaemonSet) error {
-	timeoutCh := time.After(defaultTimeout * time.Second)
+func waitForDS(ctx context.Context, clientset kubernetes.Interface, ds *appsv1.DaemonSet, timeoutSec int) error {
+	timeoutCh := time.After(time.Duration(timeoutSec) * time.Second)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -685,4 +686,11 @@ func saveNodeList(result collect.CollectorResult, opts SupportBundleCreateOpts, 
 	}
 
 	return nil
+}
+
+func getCollectTimeout(opts SupportBundleCreateOpts) int {
+	if opts.RemoteHostCollectTimeoutSeconds > 0 {
+		return opts.RemoteHostCollectTimeoutSeconds
+	}
+	return defaultTimeout
 }

--- a/pkg/supportbundle/collect_test.go
+++ b/pkg/supportbundle/collect_test.go
@@ -1,0 +1,24 @@
+package supportbundle
+
+import (
+	"testing"
+)
+
+func TestGetCollectTimeout(t *testing.T) {
+	t.Run("value not set returns default", func(t *testing.T) {
+		opts := SupportBundleCreateOpts{}
+		actualTimeout := getCollectTimeout(opts)
+		if actualTimeout != defaultTimeout {
+			t.Errorf("getCollectTimeout() = %d, want default %d", actualTimeout, defaultTimeout)
+		}
+	})
+
+	t.Run("value set returns configured timeout", func(t *testing.T) {
+		opts := SupportBundleCreateOpts{RemoteHostCollectTimeoutSeconds: 90}
+		actualTimeout := getCollectTimeout(opts)
+		expectedTimeout := 90
+		if actualTimeout != expectedTimeout {
+			t.Errorf("getCollectTimeout() = %d, want %d", actualTimeout, expectedTimeout)
+		}
+	})
+}

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -32,6 +32,7 @@ import (
 type SupportBundleCreateOpts struct {
 	CollectorProgressCallback func(chan interface{}, string)
 	CollectWithoutPermissions bool
+	RemoteHostCollectTimeoutSeconds     int
 	HttpClient                *http.Client
 	KubernetesRestConfig      *rest.Config
 	Namespace                 string

--- a/pkg/supportbundle/supportbundle.go
+++ b/pkg/supportbundle/supportbundle.go
@@ -30,18 +30,18 @@ import (
 )
 
 type SupportBundleCreateOpts struct {
-	CollectorProgressCallback func(chan interface{}, string)
-	CollectWithoutPermissions bool
-	RemoteHostCollectTimeoutSeconds     int
-	HttpClient                *http.Client
-	KubernetesRestConfig      *rest.Config
-	Namespace                 string
-	ProgressChan              chan interface{}
-	SinceTime                 *time.Time
-	OutputPath                string
-	Redact                    bool
-	FromCLI                   bool
-	RunHostCollectorsInPod    bool
+	CollectorProgressCallback       func(chan interface{}, string)
+	CollectWithoutPermissions       bool
+	RemoteHostCollectTimeoutSeconds int
+	HttpClient                      *http.Client
+	KubernetesRestConfig            *rest.Config
+	Namespace                       string
+	ProgressChan                    chan interface{}
+	SinceTime                       *time.Time
+	OutputPath                      string
+	Redact                          bool
+	FromCLI                         bool
+	RunHostCollectorsInPod          bool
 
 	// Phase 4: Tokenization options
 	Tokenize            bool   // Enable intelligent tokenization


### PR DESCRIPTION
## Description, Motivation and Context

The default collect timeout in supportbundle was hard-coded to 120 seconds. This is too short for some cases, so this PR sets it 120 secs and also makes it configurable via CLI flag

Fixes: #1980

## Checklist

- [X] New and existing tests pass locally with introduced changes.
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] The commit message(s) are informative and highlight any breaking changes
- [X] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

