### PR TITLE
feat(analyze): optional additionalDeviceTypes parameter for blockDevices

### DIFF
--- a/config/crds/troubleshoot.sh_analyzers.yaml
+++ b/config/crds/troubleshoot.sh_analyzers.yaml
@@ -880,6 +880,55 @@ spec:
                       - namespace
                       - outcomes
                       type: object
+                    ingressClass:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        ingressClassName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
                     jobStatus:
                       properties:
                         annotations:
@@ -1922,7 +1971,16 @@ spec:
                 items:
                   properties:
                     blockDevices:
+                      description: BlockDevicesAnalyze evaluates host-collected block
+                        device listings (lsblk-based).
                       properties:
+                        additionalDeviceTypes:
+                          description: |-
+                            AdditionalDeviceTypes are extra lsblk TYPE values (e.g. loop, lvm) that may count toward outcomes,
+                            in addition to whole disks and (when IncludeUnmountedPartitions is set) partitions.
+                          items:
+                            type: string
+                          type: array
                         annotations:
                           additionalProperties:
                             type: string

--- a/config/crds/troubleshoot.sh_collectors.yaml
+++ b/config/crds/troubleshoot.sh_collectors.yaml
@@ -2674,7 +2674,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -5933,7 +5935,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -6723,8 +6727,8 @@ spec:
                                 will be made available to those containers which consume them
                                 by name.
 
-                                This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate.
+                                This is a stable field but requires that the
+                                DynamicResourceAllocation feature gate is enabled.
 
                                 This field is immutable.
                               items:
@@ -7184,9 +7188,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -7987,7 +7992,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -8888,6 +8893,24 @@ spec:
                                                     CSRs will be addressed to this
                                                     signer.
                                                   type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
                                               required:
                                               - keyType
                                               - signerName
@@ -9318,6 +9341,42 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              description: |-
+                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                This field is used by the scheduler to identify the PodGroup and apply the
+                                correct group scheduling policies. The Workload object referenced
+                                by this field may not exist at the time the Pod is created.
+                                This field is immutable, but a Workload object with the same name
+                                may be recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name defines the name of the Workload object this Pod belongs to.
+                                    Workload must be in the same namespace as the Pod.
+                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                    until a Workload object is created and observed by the kube-scheduler.
+                                    It must be a DNS subdomain.
+                                  type: string
+                                podGroup:
+                                  description: |-
+                                    PodGroup is the name of the PodGroup within the Workload that this Pod
+                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                    the Pod will remain unschedulable until the Workload object is recreated
+                                    and observed by the kube-scheduler. It must be a DNS label.
+                                  type: string
+                                podGroupReplicaKey:
+                                  description: |-
+                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                    Pod belongs. It is used to distinguish pods belonging to different replicas
+                                    of the same pod group. The pod group policy is applied separately to each replica.
+                                    When set, it must be a DNS label.
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -11199,7 +11258,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -14458,7 +14519,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -15248,8 +15311,8 @@ spec:
                                 will be made available to those containers which consume them
                                 by name.
 
-                                This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate.
+                                This is a stable field but requires that the
+                                DynamicResourceAllocation feature gate is enabled.
 
                                 This field is immutable.
                               items:
@@ -15709,9 +15772,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -16512,7 +16576,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -17413,6 +17477,24 @@ spec:
                                                     CSRs will be addressed to this
                                                     signer.
                                                   type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
                                               required:
                                               - keyType
                                               - signerName
@@ -17843,6 +17925,42 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              description: |-
+                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                This field is used by the scheduler to identify the PodGroup and apply the
+                                correct group scheduling policies. The Workload object referenced
+                                by this field may not exist at the time the Pod is created.
+                                This field is immutable, but a Workload object with the same name
+                                may be recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name defines the name of the Workload object this Pod belongs to.
+                                    Workload must be in the same namespace as the Pod.
+                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                    until a Workload object is created and observed by the kube-scheduler.
+                                    It must be a DNS subdomain.
+                                  type: string
+                                podGroup:
+                                  description: |-
+                                    PodGroup is the name of the PodGroup within the Workload that this Pod
+                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                    the Pod will remain unschedulable until the Workload object is recreated
+                                    and observed by the kube-scheduler. It must be a DNS label.
+                                  type: string
+                                podGroupReplicaKey:
+                                  description: |-
+                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                    Pod belongs. It is used to distinguish pods belonging to different replicas
+                                    of the same pod group. The pod group policy is applied separately to each replica.
+                                    When set, it must be a DNS label.
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -17880,6 +17998,17 @@ spec:
                           type: BoolString
                         namespace:
                           type: string
+                      type: object
+                    supportBundleMetadata:
+                      properties:
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        namespace:
+                          type: string
+                      required:
+                      - namespace
                       type: object
                     sysctl:
                       properties:

--- a/config/crds/troubleshoot.sh_hostcollectors.yaml
+++ b/config/crds/troubleshoot.sh_hostcollectors.yaml
@@ -43,7 +43,16 @@ spec:
                 items:
                   properties:
                     blockDevices:
+                      description: BlockDevicesAnalyze evaluates host-collected block
+                        device listings (lsblk-based).
                       properties:
+                        additionalDeviceTypes:
+                          description: |-
+                            AdditionalDeviceTypes are extra lsblk TYPE values (e.g. loop, lvm) that may count toward outcomes,
+                            in addition to whole disks and (when IncludeUnmountedPartitions is set) partitions.
+                          items:
+                            type: string
+                          type: array
                         annotations:
                           additionalProperties:
                             type: string

--- a/config/crds/troubleshoot.sh_hostpreflights.yaml
+++ b/config/crds/troubleshoot.sh_hostpreflights.yaml
@@ -43,7 +43,16 @@ spec:
                 items:
                   properties:
                     blockDevices:
+                      description: BlockDevicesAnalyze evaluates host-collected block
+                        device listings (lsblk-based).
                       properties:
+                        additionalDeviceTypes:
+                          description: |-
+                            AdditionalDeviceTypes are extra lsblk TYPE values (e.g. loop, lvm) that may count toward outcomes,
+                            in addition to whole disks and (when IncludeUnmountedPartitions is set) partitions.
+                          items:
+                            type: string
+                          type: array
                         annotations:
                           additionalProperties:
                             type: string

--- a/config/crds/troubleshoot.sh_preflights.yaml
+++ b/config/crds/troubleshoot.sh_preflights.yaml
@@ -880,6 +880,55 @@ spec:
                       - namespace
                       - outcomes
                       type: object
+                    ingressClass:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        ingressClassName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
                     jobStatus:
                       properties:
                         annotations:
@@ -4522,7 +4571,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -7781,7 +7832,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -8571,8 +8624,8 @@ spec:
                                 will be made available to those containers which consume them
                                 by name.
 
-                                This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate.
+                                This is a stable field but requires that the
+                                DynamicResourceAllocation feature gate is enabled.
 
                                 This field is immutable.
                               items:
@@ -9032,9 +9085,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -9835,7 +9889,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -10736,6 +10790,24 @@ spec:
                                                     CSRs will be addressed to this
                                                     signer.
                                                   type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
                                               required:
                                               - keyType
                                               - signerName
@@ -11166,6 +11238,42 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              description: |-
+                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                This field is used by the scheduler to identify the PodGroup and apply the
+                                correct group scheduling policies. The Workload object referenced
+                                by this field may not exist at the time the Pod is created.
+                                This field is immutable, but a Workload object with the same name
+                                may be recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name defines the name of the Workload object this Pod belongs to.
+                                    Workload must be in the same namespace as the Pod.
+                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                    until a Workload object is created and observed by the kube-scheduler.
+                                    It must be a DNS subdomain.
+                                  type: string
+                                podGroup:
+                                  description: |-
+                                    PodGroup is the name of the PodGroup within the Workload that this Pod
+                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                    the Pod will remain unschedulable until the Workload object is recreated
+                                    and observed by the kube-scheduler. It must be a DNS label.
+                                  type: string
+                                podGroupReplicaKey:
+                                  description: |-
+                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                    Pod belongs. It is used to distinguish pods belonging to different replicas
+                                    of the same pod group. The pod group policy is applied separately to each replica.
+                                    When set, it must be a DNS label.
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -13047,7 +13155,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -16306,7 +16416,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -17096,8 +17208,8 @@ spec:
                                 will be made available to those containers which consume them
                                 by name.
 
-                                This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate.
+                                This is a stable field but requires that the
+                                DynamicResourceAllocation feature gate is enabled.
 
                                 This field is immutable.
                               items:
@@ -17557,9 +17669,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -18360,7 +18473,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -19261,6 +19374,24 @@ spec:
                                                     CSRs will be addressed to this
                                                     signer.
                                                   type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
                                               required:
                                               - keyType
                                               - signerName
@@ -19691,6 +19822,42 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              description: |-
+                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                This field is used by the scheduler to identify the PodGroup and apply the
+                                correct group scheduling policies. The Workload object referenced
+                                by this field may not exist at the time the Pod is created.
+                                This field is immutable, but a Workload object with the same name
+                                may be recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name defines the name of the Workload object this Pod belongs to.
+                                    Workload must be in the same namespace as the Pod.
+                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                    until a Workload object is created and observed by the kube-scheduler.
+                                    It must be a DNS subdomain.
+                                  type: string
+                                podGroup:
+                                  description: |-
+                                    PodGroup is the name of the PodGroup within the Workload that this Pod
+                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                    the Pod will remain unschedulable until the Workload object is recreated
+                                    and observed by the kube-scheduler. It must be a DNS label.
+                                  type: string
+                                podGroupReplicaKey:
+                                  description: |-
+                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                    Pod belongs. It is used to distinguish pods belonging to different replicas
+                                    of the same pod group. The pod group policy is applied separately to each replica.
+                                    When set, it must be a DNS label.
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -19728,6 +19895,17 @@ spec:
                           type: BoolString
                         namespace:
                           type: string
+                      type: object
+                    supportBundleMetadata:
+                      properties:
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        namespace:
+                          type: string
+                      required:
+                      - namespace
                       type: object
                     sysctl:
                       properties:

--- a/config/crds/troubleshoot.sh_supportbundles.yaml
+++ b/config/crds/troubleshoot.sh_supportbundles.yaml
@@ -911,6 +911,55 @@ spec:
                       - namespace
                       - outcomes
                       type: object
+                    ingressClass:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        checkName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        ingressClassName:
+                          type: string
+                        outcomes:
+                          items:
+                            properties:
+                              fail:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              pass:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                              warn:
+                                properties:
+                                  message:
+                                    type: string
+                                  uri:
+                                    type: string
+                                  when:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        strict:
+                          type: BoolString
+                      required:
+                      - outcomes
+                      type: object
                     jobStatus:
                       properties:
                         annotations:
@@ -4553,7 +4602,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -7812,7 +7863,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -8602,8 +8655,8 @@ spec:
                                 will be made available to those containers which consume them
                                 by name.
 
-                                This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate.
+                                This is a stable field but requires that the
+                                DynamicResourceAllocation feature gate is enabled.
 
                                 This field is immutable.
                               items:
@@ -9063,9 +9116,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -9866,7 +9920,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -10767,6 +10821,24 @@ spec:
                                                     CSRs will be addressed to this
                                                     signer.
                                                   type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
                                               required:
                                               - keyType
                                               - signerName
@@ -11197,6 +11269,42 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              description: |-
+                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                This field is used by the scheduler to identify the PodGroup and apply the
+                                correct group scheduling policies. The Workload object referenced
+                                by this field may not exist at the time the Pod is created.
+                                This field is immutable, but a Workload object with the same name
+                                may be recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name defines the name of the Workload object this Pod belongs to.
+                                    Workload must be in the same namespace as the Pod.
+                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                    until a Workload object is created and observed by the kube-scheduler.
+                                    It must be a DNS subdomain.
+                                  type: string
+                                podGroup:
+                                  description: |-
+                                    PodGroup is the name of the PodGroup within the Workload that this Pod
+                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                    the Pod will remain unschedulable until the Workload object is recreated
+                                    and observed by the kube-scheduler. It must be a DNS label.
+                                  type: string
+                                podGroupReplicaKey:
+                                  description: |-
+                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                    Pod belongs. It is used to distinguish pods belonging to different replicas
+                                    of the same pod group. The pod group policy is applied separately to each replica.
+                                    When set, it must be a DNS label.
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -13078,7 +13186,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -16337,7 +16447,9 @@ spec:
                                         type: integer
                                     type: object
                                   resizePolicy:
-                                    description: Resources resize policy for the container.
+                                    description: |-
+                                      Resources resize policy for the container.
+                                      This field cannot be set on ephemeral containers.
                                     items:
                                       description: ContainerResizePolicy represents
                                         resource resize policy for the container.
@@ -17127,8 +17239,8 @@ spec:
                                 will be made available to those containers which consume them
                                 by name.
 
-                                This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate.
+                                This is a stable field but requires that the
+                                DynamicResourceAllocation feature gate is enabled.
 
                                 This field is immutable.
                               items:
@@ -17588,9 +17700,10 @@ spec:
                                   operator:
                                     description: |-
                                       Operator represents a key's relationship to the value.
-                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                       Exists is equivalent to wildcard for value, so that a pod can
                                       tolerate all taints of a particular category.
+                                      Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                     type: string
                                   tolerationSeconds:
                                     description: |-
@@ -18391,7 +18504,7 @@ spec:
                                               resources:
                                                 description: |-
                                                   resources represents the minimum resources the volume should have.
-                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  Users are allowed to specify resource requirements
                                                   that are lower than previous value but must still be higher than capacity recorded in the
                                                   status field of the claim.
                                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -19292,6 +19405,24 @@ spec:
                                                     CSRs will be addressed to this
                                                     signer.
                                                   type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    userAnnotations allow pod authors to pass additional information to
+                                                    the signer implementation.  Kubernetes does not restrict or validate this
+                                                    metadata in any way.
+
+                                                    These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                    the PodCertificateRequest objects that Kubelet creates.
+
+                                                    Entries are subject to the same validation as object metadata annotations,
+                                                    with the addition that all keys must be domain-prefixed. No restrictions
+                                                    are placed on values, except an overall size limitation on the entire field.
+
+                                                    Signers should document the keys and values they support. Signers should
+                                                    deny requests that contain keys they do not recognize.
+                                                  type: object
                                               required:
                                               - keyType
                                               - signerName
@@ -19722,6 +19853,42 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              description: |-
+                                WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                This field is used by the scheduler to identify the PodGroup and apply the
+                                correct group scheduling policies. The Workload object referenced
+                                by this field may not exist at the time the Pod is created.
+                                This field is immutable, but a Workload object with the same name
+                                may be recreated with different policies. Doing this during pod scheduling
+                                may result in the placement not conforming to the expected policies.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name defines the name of the Workload object this Pod belongs to.
+                                    Workload must be in the same namespace as the Pod.
+                                    If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                    until a Workload object is created and observed by the kube-scheduler.
+                                    It must be a DNS subdomain.
+                                  type: string
+                                podGroup:
+                                  description: |-
+                                    PodGroup is the name of the PodGroup within the Workload that this Pod
+                                    belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                    the Pod will remain unschedulable until the Workload object is recreated
+                                    and observed by the kube-scheduler. It must be a DNS label.
+                                  type: string
+                                podGroupReplicaKey:
+                                  description: |-
+                                    PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                    Pod belongs. It is used to distinguish pods belonging to different replicas
+                                    of the same pod group. The pod group policy is applied separately to each replica.
+                                    When set, it must be a DNS label.
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -19760,6 +19927,17 @@ spec:
                         namespace:
                           type: string
                       type: object
+                    supportBundleMetadata:
+                      properties:
+                        collectorName:
+                          type: string
+                        exclude:
+                          type: BoolString
+                        namespace:
+                          type: string
+                      required:
+                      - namespace
+                      type: object
                     sysctl:
                       properties:
                         collectorName:
@@ -19797,7 +19975,16 @@ spec:
                 items:
                   properties:
                     blockDevices:
+                      description: BlockDevicesAnalyze evaluates host-collected block
+                        device listings (lsblk-based).
                       properties:
+                        additionalDeviceTypes:
+                          description: |-
+                            AdditionalDeviceTypes are extra lsblk TYPE values (e.g. loop, lvm) that may count toward outcomes,
+                            in addition to whole disks and (when IncludeUnmountedPartitions is set) partitions.
+                          items:
+                            type: string
+                          type: array
                         annotations:
                           additionalProperties:
                             type: string

--- a/pkg/analyze/host_block_devices.go
+++ b/pkg/analyze/host_block_devices.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,25 @@ import (
 
 type AnalyzeHostBlockDevices struct {
 	hostAnalyzer *troubleshootv1beta2.BlockDevicesAnalyze
+}
+
+// blockDevicesMatchConfig carries analyzer settings for counting devices toward a blockDevices when-clause
+// ("<name-regex> <op> <count>" against host block_devices.json). A device is eligible when its name matches
+// the regex; its type is "disk", or "part" if includeUnmountedPartitions, or listed in additionalDeviceTypes;
+// size >= minimumAcceptableSize when that is non-zero; it has no mountpoint or filesystem; it is not
+// read-only or removable; and no other row has ParentKernelName equal to its KernelName.
+type blockDevicesMatchConfig struct {
+	minimumAcceptableSize      uint64
+	includeUnmountedPartitions bool
+	additionalDeviceTypes      []string
+}
+
+func matchConfigFromAnalyzer(a *troubleshootv1beta2.BlockDevicesAnalyze) blockDevicesMatchConfig {
+	return blockDevicesMatchConfig{
+		minimumAcceptableSize:      a.MinimumAcceptableSize,
+		includeUnmountedPartitions: a.IncludeUnmountedPartitions,
+		additionalDeviceTypes:      a.AdditionalDeviceTypes,
+	}
 }
 
 func (a *AnalyzeHostBlockDevices) Title() string {
@@ -49,7 +69,7 @@ func (a *AnalyzeHostBlockDevices) Analyze(
 
 // <regexp> <op> <count>
 // example: sdb > 0
-func compareHostBlockDevicesConditionalToActual(conditional string, minimumAcceptableSize uint64, includeUnmountedPartitions bool, devices []collect.BlockDeviceInfo) (res bool, err error) {
+func compareHostBlockDevicesConditionalToActual(conditional string, cfg blockDevicesMatchConfig, devices []collect.BlockDeviceInfo) (res bool, err error) {
 	parts := strings.Split(conditional, " ")
 	if len(parts) != 3 {
 		return false, fmt.Errorf("Expected exactly 3 parts, got %d", len(parts))
@@ -59,7 +79,7 @@ func compareHostBlockDevicesConditionalToActual(conditional string, minimumAccep
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to compile regex %q", parts[0])
 	}
-	count := countEligibleBlockDevices(rx, minimumAcceptableSize, includeUnmountedPartitions, devices)
+	count := countEligibleBlockDevices(rx, cfg, devices)
 
 	desiredInt, err := strconv.Atoi(parts[2])
 	if err != nil {
@@ -82,11 +102,11 @@ func compareHostBlockDevicesConditionalToActual(conditional string, minimumAccep
 	return false, fmt.Errorf("Unexpected operator %q", parts[1])
 }
 
-func countEligibleBlockDevices(rx *regexp.Regexp, minimumAcceptableSize uint64, includeUnmountedPartitions bool, devices []collect.BlockDeviceInfo) int {
+func countEligibleBlockDevices(rx *regexp.Regexp, cfg blockDevicesMatchConfig, devices []collect.BlockDeviceInfo) int {
 	count := 0
 
 	for _, device := range devices {
-		if isEligibleBlockDevice(rx, minimumAcceptableSize, includeUnmountedPartitions, device, devices) {
+		if isEligibleBlockDevice(rx, cfg, device, devices) {
 			count++
 		}
 	}
@@ -94,23 +114,27 @@ func countEligibleBlockDevices(rx *regexp.Regexp, minimumAcceptableSize uint64, 
 	return count
 }
 
-func isEligibleBlockDevice(rx *regexp.Regexp, minimumAcceptableSize uint64, includeUnmountedPartitions bool, device collect.BlockDeviceInfo, devices []collect.BlockDeviceInfo) bool {
+func isEligibleDeviceType(deviceType string, cfg blockDevicesMatchConfig) bool {
+	if deviceType == "disk" {
+		return true
+	}
+	if cfg.includeUnmountedPartitions && deviceType == "part" {
+		return true
+	}
+	return slices.Contains(cfg.additionalDeviceTypes, deviceType)
+}
+
+func isEligibleBlockDevice(rx *regexp.Regexp, cfg blockDevicesMatchConfig, device collect.BlockDeviceInfo, devices []collect.BlockDeviceInfo) bool {
 	if !rx.MatchString(device.Name) {
 		return false
 	}
 
-	if includeUnmountedPartitions {
-		if device.Type != "disk" && device.Type != "part" {
-			return false
-		}
-	} else {
-		if device.Type != "disk" {
-			return false
-		}
+	if !isEligibleDeviceType(device.Type, cfg) {
+		return false
 	}
 
-	if minimumAcceptableSize != 0 {
-		if device.Size < minimumAcceptableSize {
+	if cfg.minimumAcceptableSize != 0 {
+		if device.Size < cfg.minimumAcceptableSize {
 			return false
 		}
 	}
@@ -141,12 +165,10 @@ func isEligibleBlockDevice(rx *regexp.Regexp, minimumAcceptableSize uint64, incl
 }
 
 func (a *AnalyzeHostBlockDevices) CheckCondition(when string, data []byte) (bool, error) {
-
 	var devices []collect.BlockDeviceInfo
 	if err := json.Unmarshal(data, &devices); err != nil {
 		return false, errors.Wrap(err, "failed to unmarshal block devices info")
 	}
 
-	return compareHostBlockDevicesConditionalToActual(when, a.hostAnalyzer.MinimumAcceptableSize, a.hostAnalyzer.IncludeUnmountedPartitions, devices)
-
+	return compareHostBlockDevicesConditionalToActual(when, matchConfigFromAnalyzer(a.hostAnalyzer), devices)
 }

--- a/pkg/analyze/host_block_devices_match_test.go
+++ b/pkg/analyze/host_block_devices_match_test.go
@@ -1,0 +1,102 @@
+package analyzer
+
+import (
+	"testing"
+
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/collect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHostBlockDevices_deviceTypeEligibility documents type rules in isolation (see blockDevicesMatchConfig in host_block_devices.go).
+func TestHostBlockDevices_deviceTypeEligibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     blockDevicesMatchConfig
+		devType string
+		want    bool
+	}{
+		{name: "disk always", cfg: blockDevicesMatchConfig{}, devType: "disk", want: true},
+		{name: "part without flag", cfg: blockDevicesMatchConfig{}, devType: "part", want: false},
+		{name: "part with flag", cfg: blockDevicesMatchConfig{includeUnmountedPartitions: true}, devType: "part", want: true},
+		{name: "loop without additional", cfg: blockDevicesMatchConfig{}, devType: "loop", want: false},
+		{name: "loop with additional", cfg: blockDevicesMatchConfig{additionalDeviceTypes: []string{"loop"}}, devType: "loop", want: true},
+		{name: "lvm with additional", cfg: blockDevicesMatchConfig{additionalDeviceTypes: []string{"lvm"}}, devType: "lvm", want: true},
+		{name: "crypt with additional", cfg: blockDevicesMatchConfig{additionalDeviceTypes: []string{"crypt"}}, devType: "crypt", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isEligibleDeviceType(tt.devType, tt.cfg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestHostBlockDevices_additionalDeviceTypes covers end-to-end analyze behavior for AdditionalDeviceTypes and representative preflights.
+func TestHostBlockDevices_additionalDeviceTypes(t *testing.T) {
+	const rawStoragePass = "At least one raw block device is available for storage."
+	const rawStorageFail = "No raw block devices found. At least one unformatted, unmounted disk is required for storage. Attach a raw disk and ensure it has no filesystem or mount point."
+
+	rawStorageOutcomes := []*troubleshootv1beta2.Outcome{
+		{Fail: &troubleshootv1beta2.SingleOutcome{When: ".* == 0", Message: rawStorageFail}},
+		{Pass: &troubleshootv1beta2.SingleOutcome{When: ".* >= 1", Message: rawStoragePass}},
+	}
+
+	tests := []struct {
+		name         string
+		devices      []collect.BlockDeviceInfo
+		hostAnalyzer *troubleshootv1beta2.BlockDevicesAnalyze
+		want         []*AnalyzeResult
+	}{
+		{
+			name: "preflight-style 10GiB loop0 with includeUnmountedPartitions + additionalDeviceTypes loop",
+			devices: []collect.BlockDeviceInfo{{
+				Name: "loop0", KernelName: "loop0", Type: "loop", Major: 7, Minor: 0,
+				Size: 10737418240, ReadOnly: false, Removable: false,
+			}},
+			hostAnalyzer: &troubleshootv1beta2.BlockDevicesAnalyze{
+				IncludeUnmountedPartitions: true,
+				MinimumAcceptableSize:      10737418240,
+				AdditionalDeviceTypes:      []string{"loop"},
+				Outcomes:                   rawStorageOutcomes,
+			},
+			want: []*AnalyzeResult{{Title: "Block Devices", IsPass: true, Message: rawStoragePass}},
+		},
+		{
+			name: "preflight-style 10GiB LVM with includeUnmountedPartitions + additionalDeviceTypes lvm",
+			devices: []collect.BlockDeviceInfo{{
+				Name: "ceph--vg-lv--osd0", KernelName: "dm-0", Type: "lvm", Major: 252, Minor: 0,
+				Size: 10737418240, ReadOnly: false, Removable: false,
+			}},
+			hostAnalyzer: &troubleshootv1beta2.BlockDevicesAnalyze{
+				IncludeUnmountedPartitions: true,
+				MinimumAcceptableSize:      10737418240,
+				AdditionalDeviceTypes:      []string{"lvm"},
+				Outcomes:                   rawStorageOutcomes,
+			},
+			want: []*AnalyzeResult{{Title: "Block Devices", IsPass: true, Message: rawStoragePass}},
+		},
+		{
+			name: "loop counts with only additionalDeviceTypes (includeUnmountedPartitions false)",
+			devices: []collect.BlockDeviceInfo{{
+				Name: "loop0", KernelName: "loop0", Type: "loop", Major: 7,
+			}},
+			hostAnalyzer: &troubleshootv1beta2.BlockDevicesAnalyze{
+				AdditionalDeviceTypes: []string{"loop"},
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{Pass: &troubleshootv1beta2.SingleOutcome{When: ".* > 0", Message: "Block device available"}},
+					{Fail: &troubleshootv1beta2.SingleOutcome{Message: "No block device available"}},
+				},
+			},
+			want: []*AnalyzeResult{{Title: "Block Devices", IsPass: true, Message: "Block device available"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := analyzeHostBlockDevicesOutput(t, tt.devices, tt.hostAnalyzer)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/analyze/host_block_devices_test.go
+++ b/pkg/analyze/host_block_devices_test.go
@@ -256,23 +256,22 @@ func TestAnalyzeBlockDevices(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			req := require.New(t)
-			b, err := json.Marshal(test.devices)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			getCollectedFileContents := func(filename string) ([]byte, error) {
-				return b, nil
-			}
-
-			result, err := (&AnalyzeHostBlockDevices{test.hostAnalyzer}).Analyze(getCollectedFileContents, nil)
+			result, err := analyzeHostBlockDevicesOutput(t, test.devices, test.hostAnalyzer)
 			if test.expectErr {
 				req.Error(err)
 			} else {
 				req.NoError(err)
 			}
-
 			assert.Equal(t, test.result, result)
 		})
 	}
+}
+
+// analyzeHostBlockDevicesOutput runs the host block device analyzer on marshaled fixture data (shared by match tests).
+func analyzeHostBlockDevicesOutput(t *testing.T, devices []collect.BlockDeviceInfo, hostAnalyzer *troubleshootv1beta2.BlockDevicesAnalyze) ([]*AnalyzeResult, error) {
+	t.Helper()
+	b, err := json.Marshal(devices)
+	require.NoError(t, err)
+	getCollectedFileContents := func(string) ([]byte, error) { return b, nil }
+	return (&AnalyzeHostBlockDevices{hostAnalyzer}).Analyze(getCollectedFileContents, nil)
 }

--- a/pkg/apis/troubleshoot/v1beta2/hostanalyzer_shared.go
+++ b/pkg/apis/troubleshoot/v1beta2/hostanalyzer_shared.go
@@ -60,12 +60,16 @@ type TimeAnalyze struct {
 	Outcomes      []*Outcome `json:"outcomes" yaml:"outcomes"`
 }
 
+// BlockDevicesAnalyze evaluates host-collected block device listings (lsblk-based).
 type BlockDevicesAnalyze struct {
 	AnalyzeMeta                `json:",inline" yaml:",inline"`
-	CollectorName              string     `json:"collectorName,omitempty" yaml:"collectorName,omitempty"`
-	MinimumAcceptableSize      uint64     `json:"minimumAcceptableSize" yaml:"minimumAcceptableSize"`
-	IncludeUnmountedPartitions bool       `json:"includeUnmountedPartitions" yaml:"includeUnmountedPartitions"`
-	Outcomes                   []*Outcome `json:"outcomes" yaml:"outcomes"`
+	CollectorName              string `json:"collectorName,omitempty" yaml:"collectorName,omitempty"`
+	MinimumAcceptableSize      uint64 `json:"minimumAcceptableSize" yaml:"minimumAcceptableSize"`
+	IncludeUnmountedPartitions bool   `json:"includeUnmountedPartitions" yaml:"includeUnmountedPartitions"`
+	// AdditionalDeviceTypes are extra lsblk TYPE values (e.g. loop, lvm) that may count toward outcomes,
+	// in addition to whole disks and (when IncludeUnmountedPartitions is set) partitions.
+	AdditionalDeviceTypes []string   `json:"additionalDeviceTypes,omitempty" yaml:"additionalDeviceTypes,omitempty"`
+	Outcomes              []*Outcome `json:"outcomes" yaml:"outcomes"`
 }
 
 type SystemPackagesAnalyze struct {

--- a/pkg/apis/troubleshoot/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/troubleshoot/v1beta2/zz_generated.deepcopy.go
@@ -448,6 +448,11 @@ func (in *AnalyzerStatus) DeepCopy() *AnalyzerStatus {
 func (in *BlockDevicesAnalyze) DeepCopyInto(out *BlockDevicesAnalyze) {
 	*out = *in
 	in.AnalyzeMeta.DeepCopyInto(&out.AnalyzeMeta)
+	if in.AdditionalDeviceTypes != nil {
+		in, out := &in.AdditionalDeviceTypes, &out.AdditionalDeviceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Outcomes != nil {
 		in, out := &in.Outcomes, &out.Outcomes
 		*out = make([]*Outcome, len(*in))


### PR DESCRIPTION
## Summary
Adds optional `additionalDeviceTypes` on the host `blockDevices` analyzer so preflights can count extra `lsblk` `TYPE` values (e.g. `loop`, `lvm`) toward outcomes, refactors matching behind `blockDevicesMatchConfig`, splits/tests document eligibility, and regenerates CRDs/deepcopy.
## What changed
- **`blockDevices.additionalDeviceTypes`** — New field on `BlockDevicesAnalyze`. Listed types are eligible whether or not `includeUnmountedPartitions` is set; `disk` and optional `part` behavior unchanged.
- **Tests** — `host_block_devices_match_test.go` for type tables and preflight-style cases; `host_block_devices_test.go` keeps classic cases and uses `analyzeHostBlockDevicesOutput`.
## Why
- Makes which non-disk types count **explicit** instead of hardcoding types in Go.
- Supports real and test setups (raw loop, LVM LVs) when specs opt in via YAML.

## Example HostPreflight
```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: HostPreflight
metadata:
  name: block-additional-types
spec:
  collectors:
    - blockDevices: {}
  analyzers:
    - blockDevices:
        checkName: Available block devices (disks, partitions, loop, LVM)
        includeUnmountedPartitions: true
        minimumAcceptableSize: 10737418240 # 10 GiB
        additionalDeviceTypes:
          - loop
          - lvm
        outcomes:
          - fail:
              when: ".* == 0"
              message: No eligible block devices found
          - pass:
              when: ".* >= 1"
              message: At least one eligible block device is available.
```

Shortcut: https://app.shortcut.com/replicated/story/134793/join-preflights-similar-to-ec-v2 

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
