### PR TITLE
fix: improve collector output discoverability

### DIFF
--- a/cmd/troubleshoot/cli/root.go
+++ b/cmd/troubleshoot/cli/root.go
@@ -133,7 +133,7 @@ If no arguments are provided, specs are automatically loaded from the cluster by
 	cmd.Flags().String("since-time", "", "force pod logs collectors to return logs after a specific date (RFC3339)")
 	cmd.Flags().String("since", "", "force pod logs collectors to return logs newer than a relative duration like 5s, 2m, or 3h.")
 	cmd.Flags().Int("remote-host-collect-timeout", 30, "timeout in seconds for remote host collect operations (e.g. waiting for pods/daemonsets)")
-	cmd.Flags().StringP("output", "o", "", "specify the output file path for the support bundle")
+	cmd.Flags().StringP("output", "o", "", "specify the output file path for the support bundle (.tar.gz extension is added automatically)")
 	cmd.Flags().Bool("debug", false, "enable debug logging. This is equivalent to --v=0")
 	cmd.Flags().Bool("dry-run", false, "print support bundle spec without collecting anything")
 	cmd.Flags().Bool("auto-update", true, "enable automatic binary self-update check and install")

--- a/pkg/collect/exec.go
+++ b/pkg/collect/exec.go
@@ -87,16 +87,21 @@ func execWithoutTimeout(clientConfig *rest.Config, bundlePath string, execCollec
 		pod := pods[0]
 		stdout, stderr, execErrors := getExecOutputs(ctx, clientConfig, client, pod, execCollector)
 
+		filePrefix := execCollector.CollectorName
+		if filePrefix == "" {
+			filePrefix = execCollector.ContainerName
+		}
+
 		path := filepath.Join(execCollector.Name, pod.Namespace, pod.Name)
 		if len(stdout) > 0 {
-			output.SaveResult(bundlePath, filepath.Join(path, execCollector.CollectorName+"-stdout.txt"), bytes.NewBuffer(stdout))
+			output.SaveResult(bundlePath, filepath.Join(path, filePrefix+"-stdout.txt"), bytes.NewBuffer(stdout))
 		}
 		if len(stderr) > 0 {
-			output.SaveResult(bundlePath, filepath.Join(path, execCollector.CollectorName+"-stderr.txt"), bytes.NewBuffer(stderr))
+			output.SaveResult(bundlePath, filepath.Join(path, filePrefix+"-stderr.txt"), bytes.NewBuffer(stderr))
 		}
 
 		if len(execErrors) > 0 {
-			output.SaveResult(bundlePath, filepath.Join(path, execCollector.CollectorName+"-errors.json"), marshalErrors(execErrors))
+			output.SaveResult(bundlePath, filepath.Join(path, filePrefix+"-errors.json"), marshalErrors(execErrors))
 		}
 	}
 


### PR DESCRIPTION
## Description, Motivation and Context

- Update `--output` flag help text to document that `.tar.gz` is automatically appended to the provided path
- Exec collector now falls back to `containerName` for output file naming when `collectorName` is not set, instead of producing bare `-stdout.txt` / `-stderr.txt` filenames

Fixes: [sc-136406](https://app.shortcut.com/replicated/story/136406)

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
