### PR TITLE
fix: record skipped collectors in bundle and improve CLI warnings

### DIFF
--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -172,9 +172,12 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 				case string:
 					if strings.Contains(msg, "skipping collector") {
 						klog.Warningf("Collecting support bundle: %s", msg)
+					} else {
+						klog.Infof("Collecting support bundle: %s", msg)
 					}
+				default:
+					klog.Infof("Collecting support bundle: %v", msg)
 				}
-				klog.Infof("Collecting support bundle: %v", msg)
 			}
 		}()
 	} else {

--- a/cmd/troubleshoot/cli/run.go
+++ b/cmd/troubleshoot/cli/run.go
@@ -166,6 +166,14 @@ func runTroubleshoot(v *viper.Viper, args []string) error {
 		go func() {
 			defer wg.Done()
 			for msg := range progressChan {
+				switch msg := msg.(type) {
+				case error:
+					klog.Warningf("Collecting support bundle: %v", msg)
+				case string:
+					if strings.Contains(msg, "skipping collector") {
+						klog.Warningf("Collecting support bundle: %s", msg)
+					}
+				}
 				klog.Infof("Collecting support bundle: %v", msg)
 			}
 		}()

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -322,10 +322,10 @@ func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData map[str
 	c := CollectorResult{}
 	if err := c.SaveResult(bundlePath, "skipped-collectors.json", bytes.NewReader(skippedJSON)); err != nil {
 		klog.Errorf("Failed to save skipped collectors: %v", err)
+	} else {
+		// Write to collected data to return downstream
+		maps.Copy(allCollectedData, c)
 	}
-
-	// Write to collected data to return downstream
-	maps.Copy(allCollectedData, c)
 }
 
 // Ensure Copy collectors are last in the list

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -324,7 +325,7 @@ func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData map[str
 	}
 
 	// Write to collected data to return downstream
-	c.AddResult(allCollectedData)
+	maps.Copy(allCollectedData, c)
 }
 
 // Ensure Copy collectors are last in the list

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -317,11 +315,6 @@ func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData Collect
 		return
 	}
 	allCollectedData["skipped-collectors.json"] = skippedJSON
-	if bundlePath != "" {
-		if writeErr := os.MkdirAll(bundlePath, 0755); writeErr == nil {
-			_ = os.WriteFile(filepath.Join(bundlePath, "skipped-collectors.json"), skippedJSON, 0644)
-		}
-	}
 }
 
 // Ensure Copy collectors are last in the list

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -294,6 +296,32 @@ func DedupCollectors(allCollectors []*troubleshootv1beta2.Collect) []*troublesho
 		}
 	}
 	return finalCollectors
+}
+
+// SkippedCollector records information about a collector that was skipped during collection.
+type SkippedCollector struct {
+	Collector string   `json:"collector"`
+	Reason    string   `json:"reason"`
+	Errors    []string `json:"errors"`
+	Timestamp string   `json:"timestamp"`
+}
+
+// WriteSkippedCollectors marshals the skipped collectors list and writes it to both
+// the in-memory collected data map and optionally to disk at bundlePath.
+func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData CollectorResult, bundlePath string) {
+	if len(skipped) == 0 {
+		return
+	}
+	skippedJSON, err := json.Marshal(skipped)
+	if err != nil {
+		return
+	}
+	allCollectedData["skipped-collectors.json"] = skippedJSON
+	if bundlePath != "" {
+		if writeErr := os.MkdirAll(bundlePath, 0755); writeErr == nil {
+			_ = os.WriteFile(filepath.Join(bundlePath, "skipped-collectors.json"), skippedJSON, 0644)
+		}
+	}
 }
 
 // Ensure Copy collectors are last in the list

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -308,7 +308,7 @@ type SkippedCollector struct {
 
 // WriteSkippedCollectors marshals the skipped collectors list and saves it
 // using SaveResult which handles both in-memory and on-disk storage.
-func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData CollectorResult, bundlePath string) {
+func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData map[string][]byte, bundlePath string) {
 	if len(skipped) == 0 {
 		return
 	}
@@ -316,9 +316,15 @@ func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData Collect
 	if err != nil {
 		return
 	}
-	if err := allCollectedData.SaveResult(bundlePath, "skipped-collectors.json", bytes.NewReader(skippedJSON)); err != nil {
+
+	// Either write to bundle path or memory
+	c := CollectorResult{}
+	if err := c.SaveResult(bundlePath, "skipped-collectors.json", bytes.NewReader(skippedJSON)); err != nil {
 		klog.Errorf("Failed to save skipped collectors: %v", err)
 	}
+
+	// Write to collected data to return downstream
+	c.AddResult(allCollectedData)
 }
 
 // Ensure Copy collectors are last in the list

--- a/pkg/collect/collector.go
+++ b/pkg/collect/collector.go
@@ -1,6 +1,7 @@
 package collect
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/replicatedhq/troubleshoot/pkg/multitype"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 )
 
 type Collector interface {
@@ -304,8 +306,8 @@ type SkippedCollector struct {
 	Timestamp string   `json:"timestamp"`
 }
 
-// WriteSkippedCollectors marshals the skipped collectors list and writes it to both
-// the in-memory collected data map and optionally to disk at bundlePath.
+// WriteSkippedCollectors marshals the skipped collectors list and saves it
+// using SaveResult which handles both in-memory and on-disk storage.
 func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData CollectorResult, bundlePath string) {
 	if len(skipped) == 0 {
 		return
@@ -314,7 +316,9 @@ func WriteSkippedCollectors(skipped []SkippedCollector, allCollectedData Collect
 	if err != nil {
 		return
 	}
-	allCollectedData["skipped-collectors.json"] = skippedJSON
+	if err := allCollectedData.SaveResult(bundlePath, "skipped-collectors.json", bytes.NewReader(skippedJSON)); err != nil {
+		klog.Errorf("Failed to save skipped collectors: %v", err)
+	}
 }
 
 // Ensure Copy collectors are last in the list

--- a/pkg/collect/collector_test.go
+++ b/pkg/collect/collector_test.go
@@ -1,6 +1,9 @@
 package collect
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -516,6 +519,91 @@ func TestEnsureCopyLast(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := EnsureCopyLast(tt.allCollectors)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWriteSkippedCollectors(t *testing.T) {
+	tests := []struct {
+		name        string
+		skipped     []SkippedCollector
+		bundlePath  string
+		useTempDir  bool
+		wantInMap   bool
+		wantOnDisk  bool
+		wantEntries []SkippedCollector
+	}{
+		{
+			name:       "empty skipped list does nothing",
+			skipped:    nil,
+			bundlePath: "",
+			wantInMap:  false,
+		},
+		{
+			name: "in-memory only when bundlePath is empty",
+			skipped: []SkippedCollector{
+				{Collector: "clusterResources", Reason: "excluded", Timestamp: "2026-01-01T00:00:00Z"},
+			},
+			bundlePath: "",
+			wantInMap:  true,
+			wantOnDisk: false,
+			wantEntries: []SkippedCollector{
+				{Collector: "clusterResources", Reason: "excluded", Timestamp: "2026-01-01T00:00:00Z"},
+			},
+		},
+		{
+			name: "writes to disk when bundlePath is set",
+			skipped: []SkippedCollector{
+				{Collector: "clusterResources", Reason: "excluded", Timestamp: "2026-01-01T00:00:00Z"},
+				{Collector: "logs", Reason: "insufficient RBAC permissions", Errors: []string{"pods is forbidden"}, Timestamp: "2026-01-01T00:00:01Z"},
+			},
+			useTempDir: true,
+			wantInMap:  true,
+			wantOnDisk: true,
+			wantEntries: []SkippedCollector{
+				{Collector: "clusterResources", Reason: "excluded", Timestamp: "2026-01-01T00:00:00Z"},
+				{Collector: "logs", Reason: "insufficient RBAC permissions", Errors: []string{"pods is forbidden"}, Timestamp: "2026-01-01T00:00:01Z"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundlePath := tt.bundlePath
+			if tt.useTempDir {
+				bundlePath = t.TempDir()
+			}
+
+			result := CollectorResult{}
+			WriteSkippedCollectors(tt.skipped, result, bundlePath)
+
+			if !tt.wantInMap {
+				assert.Empty(t, result)
+				return
+			}
+
+			// Verify in-memory entry exists
+			if bundlePath == "" {
+				// In-memory mode: data is stored in the map
+				data, ok := result["skipped-collectors.json"]
+				require.True(t, ok, "skipped-collectors.json should be in result map")
+				require.NotNil(t, data)
+
+				var got []SkippedCollector
+				require.NoError(t, json.Unmarshal(data, &got))
+				assert.Equal(t, tt.wantEntries, got)
+			} else {
+				// On-disk mode: map entry exists with nil value, file is on disk
+				_, ok := result["skipped-collectors.json"]
+				require.True(t, ok, "skipped-collectors.json should be in result map")
+
+				diskData, err := os.ReadFile(filepath.Join(bundlePath, "skipped-collectors.json"))
+				require.NoError(t, err)
+
+				var got []SkippedCollector
+				require.NoError(t, json.Unmarshal(diskData, &got))
+				assert.Equal(t, tt.wantEntries, got)
+			}
 		})
 	}
 }

--- a/pkg/collect/exec.go
+++ b/pkg/collect/exec.go
@@ -87,9 +87,14 @@ func execWithoutTimeout(clientConfig *rest.Config, bundlePath string, execCollec
 		pod := pods[0]
 		stdout, stderr, execErrors := getExecOutputs(ctx, clientConfig, client, pod, execCollector)
 
+		container := pod.Spec.Containers[0].Name
+		if execCollector.ContainerName != "" {
+			container = execCollector.ContainerName
+		}
+
 		filePrefix := execCollector.CollectorName
 		if filePrefix == "" {
-			filePrefix = execCollector.ContainerName
+			filePrefix = container
 		}
 
 		path := filepath.Join(execCollector.Name, pod.Namespace, pod.Name)

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -87,9 +88,7 @@ func (r CollectorResult) SymLinkResult(bundlePath, relativeLinkPath, relativeFil
 // It also ensures that when operating on the results in memory (e.g preflights),
 // all files are included.
 func (r CollectorResult) AddResult(other CollectorResult) {
-	for k, v := range other {
-		r[k] = v
-	}
+	maps.Copy(other, r)
 }
 
 // SaveResult saves the collector result to relativePath file on disk. If bundlePath is

--- a/pkg/collect/result.go
+++ b/pkg/collect/result.go
@@ -88,7 +88,7 @@ func (r CollectorResult) SymLinkResult(bundlePath, relativeLinkPath, relativeFil
 // It also ensures that when operating on the results in memory (e.g preflights),
 // all files are included.
 func (r CollectorResult) AddResult(other CollectorResult) {
-	maps.Copy(other, r)
+	maps.Copy(r, other)
 }
 
 // SaveResult saves the collector result to relativePath file on disk. If bundlePath is

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -245,13 +245,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 	// move Copy Collectors if any to the end of the execution list
 	allCollectors = collect.EnsureCopyLast(allCollectors)
 
-	type skippedCollector struct {
-		Collector string   `json:"collector"`
-		Reason    string   `json:"reason"`
-		Errors    []string `json:"errors"`
-		Timestamp string   `json:"timestamp"`
-	}
-	var skippedCollectors []skippedCollector
+	var skippedCollectors []collect.SkippedCollector
 
 	for i, collector := range allCollectors {
 		_, span := otel.Tracer(constants.LIB_TRACER_NAME).Start(ctx, collector.Title())
@@ -263,7 +257,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 			span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 			span.End()
 
-			skippedCollectors = append(skippedCollectors, skippedCollector{
+			skippedCollectors = append(skippedCollectors, collect.SkippedCollector{
 				Collector: collector.Title(),
 				Reason:    "excluded",
 				Timestamp: time.Now().Format(time.RFC3339),
@@ -291,7 +285,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 				for _, e := range rbacErrors {
 					errorMessages = append(errorMessages, e.Error())
 				}
-				skippedCollectors = append(skippedCollectors, skippedCollector{
+				skippedCollectors = append(skippedCollectors, collect.SkippedCollector{
 					Collector: collector.Title(),
 					Reason:    "insufficient RBAC permissions",
 					Errors:    errorMessages,
@@ -349,16 +343,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 	}
 
 	// Write skipped collectors manifest so users can see what was missed
-	if len(skippedCollectors) > 0 {
-		if skippedJSON, err := json.Marshal(skippedCollectors); err == nil {
-			allCollectedData["skipped-collectors.json"] = skippedJSON
-			if opts.BundlePath != "" {
-				if writeErr := os.MkdirAll(opts.BundlePath, 0755); writeErr == nil {
-					_ = os.WriteFile(filepath.Join(opts.BundlePath, "skipped-collectors.json"), skippedJSON, 0644)
-				}
-			}
-		}
-	}
+	collect.WriteSkippedCollectors(skippedCollectors, allCollectedData, opts.BundlePath)
 
 	// The values of map entries will contain the collected data in bytes if the data was not stored to disk
 	collectResult.AllCollectedData = allCollectedData

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -245,6 +245,14 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 	// move Copy Collectors if any to the end of the execution list
 	allCollectors = collect.EnsureCopyLast(allCollectors)
 
+	type skippedCollector struct {
+		Collector string   `json:"collector"`
+		Reason    string   `json:"reason"`
+		Errors    []string `json:"errors"`
+		Timestamp string   `json:"timestamp"`
+	}
+	var skippedCollectors []skippedCollector
+
 	for i, collector := range allCollectors {
 		_, span := otel.Tracer(constants.LIB_TRACER_NAME).Start(ctx, collector.Title())
 		span.SetAttributes(attribute.String("type", reflect.TypeOf(collector).String()))
@@ -254,6 +262,13 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 			klog.V(1).Infof("excluding %q collector", collector.Title())
 			span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 			span.End()
+
+			skippedCollectors = append(skippedCollectors, skippedCollector{
+				Collector: collector.Title(),
+				Reason:    "excluded",
+				Timestamp: time.Now().Format(time.RFC3339),
+			})
+
 			continue
 		}
 
@@ -270,6 +285,19 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 				}
 				span.SetStatus(codes.Error, "skipping collector, insufficient RBAC permissions")
 				span.End()
+
+				rbacErrors := collector.GetRBACErrors()
+				errorMessages := make([]string, 0, len(rbacErrors))
+				for _, e := range rbacErrors {
+					errorMessages = append(errorMessages, e.Error())
+				}
+				skippedCollectors = append(skippedCollectors, skippedCollector{
+					Collector: collector.Title(),
+					Reason:    "insufficient RBAC permissions",
+					Errors:    errorMessages,
+					Timestamp: time.Now().Format(time.RFC3339),
+				})
+
 				continue
 			}
 		}
@@ -318,6 +346,18 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 			allCollectedData[k] = v
 		}
 		span.End()
+	}
+
+	// Write skipped collectors manifest so users can see what was missed
+	if len(skippedCollectors) > 0 {
+		if skippedJSON, err := json.Marshal(skippedCollectors); err == nil {
+			allCollectedData["skipped-collectors.json"] = skippedJSON
+			if opts.BundlePath != "" {
+				if writeErr := os.MkdirAll(opts.BundlePath, 0755); writeErr == nil {
+					_ = os.WriteFile(filepath.Join(opts.BundlePath, "skipped-collectors.json"), skippedJSON, 0644)
+				}
+			}
+		}
 	}
 
 	// The values of map entries will contain the collected data in bytes if the data was not stored to disk

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -184,7 +184,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 
 	allCollectorsMap := make(map[reflect.Type][]collect.Collector)
 	collectorTypeOrder := make([]reflect.Type, 0) // Preserve order of collector types
-	allCollectedData := collect.CollectorResult{}
+	allCollectedData := make(map[string][]byte)
 
 	for _, desiredCollector := range collectSpecs {
 		if collectorInterface, ok := collect.GetCollector(desiredCollector, opts.BundlePath, opts.Namespace, opts.KubernetesRestConfig, k8sClient, nil); ok {

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -184,7 +184,7 @@ func CollectWithContext(ctx context.Context, opts CollectOpts, p *troubleshootv1
 
 	allCollectorsMap := make(map[reflect.Type][]collect.Collector)
 	collectorTypeOrder := make([]reflect.Type, 0) // Preserve order of collector types
-	allCollectedData := make(map[string][]byte)
+	allCollectedData := collect.CollectorResult{}
 
 	for _, desiredCollector := range collectSpecs {
 		if collectorInterface, ok := collect.GetCollector(desiredCollector, opts.BundlePath, opts.Namespace, opts.KubernetesRestConfig, k8sClient, nil); ok {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -155,13 +155,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 	// move Copy Collectors if any to the end of the execution list
 	allCollectors = collect.EnsureCopyLast(allCollectors)
 
-	type skippedCollector struct {
-		Collector string   `json:"collector"`
-		Reason    string   `json:"reason"`
-		Errors    []string `json:"errors"`
-		Timestamp string   `json:"timestamp"`
-	}
-	var skippedCollectors []skippedCollector
+	var skippedCollectors []collect.SkippedCollector
 
 	for _, collector := range allCollectors {
 		_, span := otel.Tracer(constants.LIB_TRACER_NAME).Start(ctx, collector.Title())
@@ -174,7 +168,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 			span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 			span.End()
 
-			skippedCollectors = append(skippedCollectors, skippedCollector{
+			skippedCollectors = append(skippedCollectors, collect.SkippedCollector{
 				Collector: collector.Title(),
 				Reason:    "excluded",
 				Timestamp: time.Now().Format(time.RFC3339),
@@ -196,7 +190,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 				for _, e := range rbacErrors {
 					errorMessages = append(errorMessages, e.Error())
 				}
-				skippedCollectors = append(skippedCollectors, skippedCollector{
+				skippedCollectors = append(skippedCollectors, collect.SkippedCollector{
 					Collector: collector.Title(),
 					Reason:    "insufficient RBAC permissions",
 					Errors:    errorMessages,
@@ -236,14 +230,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 	}
 
 	// Write skipped collectors manifest to the bundle so users can see what was missed
-	if len(skippedCollectors) > 0 {
-		if skippedJSON, err := json.Marshal(skippedCollectors); err == nil {
-			allCollectedData["skipped-collectors.json"] = skippedJSON
-			if writeErr := os.MkdirAll(bundlePath, 0755); writeErr == nil {
-				_ = os.WriteFile(filepath.Join(bundlePath, "skipped-collectors.json"), skippedJSON, 0644)
-			}
-		}
-	}
+	collect.WriteSkippedCollectors(skippedCollectors, allCollectedData, bundlePath)
 
 	collectResult := allCollectedData
 

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -106,7 +106,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 
 	allCollectorsMap := make(map[reflect.Type][]collect.Collector)
 	collectorTypeOrder := make([]reflect.Type, 0) // Preserve order of collector types
-	allCollectedData := collect.CollectorResult{}
+	allCollectedData := map[string][]byte{}
 
 	for _, desiredCollector := range collectSpecs {
 		if collectorInterface, ok := collect.GetCollector(desiredCollector, bundlePath, opts.Namespace, opts.KubernetesRestConfig, k8sClient, opts.SinceTime); ok {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -39,9 +39,8 @@ import (
 )
 
 const (
-	selectorLabelKey   = "ds-selector-label"
-	selectorLabelValue = "remote-host-collector"
-	defaultTimeout     = 30
+	selectorLabelKey = "ds-selector-label"
+	defaultTimeout   = 30
 )
 
 func runHostCollectors(ctx context.Context, hostCollectors []*troubleshootv1beta2.HostCollect, additionalRedactors *troubleshootv1beta2.Redactor, bundlePath string, opts SupportBundleCreateOpts) (collect.CollectorResult, error) {

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -155,6 +155,14 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 	// move Copy Collectors if any to the end of the execution list
 	allCollectors = collect.EnsureCopyLast(allCollectors)
 
+	type skippedCollector struct {
+		Collector string   `json:"collector"`
+		Reason    string   `json:"reason"`
+		Errors    []string `json:"errors"`
+		Timestamp string   `json:"timestamp"`
+	}
+	var skippedCollectors []skippedCollector
+
 	for _, collector := range allCollectors {
 		_, span := otel.Tracer(constants.LIB_TRACER_NAME).Start(ctx, collector.Title())
 		span.SetAttributes(attribute.String("type", reflect.TypeOf(collector).String()))
@@ -165,6 +173,13 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 			opts.CollectorProgressCallback(opts.ProgressChan, msg)
 			span.SetAttributes(attribute.Bool(constants.EXCLUDED, true))
 			span.End()
+
+			skippedCollectors = append(skippedCollectors, skippedCollector{
+				Collector: collector.Title(),
+				Reason:    "excluded",
+				Timestamp: time.Now().Format(time.RFC3339),
+			})
+
 			continue
 		}
 
@@ -175,6 +190,19 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 				opts.CollectorProgressCallback(opts.ProgressChan, msg)
 				span.SetStatus(codes.Error, "skipping collector, insufficient RBAC permissions")
 				span.End()
+
+				rbacErrors := collector.GetRBACErrors()
+				errorMessages := make([]string, 0, len(rbacErrors))
+				for _, e := range rbacErrors {
+					errorMessages = append(errorMessages, e.Error())
+				}
+				skippedCollectors = append(skippedCollectors, skippedCollector{
+					Collector: collector.Title(),
+					Reason:    "insufficient RBAC permissions",
+					Errors:    errorMessages,
+					Timestamp: time.Now().Format(time.RFC3339),
+				})
+
 				continue
 			}
 		}
@@ -205,6 +233,16 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 			allCollectedData[k] = v
 		}
 		span.End()
+	}
+
+	// Write skipped collectors manifest to the bundle so users can see what was missed
+	if len(skippedCollectors) > 0 {
+		if skippedJSON, err := json.Marshal(skippedCollectors); err == nil {
+			allCollectedData["skipped-collectors.json"] = skippedJSON
+			if writeErr := os.MkdirAll(bundlePath, 0755); writeErr == nil {
+				_ = os.WriteFile(filepath.Join(bundlePath, "skipped-collectors.json"), skippedJSON, 0644)
+			}
+		}
 	}
 
 	collectResult := allCollectedData

--- a/pkg/supportbundle/collect.go
+++ b/pkg/supportbundle/collect.go
@@ -106,7 +106,7 @@ func runCollectors(ctx context.Context, collectors []*troubleshootv1beta2.Collec
 
 	allCollectorsMap := make(map[reflect.Type][]collect.Collector)
 	collectorTypeOrder := make([]reflect.Type, 0) // Preserve order of collector types
-	allCollectedData := make(map[string][]byte)
+	allCollectedData := collect.CollectorResult{}
 
 	for _, desiredCollector := range collectSpecs {
 		if collectorInterface, ok := collect.GetCollector(desiredCollector, bundlePath, opts.Namespace, opts.KubernetesRestConfig, k8sClient, opts.SinceTime); ok {

--- a/test/e2e/support-bundle/skipped_collectors_e2e_test.go
+++ b/test/e2e/support-bundle/skipped_collectors_e2e_test.go
@@ -1,0 +1,72 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestSkippedCollectors(t *testing.T) {
+	feature := features.New("Skipped Collectors").
+		Assess("bundle contains skipped-collectors.json for excluded collectors", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			var out bytes.Buffer
+
+			supportBundleName := "skipped-collectors-test"
+			tarPath := fmt.Sprintf("%s.tar.gz", supportBundleName)
+			cmd := exec.CommandContext(ctx, sbBinary(), "spec/skippedCollectors.yaml",
+				"--interactive=false",
+				fmt.Sprintf("-o=%s", supportBundleName),
+			)
+			cmd.Stdout = &out
+			cmd.Stderr = &out
+			err := cmd.Run()
+			if err != nil {
+				t.Fatalf("support-bundle command failed: %v\nOutput: %s", err, out.String())
+			}
+
+			defer func() {
+				err := os.Remove(tarPath)
+				if err != nil {
+					t.Fatal("Error removing file:", err)
+				}
+			}()
+
+			// Read skipped-collectors.json from the bundle
+			skippedJSON, err := readFileFromTar(tarPath, fmt.Sprintf("%s/skipped-collectors.json", supportBundleName))
+			require.NoError(t, err, "skipped-collectors.json should exist in the bundle")
+
+			var skipped []struct {
+				Collector string   `json:"collector"`
+				Reason    string   `json:"reason"`
+				Errors    []string `json:"errors"`
+				Timestamp string   `json:"timestamp"`
+			}
+			err = json.Unmarshal(skippedJSON, &skipped)
+			require.NoError(t, err)
+
+			// Both excluded collectors should be recorded
+			assert.Len(t, skipped, 2)
+
+			collectors := map[string]string{}
+			for _, s := range skipped {
+				collectors[s.Collector] = s.Reason
+				assert.NotEmpty(t, s.Timestamp, "timestamp should be set")
+			}
+
+			assert.Equal(t, "excluded", collectors["cluster-resources"])
+			assert.Equal(t, "excluded", collectors["cluster-info"])
+
+			return ctx
+		}).Feature()
+
+	testenv.Test(t, feature)
+}

--- a/test/e2e/support-bundle/spec/skippedCollectors.yaml
+++ b/test/e2e/support-bundle/spec/skippedCollectors.yaml
@@ -1,0 +1,10 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: skipped-collectors-test
+spec:
+  collectors:
+    - clusterResources:
+        exclude: true
+    - clusterInfo:
+        exclude: true


### PR DESCRIPTION
## Description, Motivation and Context

- Write `skipped-collectors.json` to the support bundle and preflight bundle recording which collectors were skipped (RBAC permissions or spec exclusion), with reason, errors, and timestamp
- Surface RBAC errors and skipped-collector messages as `klog.Warningf` in non-interactive mode so they're visible without `-v` flags
- Exec collector file naming now falls back to the resolved container name (from the pod spec) when `collectorName` is not set, instead of only checking `containerName` from the spec

Fixes: [sc-136406](https://app.shortcut.com/replicated/story/136406)

## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
