### PR TITLE
feat(ci): add Slack release notification via reusable workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
   notify:
     needs: goreleaser
     if: ${{ !contains(github.ref_name, '-') }}
-    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@main
+    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@0432fb838fc83852b78be97a150b35991a85d56f # main
     with:
       tag: ${{ github.ref_name }}
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,3 +46,12 @@ jobs:
         uses: rajatjindal/krew-release-bot@v0.0.51
         with:
           krew_template_file: deploy/krew/support-bundle.yaml
+
+  notify:
+    needs: goreleaser
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@main
+    with:
+      tag: ${{ github.ref_name }}
+    secrets:
+      slack_webhook: ${{ secrets.RELEASE_SLACK_WEBHOOK }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
 
   notify:
     if: ${{ !contains(github.ref_name, '-') }}
-    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@0432fb838fc83852b78be97a150b35991a85d56f # main
+    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@0432fb838fc83852b78be97a150b35991a85d56f
     with:
       tag: ${{ github.ref_name }}
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,6 @@ jobs:
           krew_template_file: deploy/krew/support-bundle.yaml
 
   notify:
-    needs: goreleaser
     if: ${{ !contains(github.ref_name, '-') }}
     uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@0432fb838fc83852b78be97a150b35991a85d56f # main
     with:


### PR DESCRIPTION
## Summary

Adds a `notify` job to the release workflow that posts to Slack when a release tag is pushed, using the `replicatedhq/reusable-workflows/notify-release` reusable workflow.

- Runs in parallel with `goreleaser` (no `needs:`) so the team gets notified immediately when a release starts, not after it finishes
- Skipped for pre-release tags (e.g., `v1.0.0-rc1`)
- Posts a message with a compare URL between previous and current release
- Reusable workflow pinned to commit SHA for supply chain safety
- Requires `RELEASE_SLACK_WEBHOOK` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)