### PR TITLE
fix(analyze): include matched file path in textAnalyze result titles for multi-file globs

### DIFF
--- a/pkg/analyze/text_analyze.go
+++ b/pkg/analyze/text_analyze.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -79,9 +80,31 @@ func analyzeTextAnalyze(
 
 	results := []*AnalyzeResult{}
 
+	// Iterate matched files in sorted order so multi-file results are
+	// deterministic, and include the matched file path in each result title
+	// when more than one file matched. Without this, a glob fileName (e.g.
+	// the per-node output of a runDaemonSet collector) produces N identical
+	// results that cannot be told apart in any rendered report. The shared
+	// directory prefix is trimmed because the matched keys can be absolute
+	// paths into a temp dir at runtime; only the distinguishing part of the
+	// path belongs in the title.
+	fileNames := make([]string, 0, len(collected))
+	for fileName := range collected {
+		fileNames = append(fileNames, fileName)
+	}
+	sort.Strings(fileNames)
+
+	sharedPrefix := commonDirPrefix(fileNames)
+	resultTitle := func(fileName string) string {
+		if len(collected) > 1 {
+			return fmt.Sprintf("%s (%s)", title, strings.TrimPrefix(fileName, sharedPrefix))
+		}
+		return title
+	}
+
 	if analyzer.RegexPattern != "" {
-		for _, fileContents := range collected {
-			result, err := analyzeRegexPattern(analyzer.RegexPattern, fileContents, analyzer.Outcomes, title)
+		for _, fileName := range fileNames {
+			result, err := analyzeRegexPattern(analyzer.RegexPattern, collected[fileName], analyzer.Outcomes, resultTitle(fileName))
 			if err != nil {
 				return nil, err
 			}
@@ -92,8 +115,8 @@ func analyzeTextAnalyze(
 	}
 
 	if analyzer.RegexGroups != "" {
-		for _, fileContents := range collected {
-			result, err := analyzeRegexGroups(analyzer.RegexGroups, fileContents, analyzer.Outcomes, title)
+		for _, fileName := range fileNames {
+			result, err := analyzeRegexGroups(analyzer.RegexGroups, collected[fileName], analyzer.Outcomes, resultTitle(fileName))
 			if err != nil {
 				return nil, err
 			}
@@ -120,6 +143,31 @@ func analyzeTextAnalyze(
 			Message: "Invalid analyzer",
 		},
 	}, nil
+}
+
+// commonDirPrefix returns the longest directory prefix (ending in "/") shared
+// by all of the given paths, or "" if they share none.
+func commonDirPrefix(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	prefix := paths[0]
+	i := strings.LastIndex(prefix, "/")
+	if i < 0 {
+		return ""
+	}
+	prefix = prefix[:i+1]
+	for _, path := range paths[1:] {
+		for !strings.HasPrefix(path, prefix) {
+			trimmed := strings.TrimSuffix(prefix, "/")
+			i := strings.LastIndex(trimmed, "/")
+			if i < 0 {
+				return ""
+			}
+			prefix = trimmed[:i+1]
+		}
+	}
+	return prefix
 }
 
 // isLikelyExecOutput checks if a filename looks like exec collector output

--- a/pkg/analyze/text_analyze_test.go
+++ b/pkg/analyze/text_analyze_test.go
@@ -280,7 +280,7 @@ func Test_textAnalyze(t *testing.T) {
 					IsPass:  true,
 					IsWarn:  false,
 					IsFail:  false,
-					Title:   "text-collector-1",
+					Title:   "text-collector-1 (cfile-1.txt)",
 					Message: "pass",
 					IconKey: "kubernetes_text_analyze",
 					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
@@ -289,7 +289,7 @@ func Test_textAnalyze(t *testing.T) {
 					IsPass:  false,
 					IsWarn:  false,
 					IsFail:  true,
-					Title:   "text-collector-1",
+					Title:   "text-collector-1 (cfile-2.txt)",
 					Message: "fail",
 					IconKey: "kubernetes_text_analyze",
 					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
@@ -338,6 +338,107 @@ func Test_textAnalyze(t *testing.T) {
 			},
 		},
 		{
+			name: "glob matching multiple files includes matched file in each title",
+			analyzer: troubleshootv1beta2.TextAnalyze{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							When:    "true",
+							Message: "swap is disabled on this node",
+						},
+					},
+					{
+						Fail: &troubleshootv1beta2.SingleOutcome{
+							When:    "false",
+							Message: "swap is enabled on this node",
+						},
+					},
+				},
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "Swap disabled on every node",
+				},
+				CollectorName: "swap-check",
+				FileName:      "*.log",
+				RegexPattern:  "total_swap_kb=0",
+			},
+			expectResult: []AnalyzeResult{
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "Swap disabled on every node (node-a.log)",
+					Message: "swap is disabled on this node",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+				},
+				{
+					IsPass:  false,
+					IsWarn:  false,
+					IsFail:  true,
+					Title:   "Swap disabled on every node (node-b.log)",
+					Message: "swap is enabled on this node",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+				},
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "Swap disabled on every node (node-c.log)",
+					Message: "swap is disabled on this node",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
+				},
+			},
+			files: map[string][]byte{
+				"swap-check/node-a.log": []byte("total_swap_kb=0"),
+				"swap-check/node-b.log": []byte("total_swap_kb=1024"),
+				"swap-check/node-c.log": []byte("total_swap_kb=0"),
+			},
+		},
+		{
+			name: "regexGroups glob matching multiple files includes matched file in each title",
+			analyzer: troubleshootv1beta2.TextAnalyze{
+				Outcomes: []*troubleshootv1beta2.Outcome{
+					{
+						Pass: &troubleshootv1beta2.SingleOutcome{
+							Message: "found node {{ .node }}",
+						},
+					},
+				},
+				AnalyzeMeta: troubleshootv1beta2.AnalyzeMeta{
+					CheckName: "node identity",
+				},
+				CollectorName: "ds",
+				FileName:      "*.log",
+				RegexGroups:   `node=(?P<node>\S+)`,
+			},
+			expectResult: []AnalyzeResult{
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "node identity (a.log)",
+					Message: "found node alpha",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg?w=13&h=16",
+				},
+				{
+					IsPass:  true,
+					IsWarn:  false,
+					IsFail:  false,
+					Title:   "node identity (b.log)",
+					Message: "found node beta",
+					IconKey: "kubernetes_text_analyze",
+					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg?w=13&h=16",
+				},
+			},
+			files: map[string][]byte{
+				"ds/a.log": []byte("node=alpha"),
+				"ds/b.log": []byte("node=beta"),
+			},
+		},
+		{
 			name: "multiple results with both warn and fail case 1, only fail",
 			analyzer: troubleshootv1beta2.TextAnalyze{
 				Outcomes: []*troubleshootv1beta2.Outcome{
@@ -366,7 +467,7 @@ func Test_textAnalyze(t *testing.T) {
 					IsPass:  true,
 					IsWarn:  false,
 					IsFail:  false,
-					Title:   "text-collector-1",
+					Title:   "text-collector-1 (cfile-1.txt)",
 					Message: "pass",
 					IconKey: "kubernetes_text_analyze",
 					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
@@ -375,7 +476,7 @@ func Test_textAnalyze(t *testing.T) {
 					IsPass:  false,
 					IsWarn:  false,
 					IsFail:  true,
-					Title:   "text-collector-1",
+					Title:   "text-collector-1 (cfile-2.txt)",
 					Message: "fail",
 					IconKey: "kubernetes_text_analyze",
 					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
@@ -755,7 +856,7 @@ func Test_textAnalyze(t *testing.T) {
 					IsPass:  true,
 					IsWarn:  false,
 					IsFail:  false,
-					Title:   "text-collector-1",
+					Title:   "text-collector-1 (cfile-1.txt)",
 					Message: "success",
 					IconKey: "kubernetes_text_analyze",
 					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",
@@ -764,7 +865,7 @@ func Test_textAnalyze(t *testing.T) {
 					IsPass:  true,
 					IsWarn:  false,
 					IsFail:  false,
-					Title:   "text-collector-1",
+					Title:   "text-collector-1 (cfile-2.txt)",
 					Message: "success",
 					IconKey: "kubernetes_text_analyze",
 					IconURI: "https://troubleshoot.sh/images/analyzer-icons/text-analyze.svg",


### PR DESCRIPTION
## Description, Motivation and Context

### Bug report

**Symptom.** When a `textAnalyze` analyzer uses a glob `fileName` to analyze the per-node output of a [`runDaemonSet`](https://troubleshoot.sh/docs/collect/run-daemonset/) collector, the analyzer fires once per matched file as designed, but every result carries an identical title and outcome message. On a 3-node cluster, a per-node check renders as three indistinguishable rows in `preflight` output and in any downstream UI that displays analyzer results. Operators can't tell which node a failing verdict belongs to without opening the bundle and inspecting file names.

Reproduction (any multi-node cluster):

```yaml
apiVersion: troubleshoot.sh/v1beta2
kind: Preflight
metadata:
  name: per-node-check
spec:
  collectors:
    - runDaemonSet:
        name: swap-check
        namespace: default
        podSpec:
          containers:
            - name: swap-check
              image: busybox:1.36
              command: ["sh", "-c"]
              args: ["awk 'NR>1 {sum+=$3} END {print \"total_swap_kb=\"sum+0}' /proc/swaps"]
  analyzers:
    - textAnalyze:
        checkName: "Swap disabled on every node"
        fileName: swap-check/*.log
        regex: 'total_swap_kb=0'
        outcomes:
          - pass:
              when: "true"
              message: "Swap is disabled on this node"
          - fail:
              when: "false"
              message: "Swap is enabled on this node"
```

Expected: each result identifies the file (node) it came from.
Actual: N identical results.

**Root cause.** `analyzeTextAnalyze` iterates the glob-matched `map[string][]byte` by value and discards the keys, so the matched file path never reaches the `AnalyzeResult`, and `AnalyzeResult` has no other field that could carry it. Nothing downstream (CLI human/JSON/YAML output, or UIs that render analyzer results) can display what it never receives.

### Fix

When a glob matches more than one file:

- Append the distinguishing part of the matched path to each result title: `Swap disabled on every node (node-a.log)`. The directory prefix shared by all matches is trimmed, because at preflight runtime the map keys can be absolute paths into a temp dir, and only the differing tail identifies the file. For nested globs (e.g. exec collector output at `collector/namespace/pod/file.txt`), the preserved tail keeps the distinguishing segments (`namespace/pod/file.txt`).
- Iterate matches in sorted order so multi-file results render deterministically (map iteration order made result ordering random before).

Single-file matches keep their exact current title, so existing specs that match one file see no change.

This pairs well with `runDaemonSet`: per-node preflights were already easy to collect, and now each node's verdict is identifiable at a glance.

### Verification

Before/after on a 3-node k3s cluster, same spec as above:

```
# released preflight
PASS: Swap disabled on every node
PASS: Swap disabled on every node
PASS: Swap disabled on every node

# with this change
PASS: Swap disabled on every node (3dcb85a11.log)
PASS: Swap disabled on every node (3dcb85a12.log)
PASS: Swap disabled on every node (3dcb85a13.log)
```

(`runDaemonSet` names each log after its node, so the node name lands in the title.)

Unit tests: added a multi-file glob case (`regex`) asserting one titled result per file, and a multi-file `regexGroups` case asserting titles plus templated messages. Existing multi-file test expectations were updated to the new titles; their diff doubles as a record of the behavior change.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

Happy to follow up with a troubleshoot.sh docs PR noting the title behavior for glob matches if you'd like one.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Titles change only when a glob matches multiple files, where the previous titles were identical duplicates that couldn't be referenced individually anyway. Single-file results are byte-for-byte unchanged.
