### PR TITLE
fix(preflight): redact local host preflight collector output

### DIFF
--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -145,6 +145,15 @@ func CollectHostWithContext(
 		span.End()
 	}
 
+	// Local host preflight collectors are the only collection path (cluster,
+	// remote host, in-cluster support bundle) that skipped redaction entirely.
+	// A `run` collector's captured environment in particular can carry
+	// credentials verbatim (e.g. HTTPS_PROXY with embedded Basic Auth) into
+	// the bundle. See https://github.com/replicatedhq/troubleshoot/issues/2100.
+	if err := collect.RedactResult(opts.BundlePath, collect.CollectorResult(allCollectedData), nil); err != nil {
+		return nil, errors.Wrap(err, "failed to redact host collector results")
+	}
+
 	// The values of map entries will contain the collected data in bytes if the data was not stored to disk
 	collectResult.AllCollectedData = allCollectedData
 

--- a/pkg/preflight/collect_test.go
+++ b/pkg/preflight/collect_test.go
@@ -1,6 +1,9 @@
 package preflight
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -208,4 +211,47 @@ func TestCollectWithContext_PreservesOrderAfterClusterResources(t *testing.T) {
 	if dataIndex >= 0 && secretIndex >= 0 {
 		assert.Less(t, dataIndex, secretIndex, "data collectors should come before secret collectors, preserving relative order")
 	}
+}
+
+// TestCollectHostWithContext_RedactsSensitiveEnvValues verifies that a `run`
+// host collector's captured environment is redacted before being written to
+// the bundle. CollectHostWithContext is the only collection path (cluster,
+// host, remote) that skipped redaction entirely: every env var passed to the
+// command -- including credentials embedded in a proxy URL -- landed
+// verbatim in <collectorName>-info.json.
+func TestCollectHostWithContext_RedactsSensitiveEnvValues(t *testing.T) {
+	bundlePath := t.TempDir()
+
+	hostPreflight := &troubleshootv1beta2.HostPreflight{
+		Spec: troubleshootv1beta2.HostPreflightSpec{
+			Collectors: []*troubleshootv1beta2.HostCollect{
+				{
+					HostRun: &troubleshootv1beta2.HostRun{
+						HostCollectorMeta: troubleshootv1beta2.HostCollectorMeta{
+							CollectorName: "proxy-credential-check",
+						},
+						Command:          "sh",
+						Args:             []string{"-c", "echo ok"},
+						IgnoreParentEnvs: true,
+						Env: []string{
+							"HTTPS_PROXY=http://alice:sw0rdfish@proxy.example.com:3128",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := CollectHostWithContext(context.Background(), CollectOpts{
+		ProgressChan: make(chan interface{}, 100),
+		BundlePath:   bundlePath,
+	}, hostPreflight)
+	require.NoError(t, err)
+
+	infoPath := filepath.Join(bundlePath, "host-collectors/run-host/proxy-credential-check-info.json")
+	b, err := os.ReadFile(infoPath)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(b), "sw0rdfish", "proxy credential leaked unredacted into the host preflight bundle")
+	assert.Contains(t, string(b), "***HIDDEN***", "expected the built-in URL-userinfo redactor to mask the credential")
 }


### PR DESCRIPTION
Fixes #2100

## Summary

`CollectHostWithContext` (`pkg/preflight/collect.go`) was the only collection path in the codebase that never ran collected data through the redaction engine before writing it to the bundle:

- In-cluster support bundles call `collect.RedactResult` (`pkg/supportbundle/collect.go`).
- Remote (SSH) host preflight collectors set `Redact: true` on `RemoteCollector`, which triggers `RedactResult` via `RunCollectorSync` (`CollectRemoteWithContext`).
- Local host preflight collectors called neither.

In practice this means a `run` collector's captured environment (`HostRunInfo.Env` in `pkg/collect/host_run.go`, set from `cmd.Env`) lands in `<collectorName>-info.json` completely unredacted — including credentials such as a proxy URL with embedded Basic Auth (`HTTPS_PROXY=http://user:pass@proxy:3128`), which installers commonly export into the environment before running host preflights.

## Fix

Wire `CollectHostWithContext` through `collect.RedactResult` the same way `CollectRemoteWithContext` and `pkg/supportbundle/collect.go` already do. This applies the existing built-in default redactors (including the "connection strings with username and password" URL-userinfo pattern) to all local host preflight collector output, not just `run` collectors.

## Test plan

- Added `TestCollectHostWithContext_RedactsSensitiveEnvValues` (`pkg/preflight/collect_test.go`), which runs a `run` host collector with a credential-bearing env var and asserts the persisted `-info.json` no longer contains the credential in cleartext.
- Confirmed the test fails against the pre-fix code (reproduces the leak) and passes after the fix.
- `make test` passes locally (fmt, vet, generate, full unit suite).