### PR TITLE
fix(preflight): add tracing span and align error handling for host collector redaction

### DIFF
--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -150,9 +150,15 @@ func CollectHostWithContext(
 	// A `run` collector's captured environment in particular can carry
 	// credentials verbatim (e.g. HTTPS_PROXY with embedded Basic Auth) into
 	// the bundle. See https://github.com/replicatedhq/troubleshoot/issues/2100.
+	_, span := otel.Tracer(constants.LIB_TRACER_NAME).Start(ctx, "Host collectors")
+	span.SetAttributes(attribute.String("type", "Redactors"))
 	if err := collect.RedactResult(opts.BundlePath, collect.CollectorResult(allCollectedData), nil); err != nil {
-		return nil, errors.Wrap(err, "failed to redact host collector results")
+		err = errors.Wrap(err, "failed to redact host collector results")
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		return collectResult, err
 	}
+	span.End()
 
 	// The values of map entries will contain the collected data in bytes if the data was not stored to disk
 	collectResult.AllCollectedData = allCollectedData

--- a/pkg/preflight/collect.go
+++ b/pkg/preflight/collect.go
@@ -145,6 +145,9 @@ func CollectHostWithContext(
 		span.End()
 	}
 
+	// The values of map entries will contain the collected data in bytes if the data was not stored to disk
+	collectResult.AllCollectedData = allCollectedData
+
 	// Local host preflight collectors are the only collection path (cluster,
 	// remote host, in-cluster support bundle) that skipped redaction entirely.
 	// A `run` collector's captured environment in particular can carry
@@ -159,9 +162,6 @@ func CollectHostWithContext(
 		return collectResult, err
 	}
 	span.End()
-
-	// The values of map entries will contain the collected data in bytes if the data was not stored to disk
-	collectResult.AllCollectedData = allCollectedData
 
 	return collectResult, nil
 }


### PR DESCRIPTION
Follow-up to #2101.

#2101 added redaction for local host preflight collectors, which was the only collection path that skipped redaction entirely. This PR addresses the review feedback that was not included before #2101 was merged:

1. **Adds an OpenTelemetry span around the redaction step**, matching the tracing already present for host and in-cluster collectors in the support-bundle path.
2. **Aligns the error handling**: when redaction fails, "CollectHostWithContext" now returns the unredacted "collectResult" along with the error, matching the behavior of "remote_collector.RunCollectorSync" and "supportbundle.runHostCollectors". This prevents SDK consumers from seeing inconsistent return behavior across collection paths.

The regression test added in #2101 ("TestCollectHostWithContext_RedactsSensitiveEnvValues") continues to verify that "run" host collector environment variables are redacted before being written to the bundle.