### PR TITLE
Contain support bundle tar extraction within the destination directory

### DIFF
--- a/pkg/analyze/download.go
+++ b/pkg/analyze/download.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	getter "github.com/hashicorp/go-getter"
 	"github.com/pkg/errors"
@@ -175,15 +176,20 @@ func ExtractTroubleshootBundle(reader io.Reader, destDir string) error {
 			return errors.Wrap(err, "failed to read header from tar")
 		}
 
+		// Guard against path traversal (zip-slip): make sure the resolved
+		// path stays within destDir before we create anything on disk.
+		cleanDest := filepath.Clean(destDir)
+		destFileName := filepath.Join(destDir, header.Name)
+		if destFileName != cleanDest && !strings.HasPrefix(destFileName, cleanDest+string(os.PathSeparator)) {
+			return errors.Errorf("tar entry %q resolves outside of destination directory", header.Name)
+		}
+
 		switch header.Typeflag {
 		case tar.TypeDir:
-			name := filepath.Join(destDir, header.Name)
-			if err := os.MkdirAll(name, os.FileMode(header.Mode)); err != nil {
+			if err := os.MkdirAll(destFileName, os.FileMode(header.Mode)); err != nil {
 				return errors.Wrap(err, "failed to mkdir")
 			}
 		case tar.TypeReg:
-			destFileName := filepath.Join(destDir, header.Name)
-
 			dirName := filepath.Dir(destFileName)
 			if err := os.MkdirAll(dirName, 0755); err != nil {
 				return errors.Wrapf(err, "failed to mkdir for file %s", header.Name)
@@ -199,8 +205,6 @@ func ExtractTroubleshootBundle(reader io.Reader, destDir string) error {
 				return errors.Wrap(err, "failed to extract file")
 			}
 		case tar.TypeSymlink:
-			destFileName := filepath.Join(destDir, header.Name)
-
 			dirName := filepath.Dir(destFileName)
 			if err := os.MkdirAll(dirName, 0755); err != nil {
 				return errors.Wrapf(err, "failed to mkdir for symlink %s", header.Name)
@@ -209,6 +213,9 @@ func ExtractTroubleshootBundle(reader io.Reader, destDir string) error {
 			// Symlink targets should be absolute paths after extraction
 			// for other parts of the code to work correctly e.g redaction, CollectorResult
 			targetPath := filepath.Join(filepath.Dir(destFileName), header.Linkname)
+			if targetPath != cleanDest && !strings.HasPrefix(targetPath, cleanDest+string(os.PathSeparator)) {
+				return errors.Errorf("symlink %q target resolves outside of destination directory", header.Name)
+			}
 			err = os.Symlink(targetPath, destFileName)
 			if err != nil {
 				return errors.Wrap(err, "failed to create symlink")

--- a/pkg/analyze/download_test.go
+++ b/pkg/analyze/download_test.go
@@ -1,13 +1,158 @@
 package analyzer
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/replicatedhq/troubleshoot/internal/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// tarEntry describes one entry to write into an in-memory bundle archive.
+type tarEntry struct {
+	name     string
+	typeflag byte
+	linkname string
+	content  string
+}
+
+// makeTarGz builds a gzipped tar archive in memory from the given entries.
+func makeTarGz(t *testing.T, entries []tarEntry) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: e.typeflag,
+			Mode:     0o755,
+		}
+		switch e.typeflag {
+		case tar.TypeReg:
+			hdr.Mode = 0o644
+			hdr.Size = int64(len(e.content))
+		case tar.TypeSymlink:
+			hdr.Linkname = e.linkname
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		if e.typeflag == tar.TypeReg {
+			_, err := tw.Write([]byte(e.content))
+			require.NoError(t, err)
+		}
+	}
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return &buf
+}
+
+func TestExtractTroubleshootBundle(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []tarEntry
+		wantErr bool
+		// verify runs after a successful extraction
+		verify func(t *testing.T, destDir string)
+	}{
+		{
+			name: "regular file within destination succeeds",
+			entries: []tarEntry{
+				{name: "bundle/file.txt", typeflag: tar.TypeReg, content: "hello"},
+			},
+			verify: func(t *testing.T, destDir string) {
+				assert.FileExists(t, filepath.Join(destDir, "bundle", "file.txt"))
+			},
+		},
+		{
+			name: "directory within destination succeeds",
+			entries: []tarEntry{
+				{name: "bundle/subdir", typeflag: tar.TypeDir},
+			},
+			verify: func(t *testing.T, destDir string) {
+				assert.DirExists(t, filepath.Join(destDir, "bundle", "subdir"))
+			},
+		},
+		{
+			name: "path traversal regular file is rejected",
+			entries: []tarEntry{
+				{name: "../outside.txt", typeflag: tar.TypeReg, content: "escape"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "path traversal directory is rejected",
+			entries: []tarEntry{
+				{name: "../outside-dir", typeflag: tar.TypeDir},
+			},
+			wantErr: true,
+		},
+		{
+			name: "symlink with in-root target succeeds",
+			entries: []tarEntry{
+				{name: "bundle/target.txt", typeflag: tar.TypeReg, content: "data"},
+				{name: "bundle/link.txt", typeflag: tar.TypeSymlink, linkname: "target.txt"},
+			},
+			verify: func(t *testing.T, destDir string) {
+				link := filepath.Join(destDir, "bundle", "link.txt")
+				fi, err := os.Lstat(link)
+				require.NoError(t, err)
+				assert.NotZero(t, fi.Mode()&os.ModeSymlink)
+			},
+		},
+		{
+			name: "symlink escaping the destination is rejected",
+			entries: []tarEntry{
+				{name: "bundle/evil-link", typeflag: tar.TypeSymlink, linkname: "../../outside-target"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destDir := t.TempDir()
+			err := ExtractTroubleshootBundle(makeTarGz(t, tt.entries), destDir)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				// Nothing from the offending entry may exist outside destDir.
+				parent := filepath.Dir(destDir)
+				assert.NoFileExists(t, filepath.Join(parent, "outside.txt"))
+				assert.NoDirExists(t, filepath.Join(parent, "outside-dir"))
+				return
+			}
+			require.NoError(t, err)
+			if tt.verify != nil {
+				tt.verify(t, destDir)
+			}
+		})
+	}
+}
+
+// TestExtractTroubleshootBundleSiblingPrefix ensures the containment check is
+// separator-aware: an entry resolving to a sibling directory that merely shares
+// the destination's string prefix (e.g. destination "/tmp/bundle" and entry
+// resolving to "/tmp/bundle-escape") must be rejected.
+func TestExtractTroubleshootBundleSiblingPrefix(t *testing.T) {
+	parent := t.TempDir()
+	destDir := filepath.Join(parent, "bundle")
+	require.NoError(t, os.Mkdir(destDir, 0o755))
+
+	archive := makeTarGz(t, []tarEntry{
+		{name: "../bundle-escape/file.txt", typeflag: tar.TypeReg, content: "escape"},
+	})
+
+	err := ExtractTroubleshootBundle(archive, destDir)
+	require.Error(t, err)
+	assert.NoDirExists(t, filepath.Join(parent, "bundle-escape"))
+}
 
 func TestDownloadAndExtractSupportBundle(t *testing.T) {
 	// TODO: Add tests for web url downloads


### PR DESCRIPTION
While looking at how "analyze" pulls apart a downloaded support bundle, I noticed ExtractTroubleshootBundle in pkg/analyze/download.go joins each tar entry name straight onto the destination dir and writes it out, with no check that the result stays inside that dir. A bundle with entries like ../../etc/something (or a symlink pointing outside) would let the archive write files anywhere the process can reach. Since bundles are usually generated by an end user and then handed to someone else to analyze, that felt worth closing off.

This adds a small containment check before anything is written: the resolved path (and the symlink target) has to live under destDir, otherwise it errors out. Normal bundles are unaffected. Build and gofmt are clean. Happy to adjust the wording or add a test if you prefer.