### PR TITLE
Fix SBOM generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: 'v3.1.3'
 
       - name: Generate and sign SBOM
         run: make sbom

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,8 @@ sbom: sbom/assets/troubleshoot-sbom.tgz
 		--tlog-upload \
 		--yes \
 		--rekor-url=https://rekor.sigstore.dev \
-		sbom/assets/troubleshoot-sbom.tgz > sbom/assets/troubleshoot-sbom.tgz.sig
+		--bundle sbom/assets/troubleshoot-sbom.tgz.bundle \
+		sbom/assets/troubleshoot-sbom.tgz
 	cosign public-key --key cosign.key --outfile sbom/assets/key.pub
 
 .PHONY: get-govulncheck

--- a/README.md
+++ b/README.md
@@ -56,19 +56,12 @@ For questions about using Troubleshoot, how to contribute and engaging with the 
 # Software Bill of Materials
 A signed SBOM  that includes Troubleshoot dependencies is included in each release.
 - **troubleshoot-sbom.tgz** contains a software bill of materials for Troubleshoot.
-- **troubleshoot-sbom.tgz.sig** is the digital signature for troubleshoot-sbom.tgz
+- **troubleshoot-sbom.tgz.bundle** contains the signature and transparency log material used by Cosign.
 - **key.pub** is the public key from the key pair used to sign troubleshoot-sbom.tgz
 
 The following example illustrates using [cosign](https://github.com/sigstore/cosign) to verify that **troubleshoot-sbom.tgz** has
-not been tampered with.
+not been tampered with. Install [Cosign v3](https://github.com/sigstore/cosign/releases).
 ```sh
-$ cosign verify-blob --key key.pub --signature troubleshoot-sbom.tgz.sig troubleshoot-sbom.tgz
-Verified OK
-```
-
-If you were to get an error similar to the one below, it means you are verifying an SBOM signed using cosign `v1` using a newer `v2` of the binary. This version introduced [breaking changes](https://github.com/sigstore/cosign/blob/main/CHANGELOG.md#breaking-changes) which require an additional flag `--insecure-ignore-tlog=true` to successfully verify SBOMs like so.
-```sh
-$ cosign verify-blob --key key.pub --signature troubleshoot-sbom.tgz.sig troubleshoot-sbom.tgz --insecure-ignore-tlog=true
-WARNING: Skipping tlog verification is an insecure practice that lacks of transparency and auditability verification for the blob.
+$ cosign verify-blob --key key.pub --bundle troubleshoot-sbom.tgz.bundle troubleshoot-sbom.tgz
 Verified OK
 ```


### PR DESCRIPTION
## Description, Motivation and Context

Please include a summary of the change or what problem it solves. Please also include relevant motivation and context.

<!--- If it relates to an open issue, please link to the issue here.
e.g.
Fixes: #414
-->

SBOM generation failed during last release with this error

```
spdx-sbom-generator
./sbom/spdx-sbom-generator -o ./sbom/spdx
INFO[2026-08-17T18:49:38Z] Starting to generate SPDX ...                
INFO[2026-08-17T18:49:39Z] Running generator for Module Manager: `go-mod` with output `sbom/spdx/bom-go-mod.spdx` 
INFO[2026-08-17T18:49:39Z] Current Language Version go version go1.26.5 linux/amd64 
INFO[2026-08-17T18:49:51Z] Command completed successful for below package managers 
INFO[2026-08-17T18:49:51Z] Plugin go-mod generated output at sbom/spdx/bom-go-mod.spdx 
tar -czf sbom/assets/troubleshoot-sbom.tgz sbom/spdx/*.spdx
cosign sign-blob \
	--key ./cosign.key \
	--tlog-upload \
	--yes \
	--rekor-url=https://rekor.sigstore.dev/ \
	sbom/assets/troubleshoot-sbom.tgz > sbom/assets/troubleshoot-sbom.tgz.sig
Flag --tlog-upload has been deprecated, prefer using a --signing-config file with no transparency log services
Using payload from: sbom/assets/troubleshoot-sbom.tgz
Signing artifact...
Error: signing sbom/assets/troubleshoot-sbom.tgz: create bundle file: open : no such file or directory
error during command execution: signing sbom/assets/troubleshoot-sbom.tgz: create bundle file: open : no such file or directory
make: *** [Makefile:244: sbom] Error 1
```
## Checklist

- [ ] New and existing tests pass locally with introduced changes.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
