### PR TITLE
feat(supportbundle): support secret/... redactor URIs

### DIFF
--- a/pkg/supportbundle/load.go
+++ b/pkg/supportbundle/load.go
@@ -20,6 +20,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// loadFromSecret is a package-level hook so tests can stub out cluster access.
+var loadFromSecret = specs.LoadFromSecret
+
 // GetSupportBundleFromURI downloads and parses a support bundle from a URI and returns a SupportBundle object
 func GetSupportBundleFromURI(bundleURI string) (*troubleshootv1beta2.SupportBundle, error) {
 	collectorContent, err := LoadSupportBundleSpec(bundleURI)
@@ -165,6 +168,29 @@ func LoadSupportBundleSpec(arg string) ([]byte, error) {
 }
 
 func LoadRedactorSpec(arg string) ([]byte, error) {
+	if strings.HasPrefix(arg, "secret/") {
+		// format secret/namespace-name/secret-name[/data-key]
+		pathParts := strings.Split(arg, "/")
+		if len(pathParts) > 4 {
+			return nil, errors.Errorf("secret path %s must have at most 4 components", arg)
+		}
+		if len(pathParts) < 3 {
+			return nil, errors.Errorf("secret path %s must have at least 3 components", arg)
+		}
+
+		dataKey := "redactor-spec"
+		if len(pathParts) == 4 {
+			dataKey = pathParts[3]
+		}
+
+		spec, err := loadFromSecret(pathParts[1], pathParts[2], dataKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get spec from secret")
+		}
+
+		return spec, nil
+	}
+
 	if strings.HasPrefix(arg, "configmap/") {
 		// format configmap/namespace-name/configmap-name[/data-key]
 		pathParts := strings.Split(arg, "/")

--- a/pkg/supportbundle/load_test.go
+++ b/pkg/supportbundle/load_test.go
@@ -1,7 +1,9 @@
 package supportbundle
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
@@ -88,6 +90,64 @@ spec:
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParseSupportBundle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRedactorSpec(t *testing.T) {
+	origLoadFromSecret := loadFromSecret
+	defer func() { loadFromSecret = origLoadFromSecret }()
+
+	loadFromSecret = func(namespace, secretName, key string) ([]byte, error) {
+		return []byte(fmt.Sprintf("namespace=%s,secret=%s,key=%s", namespace, secretName, key)), nil
+	}
+
+	tests := []struct {
+		name        string
+		uri         string
+		wantContent string
+		wantErr     string
+	}{
+		{
+			name:        "secret URI with default key",
+			uri:         "secret/default/my-redactor",
+			wantContent: "namespace=default,secret=my-redactor,key=redactor-spec",
+		},
+		{
+			name:        "secret URI with custom key",
+			uri:         "secret/default/my-redactor/custom-key",
+			wantContent: "namespace=default,secret=my-redactor,key=custom-key",
+		},
+		{
+			name:    "secret URI with too few components",
+			uri:     "secret/default",
+			wantErr: "must have at least 3 components",
+		},
+		{
+			name:    "secret URI with too many components",
+			uri:     "secret/default/my-redactor/custom-key/extra",
+			wantErr: "must have at most 4 components",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadRedactorSpec(tt.uri)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("LoadRedactorSpec() expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("LoadRedactorSpec() error = %q, want containing %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadRedactorSpec() unexpected error = %v", err)
+			}
+			if string(got) != tt.wantContent {
+				t.Errorf("LoadRedactorSpec() = %q, want %q", string(got), tt.wantContent)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds support for `secret/...` URIs to `LoadRedactorSpec`, matching the existing support in `LoadSupportBundleSpec`.

## Changes

- `pkg/supportbundle/load.go`: `LoadRedactorSpec` now accepts `secret/<namespace>/<secret-name>[/<data-key>]` URIs, with a default data key of `redactor-spec`.
- `pkg/supportbundle/load.go`: added a package-level `loadFromSecret` hook so the new code path can be unit-tested without requiring a cluster.
- `pkg/supportbundle/load_test.go`: added `TestLoadRedactorSpec` covering default and custom data keys, as well as validation for too few/too many path components.

## Motivation

KOTS stores rendered redactor specs in Kubernetes ConfigMaps today and passes `configmap/...` URIs to `kubectl support-bundle --redactors=...`. To move those redactor specs to Secrets, the Troubleshoot library and CLI need to be able to load redactor specs from `secret/...` URIs.

## Related

- KOTS story: https://app.shortcut.com/replicated/story/139291
