### PR TITLE
fix(cluster-resources): stop emitting duplicate unredacted YAML copy

### DIFF
--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -294,7 +294,18 @@ func (c *CollectClusterResources) Collect(progressChan chan<- interface{}) (Coll
 	// crs
 	customResources, crErrors := crs(ctx, dynamicClient, client, c.ClientConfig, namespaceNames)
 	for k, v := range customResources {
-		output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, k), bytes.NewBuffer(v))
+		jsonPath := path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, k)
+		output.SaveResult(c.BundlePath, jsonPath, bytes.NewBuffer(v))
+
+		// Keep a YAML symlink for backward compatibility. It points at the JSON
+		// file, so any analyzer that expects YAML can still read it, and the
+		// content is redacted through the JSON copy.
+		if strings.HasSuffix(k, ".json") {
+			yamlPath := path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, strings.TrimSuffix(k, ".json")+".yaml")
+			if err := output.SymLinkResult(c.BundlePath, yamlPath, jsonPath); err != nil {
+				klog.V(2).Infof("failed to create YAML symlink for %s: %v", jsonPath, err)
+			}
+		}
 	}
 	output.SaveResult(c.BundlePath, path.Join(constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, fmt.Sprintf("%s-errors.json", constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES)), marshalErrors(crErrors))
 

--- a/pkg/collect/cluster_resources.go
+++ b/pkg/collect/cluster_resources.go
@@ -2294,23 +2294,18 @@ func mutatingWebhookConfigurations(ctx context.Context, client kubernetes.Interf
 	return b, nil
 }
 
-// storeCustomResource stores a custom resource as JSON and YAML
-// We use both formats for backwards compatibility. This way we
-// avoid breaking existing tools and analysers that already rely on
-// the YAML format.
+// storeCustomResource stores a custom resource as JSON only.
+// JSON is valid YAML, so any analyzer expecting YAML can consume the JSON
+// file directly. We no longer write a separate YAML file because the
+// built-in redactors are authored for JSON, and the duplicate YAML copy
+// would otherwise be left unredacted.
 func storeCustomResource(name string, objects any, m map[string][]byte) error {
 	j, err := json.MarshalIndent(objects, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	y, err := yaml.Marshal(objects)
-	if err != nil {
-		return err
-	}
-
 	m[fmt.Sprintf("%s.json", name)] = j
-	m[fmt.Sprintf("%s.yaml", name)] = y
 	return nil
 }
 

--- a/pkg/collect/cluster_resources_test.go
+++ b/pkg/collect/cluster_resources_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"sigs.k8s.io/yaml"
 )
 
 func init() {
@@ -512,17 +511,8 @@ func TestCollectClusterResources_CustomResource(t *testing.T) {
 	// Fetch the CR from cluster
 	res, errs := crsV1(ctx, dynamicClient, apixClient.ApiextensionsV1(), []string{"default"})
 	assert.Empty(t, errs)
-	require.Equal(t, 2, len(res))
+	require.Equal(t, 1, len(res))
 	assert.Equal(t, fromJSON(t, res["supportbundles.troubleshoot.sh/default.json"]), sbObject)
-	assert.Equal(t, fromYAML(t, res["supportbundles.troubleshoot.sh/default.yaml"]), sbObject)
-}
-
-func fromYAML(t *testing.T, dat []byte) troubleshootv1beta2.SupportBundle {
-	sb := []troubleshootv1beta2.SupportBundle{}
-	err := yaml.Unmarshal(dat, &sb)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(sb))
-	return sb[0]
 }
 
 func fromJSON(t *testing.T, dat []byte) troubleshootv1beta2.SupportBundle {

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -35,6 +35,26 @@ func init() {
 	}
 }
 
+// kurlInstallerRedactors are built-in redactors scoped to the kurl installer
+// custom resource. They previously applied only to the YAML copy of custom
+// resources; now that the collector emits only JSON, they target the JSON file.
+var kurlInstallerRedactors = []*troubleshootv1beta2.Redact{
+	{
+		Name: "Redact kurl installer fields",
+		FileSelector: troubleshootv1beta2.FileSelector{
+			File: fmt.Sprintf("%s/%s/%s/*.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, "installers.cluster.kurl.sh"),
+		},
+		Removals: troubleshootv1beta2.Removals{
+			Regex: []troubleshootv1beta2.Regex{
+				{Redactor: `(?i)("bootstrapToken"\s*:\s*")(?P<mask>[^"]*)(")`},
+				{Redactor: `(?i)("certKey"\s*:\s*")(?P<mask>[^"]*)(")`},
+				{Redactor: `(?i)("kubeadmToken"\s*:\s*")(?P<mask>[^"]*)(")`},
+				{Redactor: `(?i)("kubectl\.kubernetes\.io/last-applied-configuration"\s*:\s*")(?P<mask>(?:\\.|[^"\\])*)(")`},
+			},
+		},
+	},
+}
+
 // A regex cache to avoid recompiling the same regexes over and over
 func compileRegex(pattern string) (*regexp.Regexp, error) {
 	regexCacheLock.Lock()
@@ -440,39 +460,12 @@ func getRedactors(path string) ([]Redactor, error) {
 		redactors = append(redactors, r)
 	}
 
-	customResources := []struct {
-		resource string
-		yamlPath string
-	}{
-		{
-			resource: "installers.cluster.kurl.sh",
-			yamlPath: "*.spec.kubernetes.bootstrapToken",
-		},
-		{
-			resource: "installers.cluster.kurl.sh",
-			yamlPath: "*.spec.kubernetes.certKey",
-		},
-		{
-			resource: "installers.cluster.kurl.sh",
-			yamlPath: "*.spec.kubernetes.kubeadmToken",
-		},
+	// Add built-in redactors that are scoped to specific custom resource files.
+	scopedRedactors, err := buildAdditionalRedactors(path, kurlInstallerRedactors)
+	if err != nil {
+		return nil, err
 	}
-
-	uniqueCRs := map[string]bool{}
-	for _, cr := range customResources {
-		fileglob := fmt.Sprintf("%s/%s/%s/*.yaml", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, cr.resource)
-		redactors = append(redactors, NewYamlRedactor(cr.yamlPath, fileglob, ""))
-
-		// redact kubectl last applied annotation once for each resource since it contains copies of
-		// redacted fields
-		if !uniqueCRs[cr.resource] {
-			uniqueCRs[cr.resource] = true
-			redactors = append(redactors, &YamlRedactor{
-				filePath: fileglob,
-				maskPath: []string{"*", "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration"},
-			})
-		}
-	}
+	redactors = append(redactors, scopedRedactors...)
 
 	return redactors, nil
 }

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -37,12 +37,18 @@ func init() {
 
 // kurlInstallerRedactors are built-in redactors scoped to the kurl installer
 // custom resource. They previously applied only to the YAML copy of custom
-// resources; now that the collector emits only JSON, they target the JSON file.
+// resources; now they target the JSON file (and the YAML symlink that points to it).
+// The installer CRD can be either cluster-scoped (installers.cluster.kurl.sh.json)
+// or namespaced (installers.cluster.kurl.sh/<namespace>.json), so both patterns are
+// included.
 var kurlInstallerRedactors = []*troubleshootv1beta2.Redact{
 	{
 		Name: "Redact kurl installer fields",
 		FileSelector: troubleshootv1beta2.FileSelector{
-			File: fmt.Sprintf("%s/%s/%s/*.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, "installers.cluster.kurl.sh"),
+			Files: []string{
+				fmt.Sprintf("%s/%s/%s.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, "installers.cluster.kurl.sh"),
+				fmt.Sprintf("%s/%s/%s/*.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_CUSTOM_RESOURCES, "installers.cluster.kurl.sh"),
+			},
 		},
 		Removals: troubleshootv1beta2.Removals{
 			Regex: []troubleshootv1beta2.Regex{

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1894,18 +1894,29 @@ func Test_RedactKurlInstallerJSON(t *testing.T) {
   }
 ]`
 
-	r, err := Redact(strings.NewReader(input), "cluster-resources/custom-resources/installers.cluster.kurl.sh/default.json", nil)
-	require.NoError(t, err)
+	cases := []string{
+		// Cluster-scoped installer (file directly under custom-resources)
+		"cluster-resources/custom-resources/installers.cluster.kurl.sh.json",
+		// Namespaced installer (file under a per-CRD directory)
+		"cluster-resources/custom-resources/installers.cluster.kurl.sh/default.json",
+	}
 
-	out, err := ioutil.ReadAll(r)
-	require.NoError(t, err)
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			r, err := Redact(strings.NewReader(input), path, nil)
+			require.NoError(t, err)
 
-	outStr := string(out)
-	require.NotContains(t, outStr, `"abc"`)
-	require.NotContains(t, outStr, `"def"`)
-	require.NotContains(t, outStr, `"ghi"`)
-	require.Contains(t, outStr, `"bootstrapToken": "***HIDDEN***"`)
-	require.Contains(t, outStr, `"certKey": "***HIDDEN***"`)
-	require.Contains(t, outStr, `"kubeadmToken": "***HIDDEN***"`)
-	require.Contains(t, outStr, `"kubectl.kubernetes.io/last-applied-configuration": "***HIDDEN***"`)
+			out, err := ioutil.ReadAll(r)
+			require.NoError(t, err)
+
+			outStr := string(out)
+			require.NotContains(t, outStr, `"abc"`)
+			require.NotContains(t, outStr, `"def"`)
+			require.NotContains(t, outStr, `"ghi"`)
+			require.Contains(t, outStr, `"bootstrapToken": "***HIDDEN***"`)
+			require.Contains(t, outStr, `"certKey": "***HIDDEN***"`)
+			require.Contains(t, outStr, `"kubeadmToken": "***HIDDEN***"`)
+			require.Contains(t, outStr, `"kubectl.kubernetes.io/last-applied-configuration": "***HIDDEN***"`)
+		})
+	}
 }

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1874,3 +1874,38 @@ func Test_redactMatchesPath(t *testing.T) {
 		})
 	}
 }
+
+func Test_RedactKurlInstallerJSON(t *testing.T) {
+	input := `[
+  {
+    "metadata": {
+      "name": "kurl",
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"cluster.kurl.sh/v1beta1\",\"kind\":\"Installer\",\"spec\":{\"kubernetes\":{\"bootstrapToken\":\"abc\",\"certKey\":\"def\",\"kubeadmToken\":\"ghi\"}}}"
+      }
+    },
+    "spec": {
+      "kubernetes": {
+        "bootstrapToken": "abc",
+        "certKey": "def",
+        "kubeadmToken": "ghi"
+      }
+    }
+  }
+]`
+
+	r, err := Redact(strings.NewReader(input), "cluster-resources/custom-resources/installers.cluster.kurl.sh/default.json", nil)
+	require.NoError(t, err)
+
+	out, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+
+	outStr := string(out)
+	require.NotContains(t, outStr, `"abc"`)
+	require.NotContains(t, outStr, `"def"`)
+	require.NotContains(t, outStr, `"ghi"`)
+	require.Contains(t, outStr, `"bootstrapToken": "***HIDDEN***"`)
+	require.Contains(t, outStr, `"certKey": "***HIDDEN***"`)
+	require.Contains(t, outStr, `"kubeadmToken": "***HIDDEN***"`)
+	require.Contains(t, outStr, `"kubectl.kubernetes.io/last-applied-configuration": "***HIDDEN***"`)
+}


### PR DESCRIPTION
## Problem

clusterResources writes every custom resource twice: once as JSON and once as YAML under cluster-resources/custom-resources/. The built-in redactors are authored for JSON shapes, so the YAML copy is left unredacted. Adding a vendor-side YAML redactor is also a footgun because YAML literal blocks (e.g. PEM keys) cannot be safely masked with line-oriented redactors.

## Fix

- Stop writing a duplicate YAML file in storeCustomResource; emit only JSON.
- Add a .yaml symlink pointing at each JSON file for backward compatibility. Analyzers that expect YAML can still read the file, and the symlink is redacted through the JSON copy.
- Convert the built-in kurl installer redactors to target the JSON file with scoped regex redactors so they continue to apply. The selector now matches both the cluster-scoped file (installers.cluster.kurl.sh.json) and the namespaced pattern (installers.cluster.kurl.sh/*.json).

## Compatibility

No built-in analyzers require the old YAML file:
- Velero analyzers already use *.json globs.
- The AI agents CRD/yaml-compare paths accept either .json or .yaml.
- yaml-compare uses yaml.Unmarshal, which parses JSON.

Vendor specs that hardcode a .yaml filename under cluster-resources/custom-resources/ will continue to work because the symlink is present. The content will be JSON, which is valid YAML.

## Testing

- go test ./pkg/collect/... ./pkg/redact/...
- make test
- make build
- Added cluster-scoped and namespaced path cases to Test_RedactKurlInstallerJSON.


[sc-139314](https://app.shortcut.com/replicated/story/139314)