### PR TITLE
fix(analyze/distribution): match `when: "== tanzu"` outcomes

### DIFF
--- a/pkg/analyze/distribution.go
+++ b/pkg/analyze/distribution.go
@@ -352,6 +352,8 @@ func compareDistributionConditionalToActual(conditional string, actual providers
 		isMatch = actual.digitalOcean
 	case openShift:
 		isMatch = actual.openShift
+	case tanzu:
+		isMatch = actual.tanzu
 	case kurl:
 		isMatch = actual.kurl
 	case aks:

--- a/pkg/analyze/distribution_test.go
+++ b/pkg/analyze/distribution_test.go
@@ -1,8 +1,12 @@
 package analyzer
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
+	troubleshootv1beta2 "github.com/replicatedhq/troubleshoot/pkg/apis/troubleshoot/v1beta2"
+	"github.com/replicatedhq/troubleshoot/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -64,6 +68,30 @@ func Test_compareDistributionConditionalToActual(t *testing.T) {
 				embeddedCluster: true,
 			},
 			expected: true,
+		},
+		{
+			name:        "== tanzu when tanzu is found",
+			conditional: "== tanzu",
+			input: providers{
+				tanzu: true,
+			},
+			expected: true,
+		},
+		{
+			name:        "!= tanzu when tanzu is found",
+			conditional: "!= tanzu",
+			input: providers{
+				tanzu: true,
+			},
+			expected: false,
+		},
+		{
+			name:        "== tanzu when a different distribution is found",
+			conditional: "== tanzu",
+			input: providers{
+				openShift: true,
+			},
+			expected: false,
 		},
 	}
 	for _, test := range tests {
@@ -159,6 +187,14 @@ func Test_mustNormalizeDistributionName(t *testing.T) {
 			raw:      "docker-desktop",
 			expected: dockerDesktop,
 		},
+		{
+			raw:      "tanzu",
+			expected: tanzu,
+		},
+		{
+			raw:      "Tanzu",
+			expected: tanzu,
+		},
 	}
 
 	for _, test := range tests {
@@ -250,6 +286,76 @@ func TestParseNodesForProviders(t *testing.T) {
 			assert.Equalf(t, tt.wantProviderString, stringProvider,
 				"ParseNodesForProviders() gotStringProvider = %v, stringProvider %v", stringProvider, tt.wantProviderString,
 			)
+		})
+	}
+}
+
+func TestAnalyzeDistribution_tanzu(t *testing.T) {
+	// A VMware Tanzu (TKG/VKS) node as collected in the field: the distribution
+	// version label is present on every node, and the supervisor exposes the
+	// run.tanzu.vmware.com API group.
+	tanzuNodes := `{"kind":"NodeList","apiVersion":"v1","items":[{"metadata":{"name":"tkg-node","labels":{` +
+		`"kubernetes.io/arch":"amd64",` +
+		`"node-role.kubernetes.io/control-plane":"",` +
+		`"run.tanzu.vmware.com/kubernetesDistributionVersion":"v1.29.4---vmware.3-fips.1-tkg.1",` +
+		`"run.tanzu.vmware.com/tkr":"v1.29.4---vmware.3-fips.1-tkg.1"` +
+		`}},"spec":{"providerID":"vsphere://421ff733-a840-e1c3-55cb-6320ab2b5432"},` +
+		`"status":{"nodeInfo":{"kubeletVersion":"v1.29.4+vmware.3-fips.1","osImage":"VMware Photon OS/Linux"}}}]}`
+	tanzuAPIResources := `[{"groupVersion":"v1","resources":[]},{"groupVersion":"run.tanzu.vmware.com/v1alpha1","resources":[]}]`
+
+	nodesPath := fmt.Sprintf("%s/%s.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_NODES)
+	resourcesPath := fmt.Sprintf("%s/%s.json", constants.CLUSTER_RESOURCES_DIR, constants.CLUSTER_RESOURCES_RESOURCES)
+
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			// Detection via node labels alone, e.g. a workload cluster where the
+			// run.tanzu.vmware.com API group is not exposed.
+			name:  "node labels only",
+			files: map[string]string{nodesPath: tanzuNodes},
+		},
+		{
+			name:  "node labels and api resources",
+			files: map[string]string{nodesPath: tanzuNodes, resourcesPath: tanzuAPIResources},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			getFiles := func(path string) ([]byte, error) {
+				contents, ok := test.files[path]
+				if !ok {
+					return nil, errors.Errorf("file %s not collected", path)
+				}
+				return []byte(contents), nil
+			}
+
+			a := AnalyzeDistribution{
+				analyzer: &troubleshootv1beta2.Distribution{
+					Outcomes: []*troubleshootv1beta2.Outcome{
+						{
+							Pass: &troubleshootv1beta2.SingleOutcome{
+								When:    "== tanzu",
+								Message: "Tanzu is a supported distribution",
+							},
+						},
+						{
+							Fail: &troubleshootv1beta2.SingleOutcome{
+								Message: "unrecognized distro",
+							},
+						},
+					},
+				},
+			}
+
+			results, err := a.Analyze(getFiles, nil)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			assert.True(t, results[0].IsPass, "expected the tanzu outcome to pass, got %+v", results[0])
+			assert.Equal(t, "Tanzu is a supported distribution", results[0].Message)
 		})
 	}
 }


### PR DESCRIPTION
## Description, Motivation and Context

Tanzu (VMware TKG/VKS) is detected correctly, but a `when: "== tanzu"` outcome never matches, so a spec cannot gate on Tanzu.

`compareDistributionConditionalToActual` had a case for every provider except `tanzu`, so the conditional evaluated false regardless of what was collected and the analyzer fell through to the generic unrecognized-distribution warning. Detection itself is fine: `foundProviders.tanzu` is set from the `run.tanzu.vmware.com/kubernetesDistributionVersion` node label (`pkg/analyze/distribution.go:153`) and the `run.tanzu.vmware.com/` API group prefix (`pkg/analyze/distribution.go:92`).

Reported by a vendor blocked installing on VMware Tanzu. Internal ticket SC-112390.

### Verification

Running the analyzer over the affected cluster's support bundle with the spec the vendor was using:

```
before: fail=true msg="unrecognized distro"
after:  pass=true msg="Tanzu is a supported distribution"
```

The before line matches that bundle's own `analysis.json`. Tests cover `== tanzu`, `!= tanzu`, `== tanzu` against a different distribution, and an end-to-end `Analyze()` case for both detection paths. All fail with the change reverted.

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [x] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

Docs PR: https://github.com/replicatedhq/troubleshoot.sh/pull/709. `tanzu` was missing from the supported-distribution list, which is what led the vendor to conclude it was unsupported.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
