### PR TITLE
feat(redact): expand built-in env-name list to cover common credential patterns

### DIFF
--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -231,6 +231,24 @@ func redactMatchesPath(path string, redact *troubleshootv1beta2.Redact) (bool, e
 	return false, nil
 }
 
+// credentialEnvNamePatterns are regex fragments matched case-insensitively
+// against environment variable names. Any env var whose name contains one of
+// these has its value redacted, so names like OPENAI_API_KEY, SMTP_PASSWORD or
+// GITHUB_CLIENT_SECRET never reach a support bundle in cleartext.
+var credentialEnvNamePatterns = []struct {
+	// pattern must be lowercase: it doubles as the `scan` prefilter, which is
+	// matched against a lowercased copy of the line.
+	pattern string
+	// desc completes the "...names that look like %s" redactor name
+	desc string
+}{
+	{pattern: `api[-_]?key`, desc: "API keys"},
+	{pattern: `secret`, desc: "secrets"},
+	{pattern: `auth`, desc: "authorization credentials"},
+	{pattern: `private[-_]?key`, desc: "private keys"},
+	{pattern: `(?:credential|creds)`, desc: "credentials"},
+}
+
 func getRedactors(path string) ([]Redactor, error) {
 	// TODO: Make this configurable
 
@@ -464,6 +482,29 @@ func getRedactors(path string) ([]Redactor, error) {
 			return nil, err // maybe skip broken ones?
 		}
 		redactors = append(redactors, r)
+	}
+
+	// Each credential env-name pattern gets both a single-line redactor (escaped
+	// JSON, e.g. `\\"name\\":\\"FOO\\",\\"value\\":\\"bar\\"`) and a multi-line one
+	// (indented JSON, where "name" and "value" land on separate lines).
+	for _, p := range credentialEnvNamePatterns {
+		single, err := NewSingleLineRedactor(LineRedactor{
+			regex: fmt.Sprintf(`(?i)(\\\"name\\\":\\\"[^\"]*%s[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`, p.pattern),
+			scan:  p.pattern,
+		}, MASK_TEXT, path, fmt.Sprintf("Redact values for environment variables with names that look like %s", p.desc), true)
+		if err != nil {
+			return nil, err
+		}
+		redactors = append(redactors, single)
+
+		multi, err := NewMultiLineRedactor(LineRedactor{
+			regex: fmt.Sprintf(`(?i)"name": *"[^\"]*%s[^\"]*"`, p.pattern),
+			scan:  p.pattern,
+		}, `(?i)("value": *")(?P<mask>.*[^\"]*)(")`, MASK_TEXT, path, fmt.Sprintf("Redact environment variables that look like %s in multiline JSON", p.desc), true)
+		if err != nil {
+			return nil, err
+		}
+		redactors = append(redactors, multi)
 	}
 
 	// Add built-in redactors that are scoped to specific custom resource files.

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -262,21 +262,21 @@ func getRedactors(path string) ([]Redactor, error) {
 		// aws secrets
 		{
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*SECRET_?ACCESS_?KEY\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `secret_?access_?key`,
 			},
 			name: "Redact values for environment variables that look like AWS Secret Access Keys",
 		},
 		{
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*ACCESS_?KEY_?ID\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `access_?key_?id`,
 			},
 			name: "Redact values for environment variables that look like AWS Access Keys",
 		},
 		{
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*OWNER_?ACCOUNT\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `owner_?account`,
 			},
 			name: "Redact values for environment variables that look like AWS Owner or Account numbers",
@@ -284,7 +284,7 @@ func getRedactors(path string) ([]Redactor, error) {
 		// passwords in general
 		{
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*password[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `password`,
 			},
 			name: "Redact values for environment variables with names beginning with 'password'",
@@ -293,21 +293,21 @@ func getRedactors(path string) ([]Redactor, error) {
 		{
 
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*token[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `token`,
 			},
 			name: "Redact values for environment variables with names beginning with 'token'",
 		},
 		{
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*database[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `database`,
 			},
 			name: "Redact values for environment variables with names beginning with 'database'",
 		},
 		{
 			regex: LineRedactor{
-				regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`,
+				regex: `(?i)(\\\"name\\\":\\\"[^\"]*user[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`,
 				scan:  `user`,
 			},
 			name: "Redact values for environment variables with names beginning with 'user'",
@@ -489,7 +489,7 @@ func getRedactors(path string) ([]Redactor, error) {
 	// (indented JSON, where "name" and "value" land on separate lines).
 	for _, p := range credentialEnvNamePatterns {
 		single, err := NewSingleLineRedactor(LineRedactor{
-			regex: fmt.Sprintf(`(?i)(\\\"name\\\":\\\"[^\"]*%s[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>[^\"]*)(\\\")`, p.pattern),
+			regex: fmt.Sprintf(`(?i)(\\\"name\\\":\\\"[^\"]*%s[^\"]*\\\",\\\"value\\\":\\\")(?P<mask>(?:\\\\\\"|[^\"])*)(\\\")`, p.pattern),
 			scan:  p.pattern,
 		}, MASK_TEXT, path, fmt.Sprintf("Redact values for environment variables with names that look like %s", p.desc), true)
 		if err != nil {

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1977,3 +1977,42 @@ func Test_RedactCredentialEnvNames(t *testing.T) {
 		})
 	}
 }
+
+// A credential value containing an escaped quote must be masked in full. The
+// mask group excludes bare quotes, so without an explicit alternative for the
+// `\\\"` sequence it stops at the first embedded quote and leaves the tail of
+// the secret in cleartext.
+func Test_RedactEscapedQuotesInValue(t *testing.T) {
+	envNames := []string{
+		// covered by the patterns added for credential env names
+		"OPENAI_API_KEY",
+		"GITHUB_CLIENT_SECRET",
+		"PRIVATE_KEY",
+		// covered by the pre-existing built-ins
+		"MYSQL_PASSWORD",
+		"AUDITOR_TOKEN",
+		"MYSQL_USER",
+		"MYSQL_DATABASE",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_OWNER_ACCOUNT",
+	}
+
+	for _, envName := range envNames {
+		t.Run(envName, func(t *testing.T) {
+			req := require.New(t)
+			ResetRedactionList()
+
+			input := fmt.Sprintf(`{\"name\":\"%s\",\"value\":\"super\\\"sensitive\"}`, envName)
+			out, err := Redact(strings.NewReader(input), "testpath", nil)
+			req.NoError(err)
+
+			redacted, err := ioutil.ReadAll(out)
+			req.NoError(err)
+
+			req.NotContains(string(redacted), "sensitive")
+			req.Contains(string(redacted), MASK_TEXT)
+			ResetRedactionList()
+		})
+	}
+}

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1,6 +1,7 @@
 package redact
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -878,7 +879,7 @@ func Test_Redactors(t *testing.T) {
 			},
 			"annotations": {
 			  "deployment.kubernetes.io/revision": "1",
-			  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"},\"name\":\"awesome-api\",\"namespace\":\"default\"},\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"app\":\"awesome-api\",\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"JWT_SIGNING_KEY\",\"value\":\"jwt-signing-key\"},{\"name\":\"TSED_SUPPRESS_ACCESSLOG\",\"value\":\"1\"},{\"name\":\"PINO_LOG_PRETTY\",\"value\":\"1\"},{\"name\":\"PINO_LOG_LEVEL\",\"value\":\"debug\"},{\"name\":\"NODE_ENV\",\"value\":\"development\"},{\"name\":\"MYSQL_HOST\",\"value\":\"mysql\"},{\"name\":\"MYSQL_USER\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PASSWORD\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PORT\",\"value\":\"3306\"},{\"name\":\"MYSQL_DATABASE\",\"value\":\"***HIDDEN***\"},{\"name\":\"CUSTOMER_AVATAR_S3_BUCKET\",\"value\":\"products-dev-avatars-3\"},{\"name\":\"SUPPORT_BUNDLE_S3_BUCKET\",\"value\":\"products-dev-supportbundles\"},{\"name\":\"APP_RELEASE_S3_BUCKET\",\"value\":\"products-dev-releases\"},{\"name\":\"GRAPHQL_VENDOR_ENDPOINT\",\"value\":\"http://awesome-api:8013/graphql\"},{\"name\":\"GRAPHQL_PREM_ENDPOINT\",\"value\":\"http://awesome-api-prem:8033/graphql\"},{\"name\":\"ANALYZE_ENDPOINT\",\"value\":\"http://lazy-api:3000\"},{\"name\":\"GITHUB_CLIENT_ID\",\"value\":\"Iv1.64993a1aeb9575e0\"},{\"name\":\"GITHUB_PRIVATE_KEY_FILENAME\",\"value\":\"/secret-mounts/github-app-private-key--dev-only.pem\"},{\"name\":\"GITHUB_INTEGRATION_ID\",\"value\":\"7888\"},{\"name\":\"INSTALL_URL\",\"value\":\"http://localhost:8090\"},{\"name\":\"AWS_ACCESS_KEY_ID\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_SECRET_ACCESS_KEY\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_REGION\",\"value\":\"notaregion\"},{\"name\":\"AWS_OWNER_ACCOUNT\",\"value\":\"***HIDDEN***\"},{\"name\":\"S3_ENDPOINT\",\"value\":\"http://s3:4569\"},{\"name\":\"SERVER_MODE\",\"value\":\"vendor\"},{\"name\":\"NEW_RELIC_APP_NAME\",\"value\":\"awesome-api-vendor\"}],\"image\":\"localhost:32000/awesome-api:e9a281f7@sha256:6e988461ffce2bac3561234f736b9a504bfda1911fa6432b90e6bbb16f67f925\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"awesome-api\",\"ports\":[{\"containerPort\":3000,\"name\":\"awesome-api\"}],\"readinessProbe\":{\"failureThreshold\":3,\"httpGet\":{\"path\":\"/healthz\",\"port\":3000,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":2,\"periodSeconds\":2,\"successThreshold\":1,\"timeoutSeconds\":1}}]}}}}\n"
+			  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"},\"name\":\"awesome-api\",\"namespace\":\"default\"},\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"app\":\"awesome-api\",\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"JWT_SIGNING_KEY\",\"value\":\"jwt-signing-key\"},{\"name\":\"TSED_SUPPRESS_ACCESSLOG\",\"value\":\"1\"},{\"name\":\"PINO_LOG_PRETTY\",\"value\":\"1\"},{\"name\":\"PINO_LOG_LEVEL\",\"value\":\"debug\"},{\"name\":\"NODE_ENV\",\"value\":\"development\"},{\"name\":\"MYSQL_HOST\",\"value\":\"mysql\"},{\"name\":\"MYSQL_USER\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PASSWORD\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PORT\",\"value\":\"3306\"},{\"name\":\"MYSQL_DATABASE\",\"value\":\"***HIDDEN***\"},{\"name\":\"CUSTOMER_AVATAR_S3_BUCKET\",\"value\":\"products-dev-avatars-3\"},{\"name\":\"SUPPORT_BUNDLE_S3_BUCKET\",\"value\":\"products-dev-supportbundles\"},{\"name\":\"APP_RELEASE_S3_BUCKET\",\"value\":\"products-dev-releases\"},{\"name\":\"GRAPHQL_VENDOR_ENDPOINT\",\"value\":\"http://awesome-api:8013/graphql\"},{\"name\":\"GRAPHQL_PREM_ENDPOINT\",\"value\":\"http://awesome-api-prem:8033/graphql\"},{\"name\":\"ANALYZE_ENDPOINT\",\"value\":\"http://lazy-api:3000\"},{\"name\":\"GITHUB_CLIENT_ID\",\"value\":\"Iv1.64993a1aeb9575e0\"},{\"name\":\"GITHUB_PRIVATE_KEY_FILENAME\",\"value\":\"***HIDDEN***\"},{\"name\":\"GITHUB_INTEGRATION_ID\",\"value\":\"7888\"},{\"name\":\"INSTALL_URL\",\"value\":\"http://localhost:8090\"},{\"name\":\"AWS_ACCESS_KEY_ID\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_SECRET_ACCESS_KEY\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_REGION\",\"value\":\"notaregion\"},{\"name\":\"AWS_OWNER_ACCOUNT\",\"value\":\"***HIDDEN***\"},{\"name\":\"S3_ENDPOINT\",\"value\":\"http://s3:4569\"},{\"name\":\"SERVER_MODE\",\"value\":\"vendor\"},{\"name\":\"NEW_RELIC_APP_NAME\",\"value\":\"awesome-api-vendor\"}],\"image\":\"localhost:32000/awesome-api:e9a281f7@sha256:6e988461ffce2bac3561234f736b9a504bfda1911fa6432b90e6bbb16f67f925\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"awesome-api\",\"ports\":[{\"containerPort\":3000,\"name\":\"awesome-api\"}],\"readinessProbe\":{\"failureThreshold\":3,\"httpGet\":{\"path\":\"/healthz\",\"port\":3000,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":2,\"periodSeconds\":2,\"successThreshold\":1,\"timeoutSeconds\":1}}]}}}}\n"
 			}
 		  },
 		  "spec": {
@@ -996,7 +997,7 @@ func Test_Redactors(t *testing.T) {
 					  },
 					  {
 						"name": "GITHUB_PRIVATE_KEY_FILENAME",
-						"value": "/secret-mounts/github-app-private-key--dev-only.pem"
+						"value": "***HIDDEN***"
 					  },
 					  {
 						"name": "GITHUB_INTEGRATION_ID",
@@ -1221,7 +1222,7 @@ func Test_Redactors(t *testing.T) {
 			},
 			"annotations": {
 			  "deployment.kubernetes.io/revision": "1",
-			  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"},\"name\":\"cranky-api\",\"namespace\":\"default\"},\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"app\":\"cranky-api\",\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"ELASTICSEARCH_NODES\",\"value\":\"http://***HIDDEN***:***HIDDEN***@elasticsearch:9200\"},{\"name\":\"MAX_LOGIN_ATTEMPTS\",\"value\":\"7\"},{\"name\":\"LICENSE_SIGNING_KEY\",\"value\":\"\"},{\"name\":\"JWT_SIGNING_KEY\",\"value\":\"jwt-signing-key\"},{\"name\":\"GITHUB_CLIENT_ID\",\"value\":\"9a92961100c3bd14b991\"},{\"name\":\"GITHUB_CLIENT_SECRET\",\"value\":\"not-a-secret\"},{\"name\":\"LICENSE_API_ENDPOINT\",\"value\":\"http://boring-api:3000\"},{\"name\":\"vendor_assets_bucket\",\"value\":\"replicaetd-vendor-assets-dev\"},{\"name\":\"vendor_web_host\",\"value\":\"http://localhost:8080\"},{\"name\":\"download_web_host\",\"value\":\"http://localhost:8080\"},{\"name\":\"SPEC_V1_PATH\",\"value\":\"/go/src/github.com/somebigbankhq/vandam/cranky-api/spec/v1\"},{\"name\":\"SPEC_V2_PATH\",\"value\":\"/go/src/github.com/somebigbankhq/vandam/cranky-api/spec/v2\"},{\"name\":\"AWS_ACCESS_KEY_ID\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_SECRET_ACCESS_KEY\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_REGION\",\"value\":\"notaregion\"},{\"name\":\"AWS_OWNER_ACCOUNT\",\"value\":\"***HIDDEN***\"},{\"name\":\"SQS_ENDPOINT\",\"value\":\"http://sqs:9324\"},{\"name\":\"RELEASE_UDPATE_SQS_QUEUE\",\"value\":\"preflight-checker\"},{\"name\":\"LICENSE_UDPATE_SQS_QUEUE\",\"value\":\"search-builder\"},{\"name\":\"AWS_SQS_MAIL_QUEUENAME\",\"value\":\"mail-dev\"},{\"name\":\"AWS_SQS_AIRGAP_QUEUENAME\",\"value\":\"airgap-dev\"},{\"name\":\"AWS_SQS_LICENSEAGGREGATOR_QUEUENAME\",\"value\":\"licenseaggregator-dev\"},{\"name\":\"INTEGRATION_API_SQS_QUEUE_NAME\",\"value\":\"integration-api-dev\"},{\"name\":\"BUGSNAG_ENV\",\"value\":\"dev\"},{\"name\":\"VENDOR_REGISTY_HOST\",\"value\":\"https://registry:10443\"},{\"name\":\"VENDOR_REGISTY_ENDPOINT\",\"value\":\"registry:10443\"},{\"name\":\"LOG_LEVEL\",\"value\":\"debug\"},{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"ALLOW_INSECURE_REGISTRY\",\"value\":\"true\"},{\"name\":\"GRAPHQL_API_ADDRESS\",\"value\":\"http://awesome-api:3000/graphql\"},{\"name\":\"PREM_GRAPHQL_API_ADDRESS\",\"value\":\"http://awesome-api-prem:3000/graphql\"},{\"name\":\"GRAPHQL_ENDPOINT\",\"value\":\"http://awesome-api:3000/graphql\"},{\"name\":\"TITLED_ENDPOINT\",\"value\":\"http://gatekeeping-api:3000\"},{\"name\":\"MYSQL_HOST\",\"value\":\"mysql\"},{\"name\":\"MYSQL_USER\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PASSWORD\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PORT\",\"value\":\"3306\"},{\"name\":\"MYSQL_DATABASE\",\"value\":\"***HIDDEN***\"},{\"name\":\"AUDITOR_API_HOST\",\"value\":\"http://api.auditor.svc.cluster.local:3000/auditlog\"},{\"name\":\"AUDITOR_TOKEN\",\"value\":\"***HIDDEN***\"},{\"name\":\"AUDITOR_PROJECTID\",\"value\":\"dev\"},{\"name\":\"PROJECT_NAME\",\"value\":\"cranky-api\"}],\"image\":\"localhost:32000/cranky-api:e9a281f7-dirty@sha256:f6bbd155a2e7325ea93dbc48848eeba7b0e612b8849676df91e647f0d86ece03\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":2,\"httpGet\":{\"path\":\"/healthz\",\"port\":8005,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":30,\"periodSeconds\":15,\"timeoutSeconds\":1},\"name\":\"cranky-api\",\"ports\":[{\"containerPort\":8005,\"name\":\"cranky-api\"}],\"readinessProbe\":{\"failureThreshold\":3,\"httpGet\":{\"path\":\"/healthz\",\"port\":8005,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":5,\"periodSeconds\":2,\"successThreshold\":2,\"timeoutSeconds\":1},\"workingDir\":\"/go/src/github.com/somebigbankhq/vandam/cranky-api\"}]}}}}\n"
+			  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"},\"name\":\"cranky-api\",\"namespace\":\"default\"},\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"app\":\"cranky-api\",\"app.kubernetes.io/managed-by\":\"skaffold-v0.32.0\",\"skaffold.dev/builder\":\"local\",\"skaffold.dev/cleanup\":\"true\",\"skaffold.dev/deployer\":\"kustomize\",\"skaffold.dev/docker-api-version\":\"1.39\",\"skaffold.dev/tag-policy\":\"git-commit\",\"skaffold.dev/tail\":\"true\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"ELASTICSEARCH_NODES\",\"value\":\"http://***HIDDEN***:***HIDDEN***@elasticsearch:9200\"},{\"name\":\"MAX_LOGIN_ATTEMPTS\",\"value\":\"7\"},{\"name\":\"LICENSE_SIGNING_KEY\",\"value\":\"\"},{\"name\":\"JWT_SIGNING_KEY\",\"value\":\"jwt-signing-key\"},{\"name\":\"GITHUB_CLIENT_ID\",\"value\":\"9a92961100c3bd14b991\"},{\"name\":\"GITHUB_CLIENT_SECRET\",\"value\":\"***HIDDEN***\"},{\"name\":\"LICENSE_API_ENDPOINT\",\"value\":\"http://boring-api:3000\"},{\"name\":\"vendor_assets_bucket\",\"value\":\"replicaetd-vendor-assets-dev\"},{\"name\":\"vendor_web_host\",\"value\":\"http://localhost:8080\"},{\"name\":\"download_web_host\",\"value\":\"http://localhost:8080\"},{\"name\":\"SPEC_V1_PATH\",\"value\":\"/go/src/github.com/somebigbankhq/vandam/cranky-api/spec/v1\"},{\"name\":\"SPEC_V2_PATH\",\"value\":\"/go/src/github.com/somebigbankhq/vandam/cranky-api/spec/v2\"},{\"name\":\"AWS_ACCESS_KEY_ID\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_SECRET_ACCESS_KEY\",\"value\":\"***HIDDEN***\"},{\"name\":\"AWS_REGION\",\"value\":\"notaregion\"},{\"name\":\"AWS_OWNER_ACCOUNT\",\"value\":\"***HIDDEN***\"},{\"name\":\"SQS_ENDPOINT\",\"value\":\"http://sqs:9324\"},{\"name\":\"RELEASE_UDPATE_SQS_QUEUE\",\"value\":\"preflight-checker\"},{\"name\":\"LICENSE_UDPATE_SQS_QUEUE\",\"value\":\"search-builder\"},{\"name\":\"AWS_SQS_MAIL_QUEUENAME\",\"value\":\"mail-dev\"},{\"name\":\"AWS_SQS_AIRGAP_QUEUENAME\",\"value\":\"airgap-dev\"},{\"name\":\"AWS_SQS_LICENSEAGGREGATOR_QUEUENAME\",\"value\":\"licenseaggregator-dev\"},{\"name\":\"INTEGRATION_API_SQS_QUEUE_NAME\",\"value\":\"integration-api-dev\"},{\"name\":\"BUGSNAG_ENV\",\"value\":\"dev\"},{\"name\":\"VENDOR_REGISTY_HOST\",\"value\":\"https://registry:10443\"},{\"name\":\"VENDOR_REGISTY_ENDPOINT\",\"value\":\"registry:10443\"},{\"name\":\"LOG_LEVEL\",\"value\":\"debug\"},{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"ALLOW_INSECURE_REGISTRY\",\"value\":\"true\"},{\"name\":\"GRAPHQL_API_ADDRESS\",\"value\":\"http://awesome-api:3000/graphql\"},{\"name\":\"PREM_GRAPHQL_API_ADDRESS\",\"value\":\"http://awesome-api-prem:3000/graphql\"},{\"name\":\"GRAPHQL_ENDPOINT\",\"value\":\"http://awesome-api:3000/graphql\"},{\"name\":\"TITLED_ENDPOINT\",\"value\":\"http://gatekeeping-api:3000\"},{\"name\":\"MYSQL_HOST\",\"value\":\"mysql\"},{\"name\":\"MYSQL_USER\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PASSWORD\",\"value\":\"***HIDDEN***\"},{\"name\":\"MYSQL_PORT\",\"value\":\"3306\"},{\"name\":\"MYSQL_DATABASE\",\"value\":\"***HIDDEN***\"},{\"name\":\"AUDITOR_API_HOST\",\"value\":\"http://api.auditor.svc.cluster.local:3000/auditlog\"},{\"name\":\"AUDITOR_TOKEN\",\"value\":\"***HIDDEN***\"},{\"name\":\"AUDITOR_PROJECTID\",\"value\":\"dev\"},{\"name\":\"PROJECT_NAME\",\"value\":\"cranky-api\"}],\"image\":\"localhost:32000/cranky-api:e9a281f7-dirty@sha256:f6bbd155a2e7325ea93dbc48848eeba7b0e612b8849676df91e647f0d86ece03\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"failureThreshold\":2,\"httpGet\":{\"path\":\"/healthz\",\"port\":8005,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":30,\"periodSeconds\":15,\"timeoutSeconds\":1},\"name\":\"cranky-api\",\"ports\":[{\"containerPort\":8005,\"name\":\"cranky-api\"}],\"readinessProbe\":{\"failureThreshold\":3,\"httpGet\":{\"path\":\"/healthz\",\"port\":8005,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":5,\"periodSeconds\":2,\"successThreshold\":2,\"timeoutSeconds\":1},\"workingDir\":\"/go/src/github.com/somebigbankhq/vandam/cranky-api\"}]}}}}\n"
 			}
 		  },
 		  "spec": {
@@ -1287,7 +1288,7 @@ func Test_Redactors(t *testing.T) {
 					  },
 					  {
 						"name": "GITHUB_CLIENT_SECRET",
-						"value": "not-a-secret"
+						"value": "***HIDDEN***"
 					  },
 					  {
 						"name": "LICENSE_API_ENDPOINT",
@@ -1719,8 +1720,8 @@ func Test_Redactors(t *testing.T) {
 		}
 	  ]`
 
-	wantRedactionsLen := 43
-	wantRedactionsCount := 25
+	wantRedactionsLen := 47
+	wantRedactionsCount := 29
 
 	t.Run("test default redactors", func(t *testing.T) {
 		req := require.New(t)
@@ -1917,6 +1918,62 @@ func Test_RedactKurlInstallerJSON(t *testing.T) {
 			require.Contains(t, outStr, `"certKey": "***HIDDEN***"`)
 			require.Contains(t, outStr, `"kubeadmToken": "***HIDDEN***"`)
 			require.Contains(t, outStr, `"kubectl.kubernetes.io/last-applied-configuration": "***HIDDEN***"`)
+		})
+	}
+}
+
+func Test_RedactCredentialEnvNames(t *testing.T) {
+	tests := []struct {
+		envName  string
+		redacted bool
+	}{
+		// api keys
+		{envName: "OPENAI_API_KEY", redacted: true},
+		{envName: "STRIPE_APIKEY", redacted: true},
+		{envName: "SENDGRID_API-KEY", redacted: true},
+		// secrets
+		{envName: "GITHUB_CLIENT_SECRET", redacted: true},
+		{envName: "OIDC_CLIENT_SECRET", redacted: true},
+		{envName: "SECRET", redacted: true},
+		// authorization
+		{envName: "AUTH_HEADER", redacted: true},
+		{envName: "AUTHORIZATION", redacted: true},
+		// private keys
+		{envName: "PRIVATE_KEY", redacted: true},
+		{envName: "TLS_PRIVATEKEY", redacted: true},
+		// credentials
+		{envName: "GOOGLE_APPLICATION_CREDENTIALS", redacted: true},
+		{envName: "DOCKER_CREDS", redacted: true},
+		// names that carry no credential, and must survive untouched
+		{envName: "LOG_LEVEL", redacted: false},
+		{envName: "NODE_ENV", redacted: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envName, func(t *testing.T) {
+			req := require.New(t)
+
+			// escaped JSON, where name and value share a line
+			singleLine := fmt.Sprintf(`{\"name\":\"%s\",\"value\":\"super-sensitive\"}`, tt.envName)
+			// indented JSON, where name and value land on separate lines
+			multiLine := fmt.Sprintf("{\n  \"name\": \"%s\",\n  \"value\": \"super-sensitive\"\n}", tt.envName)
+
+			for _, input := range []string{singleLine, multiLine} {
+				ResetRedactionList()
+				out, err := Redact(strings.NewReader(input), "testpath", nil)
+				req.NoError(err)
+
+				redacted, err := ioutil.ReadAll(out)
+				req.NoError(err)
+
+				if tt.redacted {
+					req.NotContains(string(redacted), "super-sensitive", "input: %s", input)
+					req.Contains(string(redacted), MASK_TEXT, "input: %s", input)
+				} else {
+					req.Contains(string(redacted), "super-sensitive", "input: %s", input)
+				}
+			}
+			ResetRedactionList()
 		})
 	}
 }

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1944,9 +1944,16 @@ func Test_RedactCredentialEnvNames(t *testing.T) {
 		// credentials
 		{envName: "GOOGLE_APPLICATION_CREDENTIALS", redacted: true},
 		{envName: "DOCKER_CREDS", redacted: true},
+		// the patterns are case insensitive, and match anywhere in the name
+		{envName: "openai_api_key", redacted: true},
+		{envName: "Api_Key", redacted: true},
+		{envName: "X_API_KEY_HEADER", redacted: true},
 		// names that carry no credential, and must survive untouched
 		{envName: "LOG_LEVEL", redacted: false},
 		{envName: "NODE_ENV", redacted: false},
+		{envName: "MAX_LOGIN_ATTEMPTS", redacted: false},
+		// `creds` must not swallow unrelated words starting with "cred"
+		{envName: "CREDIT_LIMIT", redacted: false},
 	}
 
 	for _, tt := range tests {
@@ -2015,4 +2022,55 @@ func Test_RedactEscapedQuotesInValue(t *testing.T) {
 			ResetRedactionList()
 		})
 	}
+}
+
+// The `auth` and `secret` patterns are deliberately broad substrings, so they
+// also catch names that describe a credential rather than carry one. These
+// cases pin that behaviour: over-redaction is the accepted trade for not
+// leaking, and narrowing a pattern later should show up here as a deliberate
+// change rather than a silent one.
+func Test_RedactCredentialEnvNamesOverMatches(t *testing.T) {
+	overMatched := []string{
+		"AUTHORITY_URL",
+		"AUTHOR_EMAIL",
+		"OAUTH2_ISSUER",
+		"SECRET_NAME",
+		"GITHUB_PRIVATE_KEY_FILENAME",
+	}
+
+	for _, envName := range overMatched {
+		t.Run(envName, func(t *testing.T) {
+			req := require.New(t)
+			ResetRedactionList()
+
+			input := fmt.Sprintf(`{\"name\":\"%s\",\"value\":\"not-a-secret\"}`, envName)
+			out, err := Redact(strings.NewReader(input), "testpath", nil)
+			req.NoError(err)
+
+			redacted, err := ioutil.ReadAll(out)
+			req.NoError(err)
+
+			req.Contains(string(redacted), MASK_TEXT)
+			ResetRedactionList()
+		})
+	}
+}
+
+// An env var explicitly set to the empty string is masked too, since the mask
+// group matches zero characters. That is pre-existing behaviour shared with the
+// built-in password and token redactors, and it costs a small diagnostic signal:
+// "set but empty" becomes indistinguishable from "set to a secret".
+func Test_RedactCredentialEnvNamesEmptyValue(t *testing.T) {
+	req := require.New(t)
+	ResetRedactionList()
+
+	input := `{\"name\":\"API_KEY\",\"value\":\"\"}`
+	out, err := Redact(strings.NewReader(input), "testpath", nil)
+	req.NoError(err)
+
+	redacted, err := ioutil.ReadAll(out)
+	req.NoError(err)
+
+	req.Contains(string(redacted), MASK_TEXT)
+	ResetRedactionList()
 }


### PR DESCRIPTION
## Description, Motivation and Context

The built-in redactors in `pkg/redact/redact.go` only matched seven hard-coded environment variable name patterns:

- `password`
- `token`
- `database`
- `user`
- `SECRET_ACCESS_KEY`
- `ACCESS_KEY_ID`
- `OWNER_ACCOUNT`

Common credential env names fell outside that list, so values like `OPENAI_API_KEY`, `SMTP_PASSWORD`, `GITHUB_CLIENT_SECRET`, `OIDC_CLIENT_SECRET` and `PRIVATE_KEY` were written to support bundles in cleartext.

This adds a `credentialEnvNamePatterns` table and a loop that turns each entry into **both** redactor shapes the existing built-ins already come in pairs of:

- a **single-line** redactor for escaped JSON — `\"name\":\"FOO\",\"value\":\"bar\"`, as found in `kubectl.kubernetes.io/last-applied-configuration` annotations
- a **multi-line** redactor for indented JSON, where `"name"` and `"value"` land on separate lines

New patterns:

| Pattern | Covers |
| --- | --- |
| `api[-_]?key` | `OPENAI_API_KEY`, `STRIPE_APIKEY` |
| `secret` | `GITHUB_CLIENT_SECRET`, `OIDC_CLIENT_SECRET` |
| `auth` | `AUTH_HEADER`, `AUTHORIZATION` |
| `private[-_]?key` | `PRIVATE_KEY`, `TLS_PRIVATEKEY` |
| `(?:credential\|creds)` | `GOOGLE_APPLICATION_CREDENTIALS`, `DOCKER_CREDS` |

Patterns are stored lowercase so each doubles as its own `scan` prefilter — the cheap literal gate `SingleLineRedactor`/`MultiLineRedactor` run against a lowercased copy of the line before the expensive regex. The ten extra redactors therefore don't add a full regex pass per line.

### Note for reviewers

`secret` and `auth` are deliberately broad substrings, so an env var named `SECRET_NAME` or one starting with `AUTHOR` will also be masked. That's over-redaction rather than leakage, which seemed the right side to err on for a built-in — but worth a second opinion.

### Testing

- `Test_RedactCredentialEnvNames` (new): table test running every new pattern through both the escaped and the indented JSON shapes, with `LOG_LEVEL` / `NODE_ENV` as negative cases confirming non-credential values survive untouched.
- `Test_Redactors/test default redactors`: fixture updated — `GITHUB_CLIENT_SECRET` and `GITHUB_PRIVATE_KEY_FILENAME` are now masked in both the escaped annotation blob and the indented JSON. Counts moved 43 → 47 redactions and 25 → 29 distinct redactors.

Ref: [sc-139338](https://app.shortcut.com/replicated/story/139338)
Customer context: https://github.com/replicated-collab/pixee-replicated/issues/137

## Checklist

- [x] New and existing tests pass locally with introduced changes.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) are informative and highlight any breaking changes
- [ ] Any documentation required has been added/updated. For changes to https://troubleshoot.sh/ create a PR [here](https://github.com/replicatedhq/troubleshoot.sh/pulls)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Not a breaking API change, but it does change output: bundles will now mask env values they previously left in cleartext. Anyone parsing a bundle for one of these env vars will see `***HIDDEN***` where a real value used to be.
