### PR TITLE
Add SLSA provenance attestations for CLI releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,17 +19,17 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26'
           check-latest: true
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v3.1.3'
 
@@ -40,7 +40,7 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: "v2.12.3"
           args: release --clean --config deploy/.goreleaser.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Attest CLI release artifacts
         id: attest_cli
-        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        uses: actions/attest@v4
         with:
           subject-path: |
             dist/preflight_*.tar.gz
@@ -68,13 +68,13 @@ jobs:
 
       - name: Update new preflight version in krew-index
         if: ${{ !contains(github.ref_name, '-') }}
-        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51
+        uses: rajatjindal/krew-release-bot@v0.0.51
         with:
           krew_template_file: deploy/krew/preflight.yaml
 
       - name: Update new support-bundle version in krew-index
         if: ${{ !contains(github.ref_name, '-') }}
-        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51
+        uses: rajatjindal/krew-release-bot@v0.0.51
         with:
           krew_template_file: deploy/krew/support-bundle.yaml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,19 +16,20 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26'
           check-latest: true
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: 'v3.1.3'
 
@@ -39,7 +40,7 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "v2.12.3"
           args: release --clean --config deploy/.goreleaser.yaml
@@ -48,7 +49,7 @@ jobs:
 
       - name: Attest CLI release artifacts
         id: attest_cli
-        uses: actions/attest@v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: |
             dist/preflight_*.tar.gz
@@ -57,42 +58,23 @@ jobs:
             dist/support-bundle_*.zip
 
       - name: Add provenance bundle to release
-        uses: actions/github-script@v9
         env:
+          GH_TOKEN: ${{ github.token }}
           BUNDLE_PATH: ${{ steps.attest_cli.outputs.bundle-path }}
-        with:
-          script: |
-            const fs = require('fs');
-            const tag = process.env.GITHUB_REF_NAME;
-            const name = `troubleshoot_${tag}_provenance.sigstore.json`;
-            const bundle = await fs.promises.readFile(process.env.BUNDLE_PATH);
-            const { data: release } = await github.rest.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag,
-            });
-
-            await github.rest.repos.uploadReleaseAsset({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: release.id,
-              name,
-              data: bundle,
-              headers: {
-                'content-type': 'application/json',
-                'content-length': bundle.length,
-              },
-            });
+        run: |
+          bundle="dist/troubleshoot_${GITHUB_REF_NAME}_provenance.sigstore.json"
+          cp "${BUNDLE_PATH}" "${bundle}"
+          gh release upload "${GITHUB_REF_NAME}" "${bundle}" --clobber
 
       - name: Update new preflight version in krew-index
         if: ${{ !contains(github.ref_name, '-') }}
-        uses: rajatjindal/krew-release-bot@v0.0.51
+        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51
         with:
           krew_template_file: deploy/krew/preflight.yaml
 
       - name: Update new support-bundle version in krew-index
         if: ${{ !contains(github.ref_name, '-') }}
-        uses: rajatjindal/krew-release-bot@v0.0.51
+        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3 # v0.0.51
         with:
           krew_template_file: deploy/krew/support-bundle.yaml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ concurrency:
 jobs:
   goreleaser:
     runs-on: troubleshoot_release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -41,6 +45,15 @@ jobs:
           args: release --clean --config deploy/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
+
+      - name: Attest CLI release artifacts
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/preflight_*.tar.gz
+            dist/preflight_*.zip
+            dist/support-bundle_*.tar.gz
+            dist/support-bundle_*.zip
 
       - name: Update new preflight version in krew-index
         if: ${{ !contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
 
       - name: Attest CLI release artifacts
+        id: attest_cli
         uses: actions/attest@v4
         with:
           subject-path: |
@@ -54,6 +55,34 @@ jobs:
             dist/preflight_*.zip
             dist/support-bundle_*.tar.gz
             dist/support-bundle_*.zip
+
+      - name: Add provenance bundle to release
+        uses: actions/github-script@v9
+        env:
+          BUNDLE_PATH: ${{ steps.attest_cli.outputs.bundle-path }}
+        with:
+          script: |
+            const fs = require('fs');
+            const tag = process.env.GITHUB_REF_NAME;
+            const name = `troubleshoot_${tag}_provenance.sigstore.json`;
+            const bundle = await fs.promises.readFile(process.env.BUNDLE_PATH);
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag,
+            });
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              name,
+              data: bundle,
+              headers: {
+                'content-type': 'application/json',
+                'content-length': bundle.length,
+              },
+            });
 
       - name: Update new preflight version in krew-index
         if: ${{ !contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -65,3 +65,15 @@ not been tampered with. Install [Cosign v3](https://github.com/sigstore/cosign/r
 $ cosign verify-blob --key key.pub --bundle troubleshoot-sbom.tgz.bundle troubleshoot-sbom.tgz
 Verified OK
 ```
+
+# Build Provenance
+
+SLSA build provenance attestations are generated for the `preflight` and `support-bundle` archives in each release. After downloading an archive, use the [GitHub CLI](https://cli.github.com/) to verify that it was built by this repository's release workflow:
+
+```sh
+gh attestation verify preflight_linux_amd64.tar.gz \
+  --repo replicatedhq/troubleshoot \
+  --signer-workflow replicatedhq/troubleshoot/.github/workflows/release.yaml
+```
+
+Replace `preflight_linux_amd64.tar.gz` with the name of the downloaded release archive.

--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ Verified OK
 
 # Build Provenance
 
-SLSA build provenance attestations are generated for the `preflight` and `support-bundle` archives in each release. After downloading an archive, use the [GitHub CLI](https://cli.github.com/) to verify that it was built by this repository's release workflow:
+SLSA build provenance attestations are generated for the `preflight` and `support-bundle` archives in each release. Download the archive and the corresponding `troubleshoot_<version>_provenance.sigstore.json` bundle, then use [Cosign v3.1.3 or later](https://github.com/sigstore/cosign/releases) to verify that it was built by this repository's release workflow:
 
 ```sh
-gh attestation verify preflight_linux_amd64.tar.gz \
-  --repo replicatedhq/troubleshoot \
-  --signer-workflow replicatedhq/troubleshoot/.github/workflows/release.yaml
+cosign verify-blob-attestation \
+  --bundle troubleshoot_v0.135.0_provenance.sigstore.json \
+  --type https://slsa.dev/provenance/v1 \
+  --certificate-identity "https://github.com/replicatedhq/troubleshoot/.github/workflows/release.yaml@refs/tags/v0.135.0" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  preflight_linux_amd64.tar.gz
 ```
 
-Replace `preflight_linux_amd64.tar.gz` with the name of the downloaded release archive.
+Replace `v0.135.0` and `preflight_linux_amd64.tar.gz` with the release tag and downloaded archive being verified. The same provenance bundle verifies both `preflight` and `support-bundle` archives from that release.


### PR DESCRIPTION
## Summary

- grant the release job the permissions required to mint and publish keyless GitHub/Sigstore attestations
- generate SLSA build provenance for all preflight and support-bundle release archives
- publish the generated Sigstore bundle as a versioned GitHub release asset with `gh release upload`
- document keyless verification with `cosign verify-blob-attestation`, including the expected workflow, tag, issuer, and predicate type

## Testing

- `git diff --check`
- parsed `.github/workflows/release.yaml` as YAML
- syntax-checked the `gh release upload` shell commands
- confirmed the installed GitHub CLI supports `gh release upload --clobber`

The attestation and release upload steps can only run end-to-end from a tag-triggered release after this change is merged.